### PR TITLE
Added peer review policy to the about - submissions page

### DIFF
--- a/locale/en_US/locale.xml
+++ b/locale/en_US/locale.xml
@@ -382,7 +382,7 @@
 	<message key="about.submissionPreparationChecklist.description">As part of the submission process, authors are required to check off their submission's compliance with all of the following items, and submissions may be returned to authors that do not adhere to these guidelines.</message>
 	<message key="about.copyrightNotice">Copyright Notice</message>
 	<message key="about.privacyStatement">Privacy Statement</message>
-	<message key="about.peerReviewProcess">Peer Review Process</message>
+	<message key="about.reviewPolicy">Peer Review Process</message>
 	<message key="about.publicationFrequency">Publication Frequency</message>
 	<message key="about.openAccessPolicy">Open Access Policy</message>
 	<message key="about.pressSponsorship">Press Sponsorship</message>

--- a/pages/about/AboutContextHandler.inc.php
+++ b/pages/about/AboutContextHandler.inc.php
@@ -221,14 +221,14 @@ class AboutContextHandler extends Handler implements IAboutContextInfoProvider {
 	 * @param $context Press
 	 */
 	static protected function getSubmissionsInfo($context) {
-		$submissionSettingNames = array('authorGuidelines', 'copyrightNotice', 'privacyStatement');
+		$submissionSettingNames = array('authorGuidelines', 'copyrightNotice', 'privacyStatement', 'reviewPolicy');
 
 		$submissionInfo = array();
 
 		foreach ($submissionSettingNames as $settingName) {
 			$settingValue = $context->getLocalizedSetting($settingName);
 			if ($settingValue) {
-				$editorialPoliciesInfo[$settingName] = $settingValue;
+				$submissionInfo[$settingName] = $settingValue;
 			}
 		}
 

--- a/templates/about/submissions.tpl
+++ b/templates/about/submissions.tpl
@@ -78,4 +78,16 @@
 	<div class="separator"></div>
 {/if}
 
+{if $submissionInfo.reviewPolicy}
+	<div id="reviewPolicy">
+		<h3>{translate key="about.reviewPolicy"}</h3>
+
+		{url|assign:editUrl page="management" op="settings" path="press" anchor="policies"}
+		{include file="common/linkToEditPage.tpl" editUrl=$editUrl}
+
+		<p>{$submissionInfo.reviewPolicy|nl2br}</p>
+	</div>
+	<div class="separator"></div>
+{/if}
+
 {include file="common/footer.tpl"}


### PR DESCRIPTION
Pull request for [8204](http://pkp.sfu.ca/bugzilla/show_bug.cgi?id=8204).

I reactivated some [defunct code](https://github.com/MichaelThessel/omp/compare/8204_peer_review?expand=1#diff-bf758b48a6ee697fd8589ac5dd08a23aL231) to get the peer review policy to show on the about page. This has the consequence that other policies like the copyright notice will now show as well. I assume that this was intended to work like this and that this was a bug. Let me know if that works.
