### PR TITLE
pkp/pkp-lib#958 Adapt book details depending on pub format settings

### DIFF
--- a/locale/en_US/locale.xml
+++ b/locale/en_US/locale.xml
@@ -24,7 +24,8 @@
 	<message key="monograph.languages">Languages (English, French, Spanish)</message>
 	<message key="monograph.publicationFormats">Publication Formats</message>
 	<message key="monograph.publicationFormat">Format</message>
-	<message key="monograph.publicationFormatDetails">Details about the available publication formats:</message>
+	<message key="monograph.publicationFormatDetails">Details about the available publication format: {$format}</message>
+	<message key="monograph.miscellaneousDetails">Details about this monograph</message>
 	<message key="monograph.carousel.publicationFormats">Formats:</message>
 	<message key="monograph.type">Type of Submission</message>
 	<message key="submission.pageProofs">Page Proofs</message>
@@ -558,8 +559,8 @@ Your server currently supports mbstring: <strong>{$supportsMBString}</strong>]]>
 	<message key="payment.directSales.openAccess">Open Access</message>
 	<message key="payment.directSales.price.description">File formats can be made available for downloading from the press website through open access at no cost to readers or direct sales (using an online payment processor, as configured in Distribution). For this file indicate the basis of access.</message>
 	<message key="payment.directSales.validPriceRequired">A valid numeric price is required.</message>
-	<message key="payment.directSales.purchase">Purchase ({$amount} {$currency})</message>
-	<message key="payment.directSales.download">Download</message>
+	<message key="payment.directSales.purchase">Purchase {$format} ({$amount} {$currency})</message>
+	<message key="payment.directSales.download">Download {$format}</message>
 	<message key="payment.directSales.monograph.name">Purchase Monograph or Chapter Download</message>
 	<message key="payment.directSales.monograph.description">This transaction is for the purchase of a direct download of a single monograph or monograph chapter.</message>
 

--- a/plugins/themes/default/styles/objects/monograph_full.less
+++ b/plugins/themes/default/styles/objects/monograph_full.less
@@ -74,6 +74,11 @@
 			color: @text-light;
 		}
 
+		// Labels without values
+		.item_heading .label {
+			font-weight: @bold;
+		}
+
 		ul {
 			&:extend(.pkp_unstyled_list);
 		}
@@ -109,7 +114,6 @@
 
 		> div,
 		.value li {
-			.pkp_helpers_clear;
 			margin-bottom: @double;
 
 			&:last-child {
@@ -117,14 +121,22 @@
 			}
 		}
 
+		.value li {
+			position: relative;
+
+			&:first-child {
+				margin-top: @half;
+			}
+		}
+
 		.name {
-			display: inline-block;
-			padding: @half 0;
+			display: block;
+			padding-left: @quadruple;
 			line-height: @double;
 		}
 
-		.link {
-			float: right;
+		.link,
+		.pub_format_single {
 
 			a {
 				&:extend(.cmp_button);
@@ -139,10 +151,37 @@
 					content: @fa-var-download;
 					margin-right: 0.25em;
 				}
+			}
+		}
 
-				&.pdf:before {
-					content: @fa-var-file-pdf-o;
+		.link {
+			position: absolute;
+			top: 0;
+			left: 0;
+
+			a {
+				padding: 0;
+				width: @triple;
+				height: @triple;
+				line-height: @triple;
+				text-align: center;
+				overflow: hidden;
+
+				&:before {
+					content: @fa-var-download; // Always use download icon
+					position: relative;
+					top: -1px;
+					margin-right: 0;
 				}
+			}
+		}
+
+		.pub_format_single a {
+			width: 100%;
+			text-align: center;
+
+			&.pdf:before {
+				content: @fa-var-file-pdf-o;
 			}
 		}
 	}

--- a/templates/frontend/objects/monograph_full.tpl
+++ b/templates/frontend/objects/monograph_full.tpl
@@ -162,40 +162,64 @@
 				<div class="item files">
 					{assign var=publicationFormats value=$publishedMonograph->getPublicationFormats()}
 					{foreach from=$publicationFormats item=publicationFormat}
