### PR TITLE
pkp/pkp-lib#802 Improve the clarity of the publication formats grid

### DIFF
--- a/controllers/grid/catalogEntry/PublicationFormatGridCellProvider.inc.php
+++ b/controllers/grid/catalogEntry/PublicationFormatGridCellProvider.inc.php
@@ -177,7 +177,13 @@ class PublicationFormatGridCellProvider extends DataObjectGridCellProvider {
 				}
 				// If we have any notifications, wrap them in the appropriately styled div
 				if ($warningMarkup !== '') $warningMarkup = "<div class=\"pkp_notification\">$warningMarkup</div>";
-				$toolTip = ($this->getCellState($row, $column) == 'completed') ? __('grid.action.formatAvailable') : null;
+				if ($this->getCellState($row, $column) == 'completed') {
+					$toolTip = __('grid.action.disableFormat');
+					$label = __('common.disable');
+				} else {
+					$toolTip = __('grid.action.enableFormat');
+					$label = __('common.enable');
+				}
 				return array(new LinkAction(
 					'availablePublicationFormat',
 					new RemoteActionConfirmationModal(
@@ -186,7 +192,7 @@ class PublicationFormatGridCellProvider extends DataObjectGridCellProvider {
 						$router->url($request, null, 'grid.catalogEntry.PublicationFormatGridHandler',
 							'setAvailable', null, array('representationId' => $publicationFormat->getId(), 'newAvailableState' => $publicationFormat->getIsAvailable()?0:1, 'submissionId' => $monographId)),
 						'modal_approve'),
-						__('common.disable'),
+						$label,
 						$this->getCellState($row, $column),
 						$toolTip
 				));

--- a/controllers/grid/catalogEntry/PublicationFormatGridHandler.inc.php
+++ b/controllers/grid/catalogEntry/PublicationFormatGridHandler.inc.php
@@ -165,7 +165,7 @@ class PublicationFormatGridHandler extends GridHandler {
 		$this->addColumn(
 			new GridColumn(
 				'isAvailable',
-				'grid.catalogEntry.isAvailable',
+				'grid.catalogEntry.availability',
 				null,
 				'controllers/grid/common/cell/statusCell.tpl',
 				$cellProvider

--- a/locale/en_US/locale.xml
+++ b/locale/en_US/locale.xml
@@ -78,7 +78,7 @@
 	<message key="grid.catalogEntry.physicalFormat">Physical format</message>
 	<message key="grid.catalogEntry.monographRequired">A monograph id is required.</message>
 	<message key="grid.catalogEntry.publicationFormatRequired">A publication format must be chosen.</message>
-	<message key="grid.catalogEntry.isAvailable">Available</message>
+	<message key="grid.catalogEntry.availability">Availability</message>
 	<message key="grid.catalogEntry.proof">Proof</message>
 	<message key="grid.catalogEntry.availablePublicationFormat.title">Format Approval</message>
 	<message key="grid.catalogEntry.availablePublicationFormat.message"><![CDATA[<p>This format will now be made <em>available</em> to readers, through downloadable files that will now appear with the book’s catalog entry and/or through further actions taken by the press to distribute the book.</p>]]></message>
@@ -213,7 +213,8 @@
 	<message key="grid.action.approveProofs">View the proofs grid</message>
 	<message key="grid.action.proofApproved">Format has been proofed</message>
 	<message key="grid.action.availablePublicationFormat">Approve/disapprove this format</message>
-	<message key="grid.action.formatAvailable">Format is available and published</message>
+	<message key="grid.action.disableFormat">Disable this publication format</message>
+	<message key="grid.action.enableFormat">Enable this publication format</message>
 
 	<!-- Review Attachments -->
 	<message key="grid.reviewAttachments.add">Add Attachment to Review</message>


### PR DESCRIPTION
The publication formats grid isn't very clear -- currently (since the UI overhaul merge?) there are "Approve" / "Disapprove" actions. IIRC previously there were clickable checkboxes. Review and improve. [AS putting words in NW's mouth]