### PR TITLE
pkp/pkp-lib#291 Permit association of files with chapters in OMP

### DIFF
--- a/classes/monograph/ArtworkFileDAODelegate.inc.php
+++ b/classes/monograph/ArtworkFileDAODelegate.inc.php
@@ -36,6 +36,16 @@ class ArtworkFileDAODelegate extends SubmissionArtworkFileDAODelegate {
 	function newDataObject() {
 		return new ArtworkFile();
 	}
+
+	/**
+	 * @copydoc DAO::getAdditionalFieldNames()
+	 */
+	function getAdditionalFieldNames() {
+		return array_merge(
+			parent::getAdditionalFieldNames(),
+			array('chapterId')
+		);
+	}
 }
 
 ?>

--- a/classes/monograph/MonographFile.inc.php
+++ b/classes/monograph/MonographFile.inc.php
@@ -26,6 +26,19 @@ class MonographFile extends SubmissionFile {
 	}
 
 
+	/**
+	 * Copy the user-facing (editable) metadata from another monograph
+	 * file.
+	 * @param $monographFile MonographFile
+	 */
+	function copyEditableMetadataFrom($monographFile) {
+		if (is_a($monographFile, 'MonographFile')) {
+			$this->setData('chapterId', $monographFile->getData('chapterId'));
+		}
+
+		parent::copyEditableMetadataFrom($monographFile);
+	}
+
 	//
 	// Get/set methods
 	//

--- a/classes/monograph/MonographFileDAODelegate.inc.php
+++ b/classes/monograph/MonographFileDAODelegate.inc.php
@@ -37,6 +37,16 @@ class MonographFileDAODelegate extends SubmissionFileDAODelegate {
 	function newDataObject() {
 		return new MonographFile();
 	}
+
+	/**
+	 * @copydoc DAO::getAdditionalFieldNames()
+	 */
+	function getAdditionalFieldNames() {
+		return array_merge(
+			parent::getAdditionalFieldNames(),
+			array('chapterId')
+		);
+	}
 }
 
 ?>

--- a/templates/controllers/grid/users/chapter/form/chapterForm.tpl
+++ b/templates/controllers/grid/users/chapter/form/chapterForm.tpl
@@ -32,9 +32,17 @@
 		{fbvElement type="text" name="subtitle" id="subtitle" value=$subtitle maxlength="255" multilingual=true}
 	{/fbvFormSection}
 
-	<!--  Chapter Contributors -->
-	{url|assign:chapterAuthorUrl router=$smarty.const.ROUTE_COMPONENT component="listbuilder.users.ChapterAuthorListbuilderHandler" op="fetch" submissionId=$submissionId chapterId=$chapterId escape=false}
-	{load_url_in_div id="chapterAuthorContainer" url=$chapterAuthorUrl}
+	{fbvFormSection inline=true size=$fbvStyles.size.MEDIUM}
+		<!--  Chapter Contributors -->
+		{url|assign:chapterAuthorUrl router=$smarty.const.ROUTE_COMPONENT component="listbuilder.users.ChapterAuthorListbuilderHandler" op="fetch" submissionId=$submissionId chapterId=$chapterId escape=false}
+		{load_url_in_div id="chapterAuthorContainer" url=$chapterAuthorUrl}
+	{/fbvFormSection}
+
+	{fbvFormSection inline=true size=$fbvStyles.size.MEDIUM}
+		<!-- Chapter Files -->
+		{url|assign:chapterFilesUrl router=$smarty.const.ROUTE_COMPONENT component="listbuilder.files.ChapterFilesListbuilderHandler" op="fetch" submissionId=$submissionId chapterId=$chapterId escape=false}
+		{load_url_in_div id="chapterFilesContainer" url=$chapterFilesUrl}
+	{/fbvFormSection}
 
 	{fbvFormButtons submitText="common.save"}
 </form>


### PR DESCRIPTION
Permit the chapters grid to also manage file associations with chapters.

This change adds an additional listbuilder to the chapters form, permitting selection of files to be associated with the chapters. Further revisions to those files will also inherit the chapter association, hopefully permitting automatic construction of an accurate association of all associated files after progression through the workflow from submission into publication.