### PR TITLE
pkp/pkp-lib#836 book hooks and layout

### DIFF
--- a/plugins/generic/addThis/AddThisPlugin.inc.php
+++ b/plugins/generic/addThis/AddThisPlugin.inc.php
@@ -24,7 +24,7 @@ class AddThisPlugin extends GenericPlugin {
 	function register($category, $path) {
 		if (parent::register($category, $path)) {
 			if ($this->getEnabled()) {
-				HookRegistry::register('Templates::Catalog::Book::BookInfo::Sharing', array($this, 'callbackSharingDisplay'));
+				HookRegistry::register('Templates::Catalog::Book::Details', array($this, 'callbackSharingDisplay'));
 				// Register the components this plugin implements
 				HookRegistry::register('LoadComponentHandler', array($this, 'setupGridHandler'));
 			}

--- a/plugins/generic/addThis/templates/addThis.tpl
+++ b/plugins/generic/addThis/templates/addThis.tpl
@@ -7,54 +7,56 @@
  *
  * The included template that is hooked into Templates::Catalog::Book::BookInfo::Sharing.
  *}
-<div id="addThisPluginOutput" class="pkp_helpers_clear">
-	<!-- AddThis Button BEGIN -->
-	{if $addThisDisplayStyle == 'button'}
-		<a class="addthis_button" href="http://www.addthis.com/bookmark.php?v=250&amp;pubid={$addThisProfileId|escape:"url"}"><img src="http://s7.addthis.com/static/btn/sm-share-en.gif" width="83" height="16" alt="Bookmark and Share" style="border:0"/></a>
-		<script type="text/javascript" src="http://s7.addthis.com/js/250/addthis_widget.js#pubid={$addThisProfileId|escape:"url"}"></script>
-	{elseif $addThisDisplayStyle == 'simple_button'}
-		<div class="addthis_toolbox addthis_default_style ">
-		<a href="http://www.addthis.com/bookmark.php?v=250&amp;pubid={$addThisProfileId|escape:"url"}" class="addthis_button_compact">Share</a>
-		</div>
-		<script type="text/javascript" src="http://s7.addthis.com/js/250/addthis_widget.js#pubid={$addThisProfileId|escape:"url"}"></script>
-	{elseif $addThisDisplayStyle == 'large_toolbox'}
-		<div class="addthis_toolbox addthis_default_style addthis_32x32_style">
-		<a class="addthis_button_preferred_1"></a>
-		<a class="addthis_button_preferred_2"></a>
-		<a class="addthis_button_preferred_3"></a>
-		<a class="addthis_button_preferred_4"></a>
-		<a class="addthis_button_compact"></a>
-		<a class="addthis_counter addthis_bubble_style"></a>
-		</div>
-		<script type="text/javascript" src="http://s7.addthis.com/js/250/addthis_widget.js#pubid={$addThisProfileId|escape:"url"}"></script>
-	{elseif $addThisDisplayStyle == 'small_toolbox_with_share'}
-		<div class="addthis_toolbox addthis_default_style ">
-		<a href="http://www.addthis.com/bookmark.php?v=250&amp;pubid={$addThisProfileId|escape:"url"}" class="addthis_button_compact">Share</a>
-		<span class="addthis_separator">|</span>
-		<a class="addthis_button_preferred_1"></a>
-		<a class="addthis_button_preferred_2"></a>
-		<a class="addthis_button_preferred_3"></a>
-		<a class="addthis_button_preferred_4"></a>
-		</div>
-		<script type="text/javascript" src="http://s7.addthis.com/js/250/addthis_widget.js#pubid={$addThisProfileId|escape:"url"}"></script>
-	{elseif $addThisDisplayStyle == 'plus_one_share_counter'}
-		<div class="addthis_toolbox addthis_default_style ">
-		<a class="addthis_button_facebook_like" fb:like:layout="button_count"></a>
-		<a class="addthis_button_tweet"></a>
-		<a class="addthis_button_google_plusone" g:plusone:size="medium"></a>
-		<a class="addthis_counter addthis_pill_style"></a>
-		</div>
-		<script type="text/javascript" src="http://s7.addthis.com/js/250/addthis_widget.js#pubid={$addThisProfileId|escape:"url"}"></script>
-	{else} {* small_toolbox is default *}
-		<div class="addthis_toolbox addthis_default_style ">
-		<a class="addthis_button_preferred_1"></a>
-		<a class="addthis_button_preferred_2"></a>
-		<a class="addthis_button_preferred_3"></a>
-		<a class="addthis_button_preferred_4"></a>
-		<a class="addthis_button_compact"></a>
-		<a class="addthis_counter addthis_bubble_style"></a>
-		</div>
-		<script type="text/javascript" src="http://s7.addthis.com/js/250/addthis_widget.js#pubid={$addThisProfileId|escape:"url"}"></script>
-	{/if}
-	<!-- AddThis Button END -->
+<div class="item addthis">
+	<div class="value">
+		<!-- AddThis Button BEGIN -->
+		{if $addThisDisplayStyle == 'button'}
+			<a class="addthis_button" href="http://www.addthis.com/bookmark.php?v=250&amp;pubid={$addThisProfileId|escape:"url"}"><img src="http://s7.addthis.com/static/btn/sm-share-en.gif" width="83" height="16" alt="Bookmark and Share" style="border:0"/></a>
+			<script type="text/javascript" src="http://s7.addthis.com/js/250/addthis_widget.js#pubid={$addThisProfileId|escape:"url"}"></script>
+		{elseif $addThisDisplayStyle == 'simple_button'}
+			<div class="addthis_toolbox addthis_default_style ">
+			<a href="http://www.addthis.com/bookmark.php?v=250&amp;pubid={$addThisProfileId|escape:"url"}" class="addthis_button_compact">Share</a>
+			</div>
+			<script type="text/javascript" src="http://s7.addthis.com/js/250/addthis_widget.js#pubid={$addThisProfileId|escape:"url"}"></script>
+		{elseif $addThisDisplayStyle == 'large_toolbox'}
+			<div class="addthis_toolbox addthis_default_style addthis_32x32_style">
+			<a class="addthis_button_preferred_1"></a>
+			<a class="addthis_button_preferred_2"></a>
+			<a class="addthis_button_preferred_3"></a>
+			<a class="addthis_button_preferred_4"></a>
+			<a class="addthis_button_compact"></a>
+			<a class="addthis_counter addthis_bubble_style"></a>
+			</div>
+			<script type="text/javascript" src="http://s7.addthis.com/js/250/addthis_widget.js#pubid={$addThisProfileId|escape:"url"}"></script>
+		{elseif $addThisDisplayStyle == 'small_toolbox_with_share'}
+			<div class="addthis_toolbox addthis_default_style ">
+			<a href="http://www.addthis.com/bookmark.php?v=250&amp;pubid={$addThisProfileId|escape:"url"}" class="addthis_button_compact">Share</a>
+			<span class="addthis_separator">|</span>
+			<a class="addthis_button_preferred_1"></a>
+			<a class="addthis_button_preferred_2"></a>
+			<a class="addthis_button_preferred_3"></a>
+			<a class="addthis_button_preferred_4"></a>
+			</div>
+			<script type="text/javascript" src="http://s7.addthis.com/js/250/addthis_widget.js#pubid={$addThisProfileId|escape:"url"}"></script>
+		{elseif $addThisDisplayStyle == 'plus_one_share_counter'}
+			<div class="addthis_toolbox addthis_default_style ">
+			<a class="addthis_button_facebook_like" fb:like:layout="button_count"></a>
+			<a class="addthis_button_tweet"></a>
+			<a class="addthis_button_google_plusone" g:plusone:size="medium"></a>
+			<a class="addthis_counter addthis_pill_style"></a>
+			</div>
+			<script type="text/javascript" src="http://s7.addthis.com/js/250/addthis_widget.js#pubid={$addThisProfileId|escape:"url"}"></script>
+		{else} {* small_toolbox is default *}
+			<div class="addthis_toolbox addthis_default_style ">
+			<a class="addthis_button_preferred_1"></a>
+			<a class="addthis_button_preferred_2"></a>
+			<a class="addthis_button_preferred_3"></a>
+			<a class="addthis_button_preferred_4"></a>
+			<a class="addthis_button_compact"></a>
+			<a class="addthis_counter addthis_bubble_style"></a>
+			</div>
+			<script type="text/javascript" src="http://s7.addthis.com/js/250/addthis_widget.js#pubid={$addThisProfileId|escape:"url"}"></script>
+		{/if}
+		<!-- AddThis Button END -->
+	</div>
 </div>

--- a/plugins/themes/default/styles/objects/monograph_full.less
+++ b/plugins/themes/default/styles/objects/monograph_full.less
@@ -21,17 +21,33 @@
 		margin-bottom: @quadruple;
 	}
 
-	.author_roles {
-		&:extend(.pkp_unstyled_list);
+	.main_entry {
 
-		.name {
-			display: block;
+		.item {
+			padding: 30px 0;
+
+			&:first-child {
+				padding-top: 0;
+			}
+		}
+
+		.sub_item {
+			margin-bottom: @double;
+
+			&:last-child {
+				margin-bottom: 0;
+			}
+		}
+
+		.label {
+			margin: 0 0 @double;
+			font-size: @font-base;
 			font-weight: @bold;
 		}
 	}
 
-	h3 {
-		font-size: @font-base;
+	.authors .label {
+		margin-bottom: 0;
 	}
 
 	.entry_details {
@@ -44,8 +60,15 @@
 			border-bottom: @bg-border;
 		}
 
+		.sub_item {
+			margin-bottom: @double;
+
+			&:last-child {
+				margin-bottom: 0;
+			}
+		}
+
 		.label {
-			display: block;
 			font-size: @font-sml;
 			font-weight: @normal;
 			color: @text-light;
@@ -59,14 +82,6 @@
 	.cover img {
 		display: block;
 		margin: 0 auto;
-	}
-
-	.format_detail {
-		margin-bottom: @base;
-
-		&:last-child {
-			margin-bottom: 0;
-		}
 	}
 
 	.files {


### PR DESCRIPTION
This implements a more consistent markup pattern that we can use to allow components on the frontend to be added and swapped around while maintaining some visual consistency. This is useful, for example, to ensure the AddThis plugin or other plugins which add content via the hooks can blend in with other components on the page.

It's documented [here](https://github.com/pkp/omp/commit/b58489aafda519c16dd816aadee681b99b2d749a#diff-d512c39040211ac09ec7bbceac6e6a60R11) and ideally will be a pattern that we maintain for other themes, so that plugin markup output can remain compatible with multiple themes.

In terms of our long-term goals, presses will want some way to control the content that appears on the book page. Bozana has [pointed out](https://github.com/UB-Heidelberg/omp/issues/16) that everyone is going to a pretty different set of content they want on the page.  The hooks are a first-step for adding content. But I see flexibility progressing in maybe three stages:

(1) The hooks allow plugins to add content, and the markup pattern provides a clear way to keep the design consistent.

(2) We display all the core information via the hooks ourselves (abstract, downlaodable files, etc). We can then create a simple interface for them to choose where to put content, eg:

Content | Main Panel | Details Panel | Hide
-----------| ----------- | --------------- | --------
Authors | [X] Main  | [ ] Details Panel | [ ] Hidden
Published Date | [ ] Main  | [X] Details Panel | [ ] Hidden
DOI | [ ] Main  | [X] Details Panel | [ ] Hidden

At this point plugins could register to appear on this table in the settings area:

Content | Main Panel | Details Panel | Hide
-----------| ----------- | --------------- | --------
Authors | [X] Main  | [ ] Details Panel | [ ] Hidden
Published Date | [ ] Main  | [X] Details Panel | [ ] Hidden
DOI | [ ] Main  | [X] Details Panel | [ ] Hidden
AddThis | [ ] Main  | [X] Details Panel | [ ] Hidden

(3) We actually make the article page function like sidebar blocks, so they can re-order them as they'd like.

If you agree that 3 would be somewhere we want to end up, should we adjust the markup pattern now, so that it follows the same markup pattern as block plugin markup? This would mean that, eventually, we could have convergence in the systems we have to manage (just one sidebar system, instead of having a separate kind of content block management system just for books).

The markup is easy to change now if you think it's a target worth aiming for.