-						{assign var=representationId value=$publicationFormat->getId()}
-						{if $publicationFormat->getIsAvailable() && $availableFiles[$representationId]}
-							<div class="{$representationId|escape}">
-								<span class="label">
-									{$publicationFormat->getLocalizedName()|escape}
-								</span>
-								<span class="value">
-									<ul>
-										{* There will be at most one of these *}
-										{foreach from=$availableFiles[$representationId] item=availableFile}
-											<li>
-												<span class="name">
-													{$availableFile->getLocalizedName()|escape}
-												</span>
-												<span class="link">
-													{if $availableFile->getDocumentType()==$smarty.const.DOCUMENT_TYPE_PDF}
-														{url|assign:downloadUrl op="view" path=$publishedMonograph->getId()|to_array:$representationId:$availableFile->getFileIdAndRevision()}
-													{else}
-														{url|assign:downloadUrl op="download" path=$publishedMonograph->getId()|to_array:$representationId:$availableFile->getFileIdAndRevision()}
-													{/if}
-													<a href="{$downloadUrl}" class="{$availableFile->getDocumentType()}">
-														{if $availableFile->getDirectSalesPrice()}
-															{translate key="payment.directSales.purchase" amount=$currency->format($availableFile->getDirectSalesPrice()) currency=$currency->getCodeAlpha()}
+						{assign var=pubicationFormatId value=$publicationFormat->getId()}
+						{if $publicationFormat->getIsAvailable() && $availableFiles[$pubicationFormatId]}
+
+							{* Use a simplified presentation if only one file exists *}
+							{if $availableFiles[$pubicationFormatId]|@count == 1}
+								<div class="{$pubicationFormatId|escape} pub_format_single">
+									{foreach from=$availableFiles[$pubicationFormatId] item=availableFile}
+										{if $availableFile->getDocumentType()==$smarty.const.DOCUMENT_TYPE_PDF}
+											{url|assign:downloadUrl op="view" path=$publishedMonograph->getId()|to_array:$pubicationFormatId:$availableFile->getFileIdAndRevision()}
+										{else}
+											{url|assign:downloadUrl op="download" path=$publishedMonograph->getId()|to_array:$pubicationFormatId:$availableFile->getFileIdAndRevision()}
+										{/if}
+										<a href="{$downloadUrl}" class="{$availableFile->getDocumentType()|escape}">
+											{if $availableFile->getDirectSalesPrice()}
+												{translate key="payment.directSales.purchase" format=$publicationFormat->getLocalizedName() amount=$currency->format($availableFile->getDirectSalesPrice()) currency=$currency->getCodeAlpha()}
+											{else}
+												{translate key="payment.directSales.download" format=$publicationFormat->getLocalizedName()}
+												{* @todo make the open access icon appear *}
+											{/if}
+										</a>
+									{/foreach}
+								</div>
+
+							{* Use an itemized presentation if multiple files exists *}
+							{else}
+								<div class="{$pubicationFormatId|escape}">
+									<span class="label">
+										{$publicationFormat->getLocalizedName()|escape}
+									</span>
+									<span class="value">
+										<ul>
+											{* There will be at most one of these *}
+											{foreach from=$availableFiles[$pubicationFormatId] item=availableFile}
+												<li>
+													<span class="name">
+														{$availableFile->getLocalizedName()|escape}
+													</span>
+													<span class="link">
+														{if $availableFile->getDocumentType()==$smarty.const.DOCUMENT_TYPE_PDF}
+															{url|assign:downloadUrl op="view" path=$publishedMonograph->getId()|to_array:$pubicationFormatId:$availableFile->getFileIdAndRevision()}
 														{else}
-															{translate key="payment.directSales.download"}
-															{* @todo make the open access icon appear *}
+															{url|assign:downloadUrl op="download" path=$publishedMonograph->getId()|to_array:$pubicationFormatId:$availableFile->getFileIdAndRevision()}
 														{/if}
-													</a>
-												</span>
-											</li>
-										{/foreach}
-									</ul>
-								</span><!-- .value -->
-							</div>
+														<a href="{$downloadUrl}" class="{$availableFile->getDocumentType()}">
+															{if $availableFile->getDirectSalesPrice()}
+																{translate key="payment.directSales.purchase" format=$publicationFormat->getLocalizedName() amount=$currency->format($availableFile->getDirectSalesPrice()) currency=$currency->getCodeAlpha()}
+															{else}
+																{translate key="payment.directSales.download" format=$publicationFormat->getLocalizedName()}
+																{* @todo make the open access icon appear *}
+															{/if}
+														</a>
+													</span>
+												</li>
+											{/foreach}
+										</ul>
+									</span><!-- .value -->
+								</div>
+							{/if}
 						{/if}
 					{/foreach}
 				</div>
@@ -255,18 +279,24 @@
 				{foreach from=$publicationFormats item="publicationFormat"}
 					{if $publicationFormat->getIsApproved()}
 						<div class="item publication_format">
-							<h3 class="pkp_screen_reader">
-								{translate key="monograph.publicationFormatDetails"}
-							</h3>
 
-							<div class="sub_item format">
-								<div class="label">
-									{translate key="monograph.publicationFormat"}
+							{* Only add the format-specific heading if multiple publication formats exist *}
+							{if count($publicationFormats) > 1}
+								<h3 class="pkp_screen_reader">
+									{translate key="monograph.publicationFormatDetails" format=$publicationFormat->getLocalizedName}
+								</h3>
+
+								<div class="sub_item item_heading format">
+									<div class="label">
+										{$publicationFormat->getLocalizedName()|escape}
+									</div>
 								</div>
-								<div class="value">
-									{$publicationFormat->getLocalizedName()|escape}
-								</div>
-							</div>
+							{else}
+								<h3 class="pkp_screen_reader">
+									{translate key="monograph.miscellaneousDetails"}
+								</h3>
+							{/if}
+
 
 							{* DOI's and other identification codes *}
 							{assign var=identificationCodes value=$publicationFormat->getIdentificationCodes()}


### PR DESCRIPTION
This commit adjusts the display of file downloads and publication
format details depending on the number or formats and files. If
a format has only one file, it will display a large download
link with the format named in the link. If a format has multiple
files, it will present an itemized download presentation.

If there is only one publication format, it will list details
such as pub ids, pub dates, etc without naming the format. If
there are multiple publication formats, it will list these under
a heading with the name of the format.