### PR TITLE
provide ca_ES and es_ES versions of ONIX code lists

### DIFF
--- a/locale/ca_ES/ONIX_BookProduct_CodeLists.xsd
+++ b/locale/ca_ES/ONIX_BookProduct_CodeLists.xsd
@@ -1,0 +1,23250 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+	**************************************************
+	*                                                *
+	*               ONIX INTERNATIONAL               *
+	*                                                *
+	*     BOOK PRODUCT INFORMATION MESSAGE SCHEMA    *
+	*                                                *
+	*           CODE LIST DATA TYPES MODULE          *
+	*               XML SCHEMA VERSION               *
+	*                                                *
+	*                    ISSUE: 17                   *
+	*                                                *
+	*                 Status: RELEASED               *
+	*            Release date: 2012-04-20            *
+	*                                                *
+	*  Orig filename ONIX_BookProduct_CodeLists.XSD  *
+	*                                                *
+	*          Original author: Francis Cave         *
+	*                                                *
+	*              (c) 2003-2012 EDItEUR             *
+	*             http://www.editeur.org/            *
+	*                                                *
+	**************************************************
+
+	N.B. PRIMARILY DESIGNED FOR USE WITH ONIX SCHEMAS
+
+	TERMS AND CONDITIONS OF USE OF THE ONIX PRODUCT INFORMATION MESSAGE XML SCHEMA
+
+	All ONIX standards and documentation are copyright materials, made available 
+	free of charge for general use.  If you use the ONIX International Code Lists, 
+	you will be deemed to have accepted these terms and conditions:
+
+	1.  You agree that you will not add to, delete from or amend any version of the 
+	ONIX Product Information Message Schema, or any part of the Schema except for 
+	strictly internal use in your own organisation.
+
+	2.  You agree that if you wish to add to, amend, or make extracts of any version 
+	of the Schema for any purpose that is not strictly internal to your own organisation, 
+	you will in the first instance notify EDItEUR and allow EDItEUR to review 
+	and comment on your proposed use, in the interest of securing an orderly 
+	development of the Schema for the benefit of other users.
+
+	If you do not accept these terms, you must not use any version of the ONIX Product 
+	Information Message Schema.
+
+	Full copies of all published versions of the latest release of this Schema and all 
+	associated documentation are available from the EDItEUR web site, where may also be 
+	found details of how to contact EDItEUR for advice on the use of this Schema. The URL 
+	for the EDItEUR web site is:
+
+	http://www.editeur.org/
+
+
+
+	MODULE REVISION HISTORY (IN REVERSE CHRONOLOGICAL ORDER)
+
+	2012-04-20: Module for public release based upon the ONIX International 
+	            Code lists Issue 17 (April 2012)
+
+	2012-01-23: Module for public release based upon the ONIX International 
+	            Code lists Issue 16 (January 2012)
+
+	2011-10-21: Module for public release based upon the ONIX International 
+	            Code lists Issue 15 (October 2011)
+
+	2011-06-27: Module for public release based upon the ONIX International 
+	            Code lists Issue 14 (June 2011)
+
+	2011-03-23: Module for public release based upon the ONIX International 
+	            Code lists Issue 13 (March 2011)
+
+	2010-10-26: Module for public release based upon the ONIX International 
+	            Code lists Issue 12 (October 2010)
+
+	2010-05-17: Module for public release based upon the ONIX International 
+	            Code lists Issue 11, with correction in List 67 (May 2010)
+
+	2010-03-18: Module for public release based upon the ONIX International 
+	            Code lists Issue 11 (March 2010)
+
+	2009-07-15: Module for public release based upon the ONIX International 
+	            Code lists Issue 10 (July 2009)
+
+	2009-04-09: Module for public release based upon the ONIX International 
+	            Code lists Issue 9 (April 2009)
+
+	2009-02-10: Module for public release based upon the ONIX International 
+	            Code Lists Issue 8+ (revised February 2009)
+
+	2008-12-04: Module for public release based upon the ONIX International 
+	            Code Lists Issue 8+ (December 2008)
+
+	2008-04-22: Module for public release based upon the ONIX International 
+	            Code Lists Issue 8 (April 2008)
+
+	2007-03-27: Module for public release based upon the ONIX International
+	            Code Lists Issue 7 (March 2007)
+
+	2006-07-18: Module for public release based upon the ONIX International
+	            Code Lists Issue 6 (July 2006)
+
+	2005-11-28: Module for public release based upon the ONIX International
+	            Code Lists Issue 5 (November 2005)
+
+	2005-02-10: Module for public release based upon the ONIX International
+	            Code Lists Issue 4 (February 2005)
+
+	2004-11-10: Module for public release based upon the ONIX International 
+	            Code Lists Issue 3 (August 2004)
+
+	2004-08-10: Second Draft Module based upon the ONIX International 
+	            Code Lists Issue 3 (August 2004)
+
+	2003-12-30: First Draft Module based upon the ONIX International 
+	            Code Lists Issue 2 (December 2003)
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+		<xs:simpleType name="List1">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 1">Notification or update type code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Early notification</xs:documentation>
+					<xs:documentation>Use for a complete record issued earlier than approximately six months before publication.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Advance notification (confirmed)</xs:documentation>
+					<xs:documentation>Use for a complete record issued to confirm advance information approximately six months before publication; or for a complete record issued after that date and before information has been confirmed from the book-in-hand.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Notification confirmed on publication</xs:documentation>
+					<xs:documentation>Use for a complete record issued to confirm advance information at or just before actual publication date; or for a complete record issued at any later date.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Update (partial)</xs:documentation>
+					<xs:documentation>In ONIX 3.0 only, use when sending a &apos;block update&apos; record. In previous ONIX releases, ONIX updating has generally been by complete record replacement using code 03, and code 04 is not used.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Suprimeix</xs:documentation>
+					<xs:documentation>Use when sending an instruction to delete a record which was previously issued. Note that a Delete instruction should NOT be used when a product is cancelled, put out of print, or otherwise withdrawn from sale: this should be handled as a change of Publishing status, leaving the receiver to decide whether to retain or delete the record. A Delete instruction is only used when there is a particular reason to withdraw a record completely, eg because it was issued in error.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Notice of sale</xs:documentation>
+					<xs:documentation>Notice of sale of a product, from one publisher to another: sent by the publisher disposing of the product.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Notice of acquisition</xs:documentation>
+					<xs:documentation>Notice of acquisition of a product, by one publisher from another: sent by the acquiring publisher.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Update - SupplyDetail only</xs:documentation>
+					<xs:documentation>ONIX Books 2.1 supply update - &lt;SupplyDetail> only (not used in ONIX 3.0).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Update - MarketRepresentation only</xs:documentation>
+					<xs:documentation>ONIX Books 2.1 supply update - &lt;MarketRepresentation> only (not used in ONIX 3.0).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Update - SupplyDetail and MarketRepresentation</xs:documentation>
+					<xs:documentation>ONIX Books 2.1 supply update - both &lt;SupplyDetail> and &lt;MarketRepresentation> (not used in ONIX 3.0).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List2">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 2">Product composition</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Single-item retail product</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Multiple-item retail product</xs:documentation>
+					<xs:documentation>Multiple-item product retailed as a whole.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Multiple-item collection, retailed as separate parts</xs:documentation>
+					<xs:documentation>Used when an ONIX record is required for a collection-as-a-whole, even though it is not currently retailed as such.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Trade-only product</xs:documentation>
+					<xs:documentation>Product not for retail, and not carrying retail items, eg empty dumpbin, empty counterpack, promotional material.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>Multiple-item trade pack</xs:documentation>
+					<xs:documentation>Carrying multiple copies for retailing as separate items, eg shrink-wrapped trade pack, filled dumpbin, filled counterpack.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List3">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 3">Record source type code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>No especificat</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Institució editora</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Publisher&apos;s distributor</xs:documentation>
+					<xs:documentation>Use to designate a distributor providing warehousing and fulfillment for a publisher or for a publisher&apos;s sales agent, as distinct from a wholesaler.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Wholesaler</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Bibliographic agency</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Library bookseller</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Publisher&apos;s sales agent</xs:documentation>
+					<xs:documentation>Use for a publisher&apos;s sales agent responsible for marketing the publisher&apos;s products within a territory, as opposed to a publisher&apos;s distributor who fulfills orders but does not market.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Publisher&apos;s conversion service provider</xs:documentation>
+					<xs:documentation>Downstream provider of e-publication format conversion service (who might also be a distributor or retailer of the converted e-publication), supplying metadata on behalf of the publisher. The assigned ISBN is taken from the publisher&apos;s ISBN prefix.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Conversion service provider</xs:documentation>
+					<xs:documentation>Downstream provider of e-publication format conversion service (who might also be a distributor or retailer of the converted e-publication), supplying metadata on behalf of the publisher. The assigned ISBN is taken from the service provider&apos;s prefix (whether or not the service provider dedicates that prefix to a particular publisher).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List5">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 5">Product identifier type code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Propietari</xs:documentation>
+					<xs:documentation>For example, a publisher&apos;s or wholesaler&apos;s product number.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>ISBN-10</xs:documentation>
+					<xs:documentation>International Standard Book Number, pre-2007, unhyphenated (10 characters) - now DEPRECATED in ONIX for Books, except where providing historical information for compatibility with legacy systems. It should only be used in relation to products published before 2007 - when ISBN-13 superseded it - and should never be used as the ONLY identifier (it should always be accompanied by the correct GTIN-13 / ISBN-13).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>GTIN-13</xs:documentation>
+					<xs:documentation>GS1 Global Trade Item Number, formerly known as EAN article number (13 digits).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>UPC</xs:documentation>
+					<xs:documentation>UPC product number (12 digits).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>ISMN-10</xs:documentation>
+					<xs:documentation>International Standard Music Number (M plus nine digits). Pre-2008 - now DEPRECATED in ONIX for Books, except where providing historical information for compatibility with legacy systems. It should only be used in relation to products published before 2008 - when ISMN-13 superseded it - and should never be used as the ONLY identifier (it should always be accompanied by the correct ISMN-13).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Mòdul DOI</xs:documentation>
+					<xs:documentation>Digital Object Identifier (Identificador d&apos;objectes digitals, llargària i joc de caràcters variables).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>LCCN</xs:documentation>
+					<xs:documentation>Library of Congress Control Number (12 characters, alphanumeric).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>GTIN-14</xs:documentation>
+					<xs:documentation>GS1 Global Trade Item Number (14 digits).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>ISBN-13</xs:documentation>
+					<xs:documentation>International Standard Book Number, from 2007, unhyphenated (13 digits starting 978 or 9791-9799).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Legal deposit number</xs:documentation>
+					<xs:documentation>The number assigned to a publication as part of a national legal deposit process.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Mòdul URN</xs:documentation>
+					<xs:documentation>Uniform Resource Name: note that in trade applications an ISBN must be sent as a GTIN-13 and, where required, as an ISBN-13 - it should not be sent as a URN.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>OCLC number</xs:documentation>
+					<xs:documentation>A unique number assigned to a bibliographic item by OCLC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Co-publisher&apos;s ISBN-13</xs:documentation>
+					<xs:documentation>An ISBN-13 assigned by a co-publisher. The &apos;main&apos; ISBN sent with ID type code 03 and/or 15 should always be the ISBN that is used for ordering from the supplier identified in Supply Detail. However, ISBN rules allow a co-published title to carry more than one ISBN. The co-publisher should be identified in an instance of the &lt;Publisher> composite, with the applicable &lt;PublishingRole> code.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>ISMN-13</xs:documentation>
+					<xs:documentation>International Standard Music Number, from 2008 (13-digit number starting 9790).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>ISBN-A</xs:documentation>
+					<xs:documentation>Actionable ISBN, in fact a special DOI incorporating the ISBN-13 within the DOI syntax. Begins &apos;10.978.&apos; or &apos;10.979.&apos; and includes a / character between the registrant element (publisher prefix) and publication element of the ISBN, eg 10.978.000/1234567. Note the ISBN-A should always be accompanied by the ISBN itself, using codes 03 and/or 15.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>JP e-code</xs:documentation>
+					<xs:documentation>E-publication identifier controlled by JPOIID&apos;s Committee for Research and Management of Electronic Publishing Codes.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List6">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 6">Barcode indicator</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Not barcoded</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Barcoded, scheme unspecified</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>EAN13</xs:documentation>
+					<xs:documentation>Position unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 (US dollar price encoded)</xs:documentation>
+					<xs:documentation>Position unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>UPC12</xs:documentation>
+					<xs:documentation>Type and position unspecified. DEPRECATED: if possible, use more specific values below.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>UPC12+5</xs:documentation>
+					<xs:documentation>Type and position unspecified. DEPRECATED: if possible, use more specific values below.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>UPC12 (item-specific)</xs:documentation>
+					<xs:documentation>AKA item/price: position unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (item-specific)</xs:documentation>
+					<xs:documentation>AKA item/price: position unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>UPC12 (price-point)</xs:documentation>
+					<xs:documentation>AKA price/item: position unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (price-point)</xs:documentation>
+					<xs:documentation>AKA price/item: position unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>EAN13 on cover 4</xs:documentation>
+					<xs:documentation>&apos;Cover 4&apos; is defined as the back cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 on cover 4 (US dollar price encoded)</xs:documentation>
+					<xs:documentation>&apos;Cover 4&apos; is defined as the back cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>UPC12 (item-specific) on cover 4</xs:documentation>
+					<xs:documentation>AKA item/price; &apos;cover 4&apos; is defined as the back cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (item-specific) on cover 4</xs:documentation>
+					<xs:documentation>AKA item/price; &apos;cover 4&apos; is defined as the back cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>UPC12 (price-point) on cover 4</xs:documentation>
+					<xs:documentation>AKA price/item; &apos;cover 4&apos; is defined as the back cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (price-point) on cover 4</xs:documentation>
+					<xs:documentation>AKA price/item; &apos;cover 4&apos; is defined as the back cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>EAN13 on cover 3</xs:documentation>
+					<xs:documentation>&apos;Cover 3&apos; is defined as the inside back cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 on cover 3 (US dollar price encoded)</xs:documentation>
+					<xs:documentation>&apos;Cover 3&apos; is defined as the inside back cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>UPC12 (item-specific) on cover 3</xs:documentation>
+					<xs:documentation>AKA item/price; &apos;cover 3&apos; is defined as the inside back cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (item-specific) on cover 3</xs:documentation>
+					<xs:documentation>AKA item/price; &apos;cover 3&apos; is defined as the inside back cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>UPC12 (price-point) on cover 3</xs:documentation>
+					<xs:documentation>AKA price/item; &apos;cover 3&apos; is defined as the inside back cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (price-point) on cover 3</xs:documentation>
+					<xs:documentation>AKA price/item; &apos;cover 3&apos; is defined as the inside back cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>EAN13 on cover 2</xs:documentation>
+					<xs:documentation>&apos;Cover 2&apos; is defined as the inside front cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 on cover 2 (US dollar price encoded)</xs:documentation>
+					<xs:documentation>&apos;Cover 2&apos; is defined as the inside front cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>UPC12 (item-specific) on cover 2</xs:documentation>
+					<xs:documentation>AKA item/price; &apos;cover 2&apos; is defined as the inside front cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (item-specific) on cover 2</xs:documentation>
+					<xs:documentation>AKA item/price; &apos;cover 2&apos; is defined as the inside front cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>UPC12 (price-point) on cover 2</xs:documentation>
+					<xs:documentation>AKA price/item; &apos;cover 2&apos; is defined as the inside front cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (price-point) on cover 2</xs:documentation>
+					<xs:documentation>AKA price/item; &apos;cover 2&apos; is defined as the inside front cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>EAN13 on box</xs:documentation>
+					<xs:documentation>To be used only on boxed products.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="29">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 on box (US dollar price encoded)</xs:documentation>
+					<xs:documentation>To be used only on boxed products.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>UPC12 (item-specific) on box</xs:documentation>
+					<xs:documentation>AKA item/price; to be used only on boxed products.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (item-specific) on box</xs:documentation>
+					<xs:documentation>AKA item/price; to be used only on boxed products.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>UPC12 (price-point) on box</xs:documentation>
+					<xs:documentation>AKA price/item; to be used only on boxed products.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (price-point) on box</xs:documentation>
+					<xs:documentation>AKA price/item; to be used only on boxed products.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>EAN13 on tag</xs:documentation>
+					<xs:documentation>To be used only on products fitted with hanging tags.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="35">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 on tag (US dollar price encoded)</xs:documentation>
+					<xs:documentation>To be used only on products fitted with hanging tags.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="36">
+				<xs:annotation>
+					<xs:documentation>UPC12 (item-specific) on tag</xs:documentation>
+					<xs:documentation>AKA item/price; to be used only on products fitted with hanging tags.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="37">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (item-specific) on tag</xs:documentation>
+					<xs:documentation>AKA item/price; to be used only on products fitted with hanging tags.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="38">
+				<xs:annotation>
+					<xs:documentation>UPC12 (price-point) on tag</xs:documentation>
+					<xs:documentation>AKA price/item; to be used only on products fitted with hanging tags.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="39">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (price-point) on tag</xs:documentation>
+					<xs:documentation>AKA price/item; to be used only on products fitted with hanging tags.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="40">
+				<xs:annotation>
+					<xs:documentation>EAN13 on bottom</xs:documentation>
+					<xs:documentation>Not be used on books unless they are contained within outer packaging.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="41">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 on bottom (US dollar price encoded)</xs:documentation>
+					<xs:documentation>Not be used on books unless they are contained within outer packaging.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="42">
+				<xs:annotation>
+					<xs:documentation>UPC12 (item-specific) on bottom</xs:documentation>
+					<xs:documentation>AKA item/price; not be used on books unless they are contained within outer packaging.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="43">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (item-specific) on bottom</xs:documentation>
+					<xs:documentation>AKA item/price; not be used on books unless they are contained within outer packaging.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="44">
+				<xs:annotation>
+					<xs:documentation>UPC12 (price-point) on bottom</xs:documentation>
+					<xs:documentation>AKA price/item; not be used on books unless they are contained within outer packaging.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="45">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (price-point) on bottom</xs:documentation>
+					<xs:documentation>AKA price/item; not be used on books unless they are contained within outer packaging.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="46">
+				<xs:annotation>
+					<xs:documentation>EAN13 on back</xs:documentation>
+					<xs:documentation>Not be used on books unless they are contained within outer packaging.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="47">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 on back (US dollar price encoded)</xs:documentation>
+					<xs:documentation>Not be used on books unless they are contained within outer packaging.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="48">
+				<xs:annotation>
+					<xs:documentation>UPC12 (item-specific) on back</xs:documentation>
+					<xs:documentation>AKA item/price; not be used on books unless they are contained within outer packaging.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="49">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (item-specific) on back</xs:documentation>
+					<xs:documentation>AKA item/price; not be used on books unless they are contained within outer packaging.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="50">
+				<xs:annotation>
+					<xs:documentation>UPC12 (price-point) on back</xs:documentation>
+					<xs:documentation>AKA price/item; not be used on books unless they are contained within outer packaging.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="51">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (price-point) on back</xs:documentation>
+					<xs:documentation>AKA price/item; not be used on books unless they are contained within outer packaging.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="52">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 on outer sleeve/back (US dollar price encoded)</xs:documentation>
+					<xs:documentation>To be used only on products packaged in outer sleeves.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="53">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 on outer sleeve/back</xs:documentation>
+					<xs:documentation>To be used only on products packaged in outer sleeves.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="54">
+				<xs:annotation>
+					<xs:documentation>UPC12 (item-specific) on outer sleeve/back</xs:documentation>
+					<xs:documentation>AKA item/price; to be used only on products packaged in outer sleeves.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="55">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (item-specific) on outer sleeve/back</xs:documentation>
+					<xs:documentation>AKA item/price; to be used only on products packaged in outer sleeves.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="56">
+				<xs:annotation>
+					<xs:documentation>UPC12 (price-point) on outer sleeve/back</xs:documentation>
+					<xs:documentation>AKA price/item; to be used only on products packaged in outer sleeves.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="57">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (price-point) on outer sleeve/back</xs:documentation>
+					<xs:documentation>AKA price/item; to be used only on products packaged in outer sleeves.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="58">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 (no price encoded)</xs:documentation>
+					<xs:documentation>Position unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="59">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 on cover 4 (no price encoded)</xs:documentation>
+					<xs:documentation>&apos;Cover 4&apos; is defined as the back cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="60">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 on cover 3 (no price encoded)</xs:documentation>
+					<xs:documentation>&apos;Cover 3&apos; is defined as the inside back cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="61">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 on cover 2 (no price encoded)</xs:documentation>
+					<xs:documentation>&apos;Cover 2&apos; is defined as the inside front cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="62">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 on box (no price encoded)</xs:documentation>
+					<xs:documentation>To be used only on boxed products.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="63">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 on tag (no price encoded)</xs:documentation>
+					<xs:documentation>To be used only on products fitted with hanging tags.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="64">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 on bottom (no price encoded)</xs:documentation>
+					<xs:documentation>Not be used on books unless they are contained within outer packaging.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="65">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 on back (no price encoded)</xs:documentation>
+					<xs:documentation>Not be used on books unless they are contained within outer packaging.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="66">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 on outer sleeve/back (no price encoded)</xs:documentation>
+					<xs:documentation>To be used only on products packaged in outer sleeves.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="67">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 (CAN dollar price encoded)</xs:documentation>
+					<xs:documentation>Position unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="68">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 on cover 4 (CAN dollar price encoded)</xs:documentation>
+					<xs:documentation>&apos;Cover 4&apos; is defined as the back cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="69">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 on cover 3 (CAN dollar price encoded)</xs:documentation>
+					<xs:documentation>&apos;Cover 3&apos; is defined as the inside back cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="70">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 on cover 2 (CAN dollar price encoded)</xs:documentation>
+					<xs:documentation>&apos;Cover 2&apos; is defined as the inside front cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="71">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 on box (CAN dollar price encoded)</xs:documentation>
+					<xs:documentation>To be used only on boxed products.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="72">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 on tag (CAN dollar price encoded)</xs:documentation>
+					<xs:documentation>To be used only on products fitted with hanging tags.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="73">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 on bottom (CAN dollar price encoded)</xs:documentation>
+					<xs:documentation>Not be used on books unless they are contained within outer packaging.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="74">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 on back (CAN dollar price encoded)</xs:documentation>
+					<xs:documentation>Not be used on books unless they are contained within outer packaging.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="75">
+				<xs:annotation>
+					<xs:documentation>EAN13 on outer sleeve/back (CAN dollar price encoded)</xs:documentation>
+					<xs:documentation>To be used only on products packaged in outer sleeves.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List7">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 7">Product form code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>No definit</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AA">
+				<xs:annotation>
+					<xs:documentation>Audio</xs:documentation>
+					<xs:documentation>Audio recording - detail unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AB">
+				<xs:annotation>
+					<xs:documentation>Audio cassette</xs:documentation>
+					<xs:documentation>Audio cassette (analogue).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AC">
+				<xs:annotation>
+					<xs:documentation>CD-Audio</xs:documentation>
+					<xs:documentation>Audio compact disc, in any recording format: use coding in Product Form Detail to specify the format, if required.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AD">
+				<xs:annotation>
+					<xs:documentation>DAT</xs:documentation>
+					<xs:documentation>Digital audio tape cassette.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AE">
+				<xs:annotation>
+					<xs:documentation>Audio disc</xs:documentation>
+					<xs:documentation>Audio disc (excluding CD).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AF">
+				<xs:annotation>
+					<xs:documentation>Audio tape</xs:documentation>
+					<xs:documentation>Audio tape (open reel tape).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AG">
+				<xs:annotation>
+					<xs:documentation>MiniDisc</xs:documentation>
+					<xs:documentation>Sony MiniDisc format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AH">
+				<xs:annotation>
+					<xs:documentation>CD-Extra</xs:documentation>
+					<xs:documentation>Audio compact disc with part CD-ROM content.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AI">
+				<xs:annotation>
+					<xs:documentation>DVD Audio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AJ">
+				<xs:annotation>
+					<xs:documentation>Downloadable audio file</xs:documentation>
+					<xs:documentation>Audio recording downloadable online.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AK">
+				<xs:annotation>
+					<xs:documentation>Pre-recorded digital audio player</xs:documentation>
+					<xs:documentation>For example, Playaway audiobook and player: use coding in Product Form Detail to specify the recording format, if required.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AL">
+				<xs:annotation>
+					<xs:documentation>Pre-recorded SD card</xs:documentation>
+					<xs:documentation>For example, Audiofy audiobook chip.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AZ">
+				<xs:annotation>
+					<xs:documentation>Other audio format</xs:documentation>
+					<xs:documentation>Other audio format not specified by AB to AL.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BA">
+				<xs:annotation>
+					<xs:documentation>Llibre</xs:documentation>
+					<xs:documentation>Book - detail unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BB">
+				<xs:annotation>
+					<xs:documentation>Hardback</xs:documentation>
+					<xs:documentation>Hardback or cased book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BC">
+				<xs:annotation>
+					<xs:documentation>Paperback / softback</xs:documentation>
+					<xs:documentation>Paperback or other softback book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BD">
+				<xs:annotation>
+					<xs:documentation>Loose-leaf</xs:documentation>
+					<xs:documentation>Loose-leaf book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BE">
+				<xs:annotation>
+					<xs:documentation>Spiral bound</xs:documentation>
+					<xs:documentation>Spiral, comb or coil bound book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BF">
+				<xs:annotation>
+					<xs:documentation>Pamphlet</xs:documentation>
+					<xs:documentation>Pamphlet or brochure, stapled; German &apos;geheftet&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BG">
+				<xs:annotation>
+					<xs:documentation>Leather / fine binding</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BH">
+				<xs:annotation>
+					<xs:documentation>Board book</xs:documentation>
+					<xs:documentation>Child&apos;s book with all pages printed on board.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BI">
+				<xs:annotation>
+					<xs:documentation>Rag book</xs:documentation>
+					<xs:documentation>Child&apos;s book with all pages printed on textile.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BJ">
+				<xs:annotation>
+					<xs:documentation>Bath book</xs:documentation>
+					<xs:documentation>Child&apos;s book printed on waterproof material.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BK">
+				<xs:annotation>
+					<xs:documentation>Novelty book</xs:documentation>
+					<xs:documentation>A book whose novelty consists wholly or partly in a format which cannot be described by any other available code - a &apos;conventional&apos; format code is always to be preferred; one or more Product Form Detail codes, eg from the B2nn group, should be used whenever possible to provide additional description.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BL">
+				<xs:annotation>
+					<xs:documentation>Slide bound</xs:documentation>
+					<xs:documentation>Slide bound book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BM">
+				<xs:annotation>
+					<xs:documentation>Big book</xs:documentation>
+					<xs:documentation>Extra-large format for teaching etc; this format and terminology may be specifically UK; required as a top-level differentiator.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BN">
+				<xs:annotation>
+					<xs:documentation>Part-work (fascículo)</xs:documentation>
+					<xs:documentation>A part-work issued with its own ISBN and intended to be collected and bound into a complete book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BO">
+				<xs:annotation>
+					<xs:documentation>Fold-out book or chart</xs:documentation>
+					<xs:documentation>Concertina-folded book or chart, designed to fold to pocket or regular page size: use for German &apos;Leporello&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BP">
+				<xs:annotation>
+					<xs:documentation>Foam book</xs:documentation>
+					<xs:documentation>A children&apos;s book whose cover and pages are made of foam.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BZ">
+				<xs:annotation>
+					<xs:documentation>Other book format</xs:documentation>
+					<xs:documentation>Other book format or binding not specified by BB to BP.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA">
+				<xs:annotation>
+					<xs:documentation>Sheet map</xs:documentation>
+					<xs:documentation>Sheet map - detail unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CB">
+				<xs:annotation>
+					<xs:documentation>Sheet map, folded</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CC">
+				<xs:annotation>
+					<xs:documentation>Sheet map, flat</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CD">
+				<xs:annotation>
+					<xs:documentation>Sheet map, rolled</xs:documentation>
+					<xs:documentation>See Code List 80 for &apos;rolled in tube&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CE">
+				<xs:annotation>
+					<xs:documentation>Globe</xs:documentation>
+					<xs:documentation>Globe or planisphere.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CZ">
+				<xs:annotation>
+					<xs:documentation>Other cartographic</xs:documentation>
+					<xs:documentation>Other cartographic format not specified by CB to CE.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DA">
+				<xs:annotation>
+					<xs:documentation>Digital</xs:documentation>
+					<xs:documentation>Digital or multimedia (detail unspecified).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DB">
+				<xs:annotation>
+					<xs:documentation>CD-ROM</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DC">
+				<xs:annotation>
+					<xs:documentation>CD-I</xs:documentation>
+					<xs:documentation>CD interactive.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DD">
+				<xs:annotation>
+					<xs:documentation>DVD</xs:documentation>
+					<xs:documentation>DEPRECATED - use VI for DVD video, AI for DVD audio, DI for DVD-ROM.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DE">
+				<xs:annotation>
+					<xs:documentation>Game cartridge</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DF">
+				<xs:annotation>
+					<xs:documentation>Diskette</xs:documentation>
+					<xs:documentation>AKA &apos;floppy disc&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DG">
+				<xs:annotation>
+					<xs:documentation>Electronic book text</xs:documentation>
+					<xs:documentation>Electronic book text in proprietary or open standard format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DH">
+				<xs:annotation>
+					<xs:documentation>Online resource</xs:documentation>
+					<xs:documentation>An electronic database or other resource or service accessible through online networks.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DI">
+				<xs:annotation>
+					<xs:documentation>DVD-ROM</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DJ">
+				<xs:annotation>
+					<xs:documentation>Secure Digital (SD) Memory Card</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DK">
+				<xs:annotation>
+					<xs:documentation>Compact Flash Memory Card</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DL">
+				<xs:annotation>
+					<xs:documentation>Memory Stick Memory Card</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DM">
+				<xs:annotation>
+					<xs:documentation>USB Flash Drive</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DN">
+				<xs:annotation>
+					<xs:documentation>Double-sided CD/DVD</xs:documentation>
+					<xs:documentation>Double-sided disc, one side Audio CD/CD-ROM, other side DVD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DZ">
+				<xs:annotation>
+					<xs:documentation>Other digital</xs:documentation>
+					<xs:documentation>Other digital or multimedia not specified by DB to DN.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FA">
+				<xs:annotation>
+					<xs:documentation>Film or transparency</xs:documentation>
+					<xs:documentation>Film or transparency - detail unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FB">
+				<xs:annotation>
+					<xs:documentation>Film</xs:documentation>
+					<xs:documentation>Continuous film or filmstrip: DEPRECATED - use FE or FF.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FC">
+				<xs:annotation>
+					<xs:documentation>Slides</xs:documentation>
+					<xs:documentation>Photographic transparencies mounted for projection.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FD">
+				<xs:annotation>
+					<xs:documentation>OHP transparencies</xs:documentation>
+					<xs:documentation>Transparencies for overhead projector.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FE">
+				<xs:annotation>
+					<xs:documentation>Filmstrip</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FF">
+				<xs:annotation>
+					<xs:documentation>Film</xs:documentation>
+					<xs:documentation>Continuous movie film as opposed to filmstrip.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FZ">
+				<xs:annotation>
+					<xs:documentation>Other film or transparency format</xs:documentation>
+					<xs:documentation>Other film or transparency format not specified by FB to FF.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MA">
+				<xs:annotation>
+					<xs:documentation>Microform</xs:documentation>
+					<xs:documentation>Microform - detail unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MB">
+				<xs:annotation>
+					<xs:documentation>Microfiche</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MC">
+				<xs:annotation>
+					<xs:documentation>Microfilm</xs:documentation>
+					<xs:documentation>Roll microfilm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MZ">
+				<xs:annotation>
+					<xs:documentation>Other microform</xs:documentation>
+					<xs:documentation>Other microform not specified by MB or MC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PA">
+				<xs:annotation>
+					<xs:documentation>Miscellaneous print</xs:documentation>
+					<xs:documentation>Miscellaneous printed material - detail unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PB">
+				<xs:annotation>
+					<xs:documentation>Address book</xs:documentation>
+					<xs:documentation>May use product form detail codes P201 to P204 to specify binding.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PC">
+				<xs:annotation>
+					<xs:documentation>Calendar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PD">
+				<xs:annotation>
+					<xs:documentation>Cards</xs:documentation>
+					<xs:documentation>Cards, flash cards (eg for teaching reading).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PE">
+				<xs:annotation>
+					<xs:documentation>Copymasters</xs:documentation>
+					<xs:documentation>Copymasters, photocopiable sheets.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PF">
+				<xs:annotation>
+					<xs:documentation>Diary</xs:documentation>
+					<xs:documentation>May use product form detail codes P201 to P204 to specify binding.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PG">
+				<xs:annotation>
+					<xs:documentation>Frieze</xs:documentation>
+					<xs:documentation>Narrow strip-shaped printed sheet used mostly for education or children&apos;s products (eg depicting alphabet, number line, procession of illustrated characters etc). Usually intended for horizontal display.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PH">
+				<xs:annotation>
+					<xs:documentation>Kit</xs:documentation>
+					<xs:documentation>Parts for post-purchase assembly.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PI">
+				<xs:annotation>
+					<xs:documentation>Sheet music</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PJ">
+				<xs:annotation>
+					<xs:documentation>Postcard book or pack</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PK">
+				<xs:annotation>
+					<xs:documentation>Poster</xs:documentation>
+					<xs:documentation>Poster for retail sale - see also XF.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PL">
+				<xs:annotation>
+					<xs:documentation>Record book</xs:documentation>
+					<xs:documentation>Record book (eg &apos;birthday book&apos;, &apos;baby book&apos;): may use product form detail codes P201 to P204 to specify binding.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PM">
+				<xs:annotation>
+					<xs:documentation>Wallet or folder</xs:documentation>
+					<xs:documentation>Wallet or folder (containing loose sheets etc): it is preferable to code the contents and treat &apos;wallet&apos; as packaging (List 80), but if this is not possible the product as a whole may be coded as a &apos;wallet&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PN">
+				<xs:annotation>
+					<xs:documentation>Pictures or photographs</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PO">
+				<xs:annotation>
+					<xs:documentation>Wallchart</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PP">
+				<xs:annotation>
+					<xs:documentation>Stickers</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PQ">
+				<xs:annotation>
+					<xs:documentation>Plate (lámina)</xs:documentation>
+					<xs:documentation>A book-sized (as opposed to poster-sized) sheet, usually in colour or high quality print.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PR">
+				<xs:annotation>
+					<xs:documentation>Notebook / blank book</xs:documentation>
+					<xs:documentation>A book with all pages blank for the buyer&apos;s own use: may use product form detail codes P201 to P204 to specify binding.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PS">
+				<xs:annotation>
+					<xs:documentation>Organizer</xs:documentation>
+					<xs:documentation>May use product form detail codes P201 to P204 to specify binding.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PT">
+				<xs:annotation>
+					<xs:documentation>Bookmark</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PZ">
+				<xs:annotation>
+					<xs:documentation>Other printed item</xs:documentation>
+					<xs:documentation>Other printed item not specified by PB to PT.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VA">
+				<xs:annotation>
+					<xs:documentation>Video</xs:documentation>
+					<xs:documentation>Video - detail unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VB">
+				<xs:annotation>
+					<xs:documentation>Video, VHS, PAL</xs:documentation>
+					<xs:documentation>DEPRECATED - use new VJ.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VC">
+				<xs:annotation>
+					<xs:documentation>Video, VHS, NTSC</xs:documentation>
+					<xs:documentation>DEPRECATED - use new VJ.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VD">
+				<xs:annotation>
+					<xs:documentation>Video, Betamax, PAL</xs:documentation>
+					<xs:documentation>DEPRECATED - use new VK.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VE">
+				<xs:annotation>
+					<xs:documentation>Video, Betamax, NTSC</xs:documentation>
+					<xs:documentation>DEPRECATED - use new VK.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VF">
+				<xs:annotation>
+					<xs:documentation>Videodisc</xs:documentation>
+					<xs:documentation>eg Laserdisc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VG">
+				<xs:annotation>
+					<xs:documentation>Video, VHS, SECAM</xs:documentation>
+					<xs:documentation>DEPRECATED - use new VJ.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VH">
+				<xs:annotation>
+					<xs:documentation>Video, Betamax, SECAM</xs:documentation>
+					<xs:documentation>DEPRECATED - use new VK.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VI">
+				<xs:annotation>
+					<xs:documentation>DVD video</xs:documentation>
+					<xs:documentation>DVD video: specify TV standard in List 78.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VJ">
+				<xs:annotation>
+					<xs:documentation>VHS video</xs:documentation>
+					<xs:documentation>VHS videotape: specify TV standard in List 78.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VK">
+				<xs:annotation>
+					<xs:documentation>Betamax video</xs:documentation>
+					<xs:documentation>Betamax videotape: specify TV standard in List 78.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VL">
+				<xs:annotation>
+					<xs:documentation>VCD</xs:documentation>
+					<xs:documentation>VideoCD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VM">
+				<xs:annotation>
+					<xs:documentation>SVCD</xs:documentation>
+					<xs:documentation>Super VideoCD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VN">
+				<xs:annotation>
+					<xs:documentation>HD DVD</xs:documentation>
+					<xs:documentation>High definition DVD disc, Toshiba HD DVD format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VO">
+				<xs:annotation>
+					<xs:documentation>Blu-ray</xs:documentation>
+					<xs:documentation>High definition DVD disc, Sony Blu-ray format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VP">
+				<xs:annotation>
+					<xs:documentation>UMD Video</xs:documentation>
+					<xs:documentation>Sony Universal Media disc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VZ">
+				<xs:annotation>
+					<xs:documentation>Other video format</xs:documentation>
+					<xs:documentation>Other video format not specified by VB to VP.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WW">
+				<xs:annotation>
+					<xs:documentation>Mixed media product</xs:documentation>
+					<xs:documentation>A product consisting of two or more items in different media, eg book and CD-ROM, book and toy etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WX">
+				<xs:annotation>
+					<xs:documentation>Multiple copy pack</xs:documentation>
+					<xs:documentation>A product containing multiple copies of one or more items packaged together for retail sale, consisting of either (a) several copies of a single item (eg 6 copies of a graded reader), or (b) several copies of each of several items (eg 3 copies each of 3 different graded readers), or (c) several copies of one or more single items plus a single copy of one or more related items (eg 30 copies of a pupil&apos;s textbook plus 1 of teacher&apos;s text). NOT TO BE CONFUSED WITH: multi-volume sets, or sets containing a single copy of a number of different items (boxed, slip-cased or otherwise); items with several components of different physical forms (see WW); or packs intended for trade distribution only, where the contents are retailed separately (see XC, XE, XL).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XA">
+				<xs:annotation>
+					<xs:documentation>Trade-only material</xs:documentation>
+					<xs:documentation>Trade-only material (unspecified).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XB">
+				<xs:annotation>
+					<xs:documentation>Dumpbin - empty</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XC">
+				<xs:annotation>
+					<xs:documentation>Dumpbin - filled</xs:documentation>
+					<xs:documentation>Dumpbin with contents.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XD">
+				<xs:annotation>
+					<xs:documentation>Counterpack - empty</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XE">
+				<xs:annotation>
+					<xs:documentation>Counterpack - filled</xs:documentation>
+					<xs:documentation>Counterpack with contents.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XF">
+				<xs:annotation>
+					<xs:documentation>Poster, promotional</xs:documentation>
+					<xs:documentation>Promotional poster for display, not for sale - see also PK.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XG">
+				<xs:annotation>
+					<xs:documentation>Shelf strip</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XH">
+				<xs:annotation>
+					<xs:documentation>Window piece</xs:documentation>
+					<xs:documentation>Promotional piece for shop window display.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XI">
+				<xs:annotation>
+					<xs:documentation>Streamer</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XJ">
+				<xs:annotation>
+					<xs:documentation>Spinner</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XK">
+				<xs:annotation>
+					<xs:documentation>Large book display</xs:documentation>
+					<xs:documentation>Large scale facsimile of book for promotional display.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XL">
+				<xs:annotation>
+					<xs:documentation>Shrink-wrapped pack</xs:documentation>
+					<xs:documentation>A quantity pack with its own product code, for trade supply only: the retail items it contains are intended for sale individually - see also WX. For products or product bundles supplied shrink-wrapped for retail sale, use the Product Form code of the contents plus code 21 from List 80.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XZ">
+				<xs:annotation>
+					<xs:documentation>Other point of sale</xs:documentation>
+					<xs:documentation>Other point of sale material not specified by XB to XL.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZA">
+				<xs:annotation>
+					<xs:documentation>General merchandise</xs:documentation>
+					<xs:documentation>General merchandise - unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZB">
+				<xs:annotation>
+					<xs:documentation>Doll</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZC">
+				<xs:annotation>
+					<xs:documentation>Soft toy</xs:documentation>
+					<xs:documentation>Soft or plush toy.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZD">
+				<xs:annotation>
+					<xs:documentation>Toy</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZE">
+				<xs:annotation>
+					<xs:documentation>Game</xs:documentation>
+					<xs:documentation>Board game, or other game (except computer game: see DE).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZF">
+				<xs:annotation>
+					<xs:documentation>T-shirt</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZZ">
+				<xs:annotation>
+					<xs:documentation>Other merchandise</xs:documentation>
+					<xs:documentation>Other merchandise not specified by ZB to ZF.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List8">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 8">Book form detail</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>A-format paperback</xs:documentation>
+					<xs:documentation>DEPRECATED.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>B-format paperback</xs:documentation>
+					<xs:documentation>&apos;B&apos; format paperback: UK 198 x 129 mm - DEPRECATED.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>C-format paperback</xs:documentation>
+					<xs:documentation>&apos;C&apos; format paperback: UK 216 x 135 mm - DEPRECATED.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Paper over boards</xs:documentation>
+					<xs:documentation>DEPRECATED.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Cloth</xs:documentation>
+					<xs:documentation>DEPRECATED.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>With dust jacket</xs:documentation>
+					<xs:documentation>DEPRECATED.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Reinforced binding</xs:documentation>
+					<xs:documentation>DEPRECATED.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List9">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 9">Product classification type code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>WCO Harmonized System</xs:documentation>
+					<xs:documentation>World Customs Organization Harmonized Commodity Coding and Description System.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>UNSPSC</xs:documentation>
+					<xs:documentation>UN Standard Product and Service Classification.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>HMRC</xs:documentation>
+					<xs:documentation>UK Revenue and Customs classifications, based on the Harmonized System.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Warenverzeichnis für die Außenhandelsstatistik</xs:documentation>
+					<xs:documentation>German export trade classification, based on the Harmonised System.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>TARIC</xs:documentation>
+					<xs:documentation>EU TARIC codes, an extended version of the Harmonized System.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Fondsgroep</xs:documentation>
+					<xs:documentation>Centraal Boekhuis free classification field for publishers.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Sender&apos;s product category</xs:documentation>
+					<xs:documentation>A product category (not a subject classification) assigned by the sender.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>GAPP Product Class</xs:documentation>
+					<xs:documentation>Product classification maintained by the Chinese General Administration of Press and Publication (http://www.gapp.gov.cn).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>CPA</xs:documentation>
+					<xs:documentation>Statistical Classification of Products by Activity in the European Economic Community, see http://ec.europa.eu/eurostat/ramon/nomenclatures/index.cfm?TargetUrl=LST_NOM_DTL&amp;StrNom=CPA_2008. Up to six digits, with one or two periods. For example, printed children&apos;s books are &apos;58.11.13&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List10">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 10">Epublication type code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="000">
+				<xs:annotation>
+					<xs:documentation>Epublication &apos;content package&apos;</xs:documentation>
+					<xs:documentation>An epublication viewed as a unique package of content which may be converted into any of a number of different types for delivery to the consumer. This code is used when an ONIX &lt;Product> record describes the content package and lists within the record the different forms in which it is available.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="001">
+				<xs:annotation>
+					<xs:documentation>HTML</xs:documentation>
+					<xs:documentation>An epublication delivered in a basic, unprotected, HTML format. Do NOT use for HTML-based formats which include DRM protection.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="002">
+				<xs:annotation>
+					<xs:documentation>PDF</xs:documentation>
+					<xs:documentation>An epublication delivered in a basic, unprotected, PDF format. Do NOT use for PDF-based formats which include DRM protection.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="003">
+				<xs:annotation>
+					<xs:documentation>PDF-Merchant</xs:documentation>
+					<xs:documentation>An epublication delivered in PDF format, capable of being read in the standard Acrobat Reader, and protected by PDF-Merchant DRM features. (This format is no longer supported for new applications.).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="004">
+				<xs:annotation>
+					<xs:documentation>Adobe Ebook Reader</xs:documentation>
+					<xs:documentation>An epublication delivered in an enhanced PDF format, using Adobe&apos;s proprietary EBX DRM, capable of being read in the Adobe Ebook Reader software, on any platform which can support this software, which was formerly known as Glassbook.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="005">
+				<xs:annotation>
+					<xs:documentation>Microsoft Reader Level 1/Level 3</xs:documentation>
+					<xs:documentation>An epublication delivered in an unencrypted Microsoft .LIT format, capable of being read in the Microsoft Reader software at any level, on any platform which can support this software. (Level 3 differs from Level 1 only in that it embeds the name of the original purchaser.).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="006">
+				<xs:annotation>
+					<xs:documentation>Microsoft Reader Level 5</xs:documentation>
+					<xs:documentation>An epublication delivered in the Microsoft .LIT format, with full encryption, capable of being read in the Microsoft Reader software at Level 5, on any platform which can support this software.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="007">
+				<xs:annotation>
+					<xs:documentation>NetLibrary</xs:documentation>
+					<xs:documentation>An epublication delivered in a proprietary HTML- or OEBF-based format, capable of being read only through subscription to the NetLibrary service.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="008">
+				<xs:annotation>
+					<xs:documentation>MetaText</xs:documentation>
+					<xs:documentation>An epublication delivered in a proprietary format through a web browser, capable of being read only through subscription to the MetaText service (the educational division of NetLibrary).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="009">
+				<xs:annotation>
+					<xs:documentation>MightyWords</xs:documentation>
+					<xs:documentation>An epublication delivered in a proprietary PDF-based format, capable of being read only through subscription to the MightyWords service.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="010">
+				<xs:annotation>
+					<xs:documentation>eReader (AKA Palm Reader)</xs:documentation>
+					<xs:documentation>An epublication delivered in a proprietary HTML-based format, capable of being read in reading software which may be used on handheld devices using the Palm OS or Pocket PC/Windows CE operating systems.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="011">
+				<xs:annotation>
+					<xs:documentation>Softbook</xs:documentation>
+					<xs:documentation>An epublication delivered in a proprietary format capable of being read in reading software which is specific to the Softbook hardware platform. Also capable of being read on the Softbook&apos;s successor, the Gemstar REB 1200.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="012">
+				<xs:annotation>
+					<xs:documentation>RocketBook</xs:documentation>
+					<xs:documentation>An epublication delivered in a proprietary .RB format, capable of being read in reading software which is specific to the RocketBook hardware platform. Also capable of being read on the RocketBook&apos;s successor, the Gemstar REB 1100.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="013">
+				<xs:annotation>
+					<xs:documentation>Gemstar REB 1100</xs:documentation>
+					<xs:documentation>An epublication delivered in a proprietary .RB format, capable of being read in reading software which is specific to the Gemstar REB 1100 hardware platform. Also capable of being read on the RocketBook with some loss of functionality.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="014">
+				<xs:annotation>
+					<xs:documentation>Gemstar REB 1200</xs:documentation>
+					<xs:documentation>An epublication delivered in a proprietary format, capable of being read in reading software which is specific to the Gemstar REB 1200 hardware platform. Also capable of being read on the Softbook with some loss of functionality.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="015">
+				<xs:annotation>
+					<xs:documentation>Franklin eBookman</xs:documentation>
+					<xs:documentation>An epublication delivered in Franklin&apos;s proprietary HTML-based format, capable of being read in reading software which is specific to the Franklin eBookman platform.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="016">
+				<xs:annotation>
+					<xs:documentation>Books24x7</xs:documentation>
+					<xs:documentation>An epublication delivered in a proprietary XML-based format and available for online access only through subscription to the Books24x7 service.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="017">
+				<xs:annotation>
+					<xs:documentation>DigitalOwl</xs:documentation>
+					<xs:documentation>An epublication available through DigitalOwl proprietary packaging, distribution and DRM software, delivered in a variety of formats across a range of platforms.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="018">
+				<xs:annotation>
+					<xs:documentation>Handheldmed</xs:documentation>
+					<xs:documentation>An epublication delivered in a proprietary HTML-based format, capable of being read in Handheldmed reader software on Palm OS, Windows, and EPOC/Psion handheld devices, available only through the Handheldmed service.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="019">
+				<xs:annotation>
+					<xs:documentation>WizeUp</xs:documentation>
+					<xs:documentation>An epublication delivered in a proprietary ???-based format and available for download only through the WizeUp service.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="020">
+				<xs:annotation>
+					<xs:documentation>TK3</xs:documentation>
+					<xs:documentation>An epublication delivered in the proprietary TK3 format, capable of being read only in the TK3 reader software supplied by Night Kitchen Inc, on any platform which can support this software.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="021">
+				<xs:annotation>
+					<xs:documentation>Litraweb</xs:documentation>
+					<xs:documentation>An epublication delivered in an encrypted .RTF format, capable of being read only in the Litraweb Visor software, and available only from Litraweb.com.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="022">
+				<xs:annotation>
+					<xs:documentation>MobiPocket</xs:documentation>
+					<xs:documentation>An epublication delivered in a proprietary format, capable of being read in the MobiPocket software on PalmOS, WindowsCE /Pocket PC, Franklin eBookman, and EPOC32 handheld devices, available through the MobiPocket service. Includes Amazon Kindle formats up to and including version 7 - but prefer code 031 for version 7, and always use 031 for KF8.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="023">
+				<xs:annotation>
+					<xs:documentation>Open Ebook</xs:documentation>
+					<xs:documentation>An epublication delivered in the standard distribution format specified in the Open Ebook Publication Structure (OEBPS) format and capable of being read in any OEBPS-compliant reading system. Includes EPUB format up to and including version 2 - but prefer code 029 for EPUB 2, and always use 029 for EPUB 3.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="024">
+				<xs:annotation>
+					<xs:documentation>Town Compass DataViewer</xs:documentation>
+					<xs:documentation>An epublication delivered in a proprietary format, capable of being read in Town Compass DataViewer reader software on a Palm OS handheld device.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="025">
+				<xs:annotation>
+					<xs:documentation>TXT</xs:documentation>
+					<xs:documentation>An epublication delivered in an openly available .TXT format, with ASCII or UTF-8 encoding, as used for example in Project Gutenberg.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="026">
+				<xs:annotation>
+					<xs:documentation>ExeBook</xs:documentation>
+					<xs:documentation>An epublication delivered as a self-executing file including its own reader software, and created with proprietary ExeBook Self-Publisher software.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="027">
+				<xs:annotation>
+					<xs:documentation>Sony BBeB</xs:documentation>
+					<xs:documentation>An epublication in a Sony proprietary format for use with the Sony Reader and LIBRIé reading devices.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="028">
+				<xs:annotation>
+					<xs:documentation>VitalSource Bookshelf</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="029">
+				<xs:annotation>
+					<xs:documentation>EPUB</xs:documentation>
+					<xs:documentation>An epublication delivered using the Open Publication Structure / OPS Container Format standard of the International Digital Publishing Forum (IDPF). [This value was originally defined as &apos;Adobe Digital Editions&apos;, which is not an epublication format but a reader which supports PDF or EPUB (IDPF) formats. Since PDF is already covered by code 002, it was agreed, and announced to the ONIX listserv in September 2009, that code 029 should be refined to represent EPUB format.].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="030">
+				<xs:annotation>
+					<xs:documentation>MyiLibrary</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="031">
+				<xs:annotation>
+					<xs:documentation>Kindle</xs:documentation>
+					<xs:documentation>Amazon proprietary file format derived from Mobipocket format, used for Kindle devices and Kindle reader software.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="032">
+				<xs:annotation>
+					<xs:documentation>Google Edition</xs:documentation>
+					<xs:documentation>An epublication made available by Google in association with a publisher; readable online on a browser-enabled device and offline on designated ebook readers.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="033">
+				<xs:annotation>
+					<xs:documentation>Vook</xs:documentation>
+					<xs:documentation>An epublication in a proprietary format combining text and video content and available to be used online or as a downloadable application for a mobile device - see www.vook.com.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="034">
+				<xs:annotation>
+					<xs:documentation>DXReader</xs:documentation>
+					<xs:documentation>An epublication in a proprietary format for use with DXReader software.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="035">
+				<xs:annotation>
+					<xs:documentation>EBL</xs:documentation>
+					<xs:documentation>An epublication in a format proprietary to the Ebook Library service.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="036">
+				<xs:annotation>
+					<xs:documentation>Ebrary</xs:documentation>
+					<xs:documentation>An epublication in a format proprietary to the Ebrary service.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="037">
+				<xs:annotation>
+					<xs:documentation>iSilo</xs:documentation>
+					<xs:documentation>An epublication in a proprietary format for use with iSilo software on various hardware platforms.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="038">
+				<xs:annotation>
+					<xs:documentation>Plucker</xs:documentation>
+					<xs:documentation>An epublication in a proprietary format for use with Plucker reader software on Palm and other handheld devices.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="039">
+				<xs:annotation>
+					<xs:documentation>VitalBook</xs:documentation>
+					<xs:documentation>A format proprietary to the VitalSource service.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="040">
+				<xs:annotation>
+					<xs:documentation>Book &apos;app&apos; for iOS</xs:documentation>
+					<xs:documentation>Epublication packaged as an application for iOS (eg Apple iPhone, iPad etc) containing both executable code and content. Content can be described with &lt;ProductContentType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="041">
+				<xs:annotation>
+					<xs:documentation>Android &apos;app&apos;</xs:documentation>
+					<xs:documentation>Epublication packaged as an application for Android (eg Android phone or tablet) containing both executable code and content. Content can be described with &lt;ProductContentType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="042">
+				<xs:annotation>
+					<xs:documentation>Other &apos;app&apos;</xs:documentation>
+					<xs:documentation>Epublication packaged as an application. Technical requirements such as target operating system and/or device should be provided in &lt;EpubTypeNote>. Content can be described with &lt;ProductContentType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="043">
+				<xs:annotation>
+					<xs:documentation>XPS</xs:documentation>
+					<xs:documentation>XML Paper Specification format [File extension .xps] for (eg) Blio.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="044">
+				<xs:annotation>
+					<xs:documentation>iBook</xs:documentation>
+					<xs:documentation>Apple&apos;s iBook format (a proprietary extension of EPUB), can only be read on Apple iOS devices.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="045">
+				<xs:annotation>
+					<xs:documentation>ePIB</xs:documentation>
+					<xs:documentation>Proprietary format used by Barnes and Noble, readable on NOOK devices and Nook reader software.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="098">
+				<xs:annotation>
+					<xs:documentation>Multiple formats</xs:documentation>
+					<xs:documentation>Product consists of parts in different formats.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="099">
+				<xs:annotation>
+					<xs:documentation>No especificat</xs:documentation>
+					<xs:documentation>Unknown, or no code yet assigned for this format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List11">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 11">Epublication format code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>HTML</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>PDF</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Microsoft Reader</xs:documentation>
+					<xs:documentation>&apos;.LIT&apos; file format used by Microsoft Reader software.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>RocketBook</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Rich text format (RTF)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Open Ebook Publication Structure (OEBPS) format standard</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>XML</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>SGML</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>EXE</xs:documentation>
+					<xs:documentation>&apos;.EXE&apos; file format used when an epublication is delivered as a self-executing package of software and content.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>ASCII</xs:documentation>
+					<xs:documentation>&apos;.TXT&apos; file format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>MobiPocket format</xs:documentation>
+					<xs:documentation>Proprietary file format used for the MobiPocket reader software.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List12">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 12">Trade category code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>UK open market edition</xs:documentation>
+					<xs:documentation>An edition from a UK publisher sold only in territories where exclusive rights are not held. Els detalls sobre els drets figuren a PR.21 (ONIX 2.1) o a P.21 (ONIX 3.0) com és habitual.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Airport edition</xs:documentation>
+					<xs:documentation>In UK, an edition intended primarily for airside sales in UK airports, though it may be available for sale in other territories where exclusive rights are not held. Els detalls sobre els drets figuren a PR.21 (ONIX 2.1) o a P.21 (ONIX 3.0) com és habitual.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Sonderausgabe</xs:documentation>
+					<xs:documentation>In Germany, a special printing sold at a lower price than the regular hardback.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Pocket paperback</xs:documentation>
+					<xs:documentation>En alguns països on s&apos;identifiquen com una categoria comercial específica, p. ex. França, «livre de poche», Alemanya «Taschendbuch», Itàlia «tascabile», Espanya «libro de bolsillo».</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Edició internacional (EUA)</xs:documentation>
+					<xs:documentation>Edició produïda només per vendre-la en determinats mercats d&apos;exportació.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Edició d&apos;audiollibre</xs:documentation>
+					<xs:documentation>Producte d&apos;àudio que es ven en un embalatge resistent i amb garantia de substitució pels cassets o discs per un determinat període de temps.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Edició de mercat obert als USA</xs:documentation>
+					<xs:documentation>Una edició d&apos;una institució publicadora dels EUA sense drets exclusius. Els detalls sobre els drets figuren a PR.21 (ONIX 2.1) o a P.21 (ONIX 3.0) com és habitual.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Livre scolaire, déclaré par l&apos;éditeur</xs:documentation>
+					<xs:documentation>A França, una categoria de llibre que té un estat legal determinat, reclamat per la institució publicadora.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Livre scolaire (non spécifié)</xs:documentation>
+					<xs:documentation>A França, una categoria de llibre que té un estat legal determinat, designat independentment de la institució publicadora.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Suplement de diari</xs:documentation>
+					<xs:documentation>Edició publicada per vendre-la només amb un diari o un periòdic.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Llibres de text de preu lliure</xs:documentation>
+					<xs:documentation>A Espanya, un llibre de text escolar sense preu de venda al detall fixat o recomanat i que la institució publicadora subministra amb condicions acordades de forma individual amb cada llibreter.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Edició per a mitjans de notícies</xs:documentation>
+					<xs:documentation>Per a edicions que es venen només en quioscs.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Llibre de text dels EUA</xs:documentation>
+					<xs:documentation>Als EUA i al Canadà, un llibre que es publica principalment per a estudiants de primària, secundària o college com a base per a l&apos;estudi. Els llibres de text publicats per als mercats d&apos;educació primària i secundària normalment els adquireixen els districtes escolars per a l&apos;ús dels estudiants. Els llibres de text publicats per al mercat d&apos;educació superior normalment els fan servir els professors d&apos;aquestes etapes com a llibres de text per a determinades classes. Els llibres de text normalment no es promocionen al públic general, i això els distingeix dels llibres comercials. Tingueu en compte que els llibres comercials que s&apos;utilitzen com a llibres per a cursos no es consideren llibres de text (encara que una edició especial educativa d&apos;un títol comercial podria ser considerada com a tal).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List13">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 13">Codi identificador de tipus de sèries</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Propietari</xs:documentation>
+					<xs:documentation>Per exemple, l&apos;identificador de la sèrie propi d&apos;una institució publicadora.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>ISSN</xs:documentation>
+					<xs:documentation>International Standard Serial Number, sense guions, 8 dígits.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Identificador de les col·leccions de la Bibliografia Nacional d&apos;Alemanya</xs:documentation>
+					<xs:documentation>Administrat per la Biblioteca Nacional d&apos;Alemanya</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Identificador de col·leccions impreses de llibres alemanys</xs:documentation>
+					<xs:documentation>Mantingut pel VLB</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Id. de col·leccions Electre</xs:documentation>
+					<xs:documentation>Administrat per Electre Information, França.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Mòdul DOI</xs:documentation>
+					<xs:documentation>Digital Object Identifier (Identificador d&apos;objectes digitals, llargària i joc de caràcters variables).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>ISBN-13</xs:documentation>
+					<xs:documentation>Utilitzeu-lo només quan la sèrie o col·lecció està disponible com a un únic producte.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Mòdul URN</xs:documentation>
+					<xs:documentation>Nom universal de recursos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List14">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 14">Marca de format de text</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>No definit</xs:documentation>
+					<xs:documentation>Per defecte.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Majúscules i minúscules dins la frase</xs:documentation>
+					<xs:documentation>Majúscules inicials només en la primera paraula i en els noms propis, p. ex. «La conquesta de Mèxic».</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Majúscules i minúscules en el títol</xs:documentation>
+					<xs:documentation>Majúscules inicials només en la primera paraula i en totes les paraules rellevants, p. ex.«La Conquesta de Mèxic».</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Tot en majúscules</xs:documentation>
+					<xs:documentation>Per exemple, «LA CONQUESTA DE MÈXIC».</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List15">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 15">Codi de tipus del títol</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>No definit</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Títol distintiu (llibre); títol de portada (fascicles); títol en un element (element de contingut de sèrie o recurs revisat)</xs:documentation>
+					<xs:documentation>El text sencer del títol distintiu de l&apos;element, sense abreviar-lo. Per a llibres on el títol en si no és distintiu es poden utilitzar elements del títol de la col·lecció o sèrie i part de numeració per a crear un títol distintiu. Quan l&apos;element és una edició antològica que conté dos o més treballs del mateix autor/a i no hi ha cap títol combinat a part, es pot crear un títol distintiu unint els dos títols individuals, amb la puntuació adequada com a: «Orgull i prejudici» / «Sentit i sensibilitat» / «Northanger Abbey».</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>ISSN títol clau de publicacions periòdiques</xs:documentation>
+					<xs:documentation>Només publicacions periòdiques.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Títol en la llengua original</xs:documentation>
+					<xs:documentation>On el subjecte del registre d&apos;ONIX és un element traduït.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Títol acrònim o sigles</xs:documentation>
+					<xs:documentation>Per a publicacions periòdiques: un acrònim o sigles del títol tipus 01, p.ex. «JAMA», «JACM».</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Títol abreujat</xs:documentation>
+					<xs:documentation>Una forma abreujada del títol tipus 01.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Títol en una altra llengua</xs:documentation>
+					<xs:documentation>Una traducció del títol tipus 01 a una altra llengua.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Títol temàtic d&apos;edició d&apos;una revista</xs:documentation>
+					<xs:documentation>Només publicacions periòdiques: quan un número de revista és explícitament devota a un tema en concret.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Títol antic</xs:documentation>
+					<xs:documentation>Llibres o publicacions periòdiques: quan un element ja s&apos;ha publicat anteriorment amb un altre títol.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Títol del distribuïdor</xs:documentation>
+					<xs:documentation>Per a llibres: el títol que consta en el fitxer de títols del distribuïdor dels llibres: amb freqüència és incomplet i pot incloure elements que no són part del títol pròpiament.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Títol alternatiu a la coberta</xs:documentation>
+					<xs:documentation>Un títol alternatiu que apareix a la coberta d&apos;un llibre.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Títol alternatiu a la coberta posterior</xs:documentation>
+					<xs:documentation>Un títol alternatiu que apareix a la coberta posterior del llibre.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Títol extens</xs:documentation>
+					<xs:documentation>Una forma extensa del títol, p. ex. el títol d&apos;un llibre de text escolar amb el curs i el tipus i altres detalls afegits per donar-li significat al títol perquè sinó només seria el nom de l&apos;assignatura. Aquest tipus de títol és necessari per a trameses a l&apos;Agència Espanyola d&apos;ISBN.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List16">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 16">Codi identificador de tipus d&apos;obra</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Propietari</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>ISBN-10</xs:documentation>
+					<xs:documentation>ISBN de 10 caràcters indicador d&apos;obra, quan és l&apos;únic identificador d&apos;obra disponible —en DESÚS a ONIX per a llibres, excepte quan proporciona informació històrica sobre compatibilitat amb sistemes legals. Només s&apos;hauria d&apos;utilitzar en productes anteriors al 2007 — quan va ser substituït per l&apos;ISBN-13—i mai no s&apos;ha d&apos;utilitzar com a ÚNIC identificador (sempre ha d&apos;anar acompanyat pel corresponent GTIN-13 / ISBN-13 de l&apos;indicador d&apos;obra).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Mòdul DOI</xs:documentation>
+					<xs:documentation>Digital Object Identifier (Identificador d&apos;objectes digitals, llargària i joc de caràcters variables).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>ISTC</xs:documentation>
+					<xs:documentation>International Standard Text Code (16 caràcters: nombres i lletres A-F, sense guions).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>ISBN-13</xs:documentation>
+					<xs:documentation>ISBN de 13 caràcters identificador d&apos;obra, quan és l&apos;únic identificador disponible.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>ISRC</xs:documentation>
+					<xs:documentation>International Standard Recording Code.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List17">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 17">Codi de rol de contribuïdor</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="A01">
+				<xs:annotation>
+					<xs:documentation>De (autor/a)</xs:documentation>
+					<xs:documentation>Autor/a d&apos;una obra textual.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A02">
+				<xs:annotation>
+					<xs:documentation>Amb</xs:documentation>
+					<xs:documentation>Amb o explicat per: autor/a «fantasma» d&apos;una obra treball literària.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A03">
+				<xs:annotation>
+					<xs:documentation>Guió de</xs:documentation>
+					<xs:documentation>Escriptor/a del guió (pel·lícula o vídeo).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A04">
+				<xs:annotation>
+					<xs:documentation>Llibret de</xs:documentation>
+					<xs:documentation>Escriptor/a del llibret (òpera): vegeu també A31.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A05">
+				<xs:annotation>
+					<xs:documentation>Lletra de</xs:documentation>
+					<xs:documentation>Autor/a de la lletra (cançó): vegeu també A31.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A06">
+				<xs:annotation>
+					<xs:documentation>De (compositor)</xs:documentation>
+					<xs:documentation>Compositor/a de la música.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A07">
+				<xs:annotation>
+					<xs:documentation>De (artista)</xs:documentation>
+					<xs:documentation>Artistes visuals quan se&apos;n fa referència com a primer creador de, p. ex. un llibre de reproduccions d&apos;obres d&apos;art.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A08">
+				<xs:annotation>
+					<xs:documentation>De (fotògraf/a)</xs:documentation>
+					<xs:documentation>Fotògraf/a quan se&apos;n fa referència com a primer creador de, p.ex., un llibre de fotografies.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A09">
+				<xs:annotation>
+					<xs:documentation>Creat per</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A10">
+				<xs:annotation>
+					<xs:documentation>D&apos;una idea de</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A11">
+				<xs:annotation>
+					<xs:documentation>Dissenyat per</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A12">
+				<xs:annotation>
+					<xs:documentation>Il·lustrat per</xs:documentation>
+					<xs:documentation>Artista quan se&apos;n fa referència com a creador d&apos;una obra d&apos;art que il·lustra un text o d&apos;una obra d&apos;art d&apos;una novel·la gràfica o còmic.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A13">
+				<xs:annotation>
+					<xs:documentation>Fotografies de</xs:documentation>
+					<xs:documentation>Fotògraf/a quan se&apos;n fa referència com a creador de les fotografies que il·lustren un text.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A14">
+				<xs:annotation>
+					<xs:documentation>Text de</xs:documentation>
+					<xs:documentation>Autor/a de text que acompanya reproduccions d&apos;art o fotografies, o que és part d&apos;una novel·la gràfica o còmic.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A15">
+				<xs:annotation>
+					<xs:documentation>Pròleg de</xs:documentation>
+					<xs:documentation>Autor/a del pròleg.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A16">
+				<xs:annotation>
+					<xs:documentation>Pròleg de</xs:documentation>
+					<xs:documentation>Autor/a del pròleg.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A17">
+				<xs:annotation>
+					<xs:documentation>Resum de</xs:documentation>
+					<xs:documentation>Autor/a del resum.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A18">
+				<xs:annotation>
+					<xs:documentation>Suplement de</xs:documentation>
+					<xs:documentation>Autor/a del suplement.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A19">
+				<xs:annotation>
+					<xs:documentation>Epíleg de</xs:documentation>
+					<xs:documentation>Autor/a de l&apos;epíleg.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A20">
+				<xs:annotation>
+					<xs:documentation>Notes de</xs:documentation>
+					<xs:documentation>Autor/a de les notes o anotacions: vegeu també A29.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A21">
+				<xs:annotation>
+					<xs:documentation>Comentaris de</xs:documentation>
+					<xs:documentation>Autor/a dels comentaris del text principal.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A22">
+				<xs:annotation>
+					<xs:documentation>Epíleg de</xs:documentation>
+					<xs:documentation>Autor/a de l&apos;epíleg.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A23">
+				<xs:annotation>
+					<xs:documentation>Preàmbul de</xs:documentation>
+					<xs:documentation>Autor/a del preàmbul.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A24">
+				<xs:annotation>
+					<xs:documentation>Introducció de</xs:documentation>
+					<xs:documentation>Autor/a de la introducció: vegeu també A29.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A25">
+				<xs:annotation>
+					<xs:documentation>Notes a peu de pàgina de</xs:documentation>
+					<xs:documentation>Autor/a o compilador/a de les notes a peu de pàgina.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A26">
+				<xs:annotation>
+					<xs:documentation>Memòria de</xs:documentation>
+					<xs:documentation>Autor/a de la memòria que acompanya el text principal.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A27">
+				<xs:annotation>
+					<xs:documentation>Experiments de</xs:documentation>
+					<xs:documentation>Persona que realitza els experiments descrits en el text.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A29">
+				<xs:annotation>
+					<xs:documentation>Introducció i notes de</xs:documentation>
+					<xs:documentation>Autor/a de la introducció i les notes: vegeu també A20 i A24.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A30">
+				<xs:annotation>
+					<xs:documentation>Programari creat per</xs:documentation>
+					<xs:documentation>Autor/a de programes informàtics auxiliars al text.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A31">
+				<xs:annotation>
+					<xs:documentation>Llibre i lletra de</xs:documentation>
+					<xs:documentation>Autor/a del contingut textual d&apos;una obra musical: vegeu també A04 i A05.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A32">
+				<xs:annotation>
+					<xs:documentation>Contribucions de</xs:documentation>
+					<xs:documentation>Autor/a de contribucions addicionals al text.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A33">
+				<xs:annotation>
+					<xs:documentation>Apèndix de</xs:documentation>
+					<xs:documentation>Autor/a de l&apos;apèndix.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A34">
+				<xs:annotation>
+					<xs:documentation>Índex de</xs:documentation>
+					<xs:documentation>Compilador/a de l&apos;índex</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A35">
+				<xs:annotation>
+					<xs:documentation>Il·lustracions de</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A36">
+				<xs:annotation>
+					<xs:documentation>Disseny de la coberta o il·lustracions de</xs:documentation>
+					<xs:documentation>També s&apos;usa per l&apos;artista de coberta d&apos;una novel·la gràfica o còmic si s&apos;esmenten per separat.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A37">
+				<xs:annotation>
+					<xs:documentation>Obra preliminar de</xs:documentation>
+					<xs:documentation>Responsable de l&apos;obra preliminar en la qual es basa l&apos;obra.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A38">
+				<xs:annotation>
+					<xs:documentation>Autor/a original</xs:documentation>
+					<xs:documentation>Autor/a de la primera edició (normalment d&apos;un treball estàndard) que no és autor/a d&apos;aquesta edició.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A39">
+				<xs:annotation>
+					<xs:documentation>Mapes de</xs:documentation>
+					<xs:documentation>Mapes il·lustrats o aportats per.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A40">
+				<xs:annotation>
+					<xs:documentation>Entintat o pintat per</xs:documentation>
+					<xs:documentation>Quan s&apos;indica que persones diferents han dibuixat i pintat les il·lustracions d&apos;una obra per separat, p, ex, per a una novel·la gràfica o còmic, utilitzeu A12 per a «dibuixat per» i A40 per a «pintat per».</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A41">
+				<xs:annotation>
+					<xs:documentation>Desplegables de</xs:documentation>
+					<xs:documentation>Dissenyador/a dels elements desplegables en un llibre de desplegables, que pot ser una altra persona i no l&apos;autor/a.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A42">
+				<xs:annotation>
+					<xs:documentation>Continuat per</xs:documentation>
+					<xs:documentation>Utilitzeu-ho quan una obra estàndard la continua una altra persona que no és l&apos;autor/a original.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A43">
+				<xs:annotation>
+					<xs:documentation>Entrevistador/a</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A44">
+				<xs:annotation>
+					<xs:documentation>Entrevistat/ada</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A99">
+				<xs:annotation>
+					<xs:documentation>Altre creador/a primari</xs:documentation>
+					<xs:documentation>Un altre tipus de creador/a primari no especificat anteriorment.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B01">
+				<xs:annotation>
+					<xs:documentation>Editat per</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B02">
+				<xs:annotation>
+					<xs:documentation>Revisat per</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B03">
+				<xs:annotation>
+					<xs:documentation>Recollit per</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B04">
+				<xs:annotation>
+					<xs:documentation>Reduït per</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B05">
+				<xs:annotation>
+					<xs:documentation>Adaptat per</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B06">
+				<xs:annotation>
+					<xs:documentation>Traduït per</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B07">
+				<xs:annotation>
+					<xs:documentation>Explicat per</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B08">
+				<xs:annotation>
+					<xs:documentation>Traduït amb comentaris per</xs:documentation>
+					<xs:documentation>Aquest codi s&apos;aplica quan el traductor/a proporciona comentaris sobre temes relacionats amb la traducció. Si el traductor/a també proporciona comentaris en el treball en si, s&apos;han d&apos;utilitzar els codis B06 i A21.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B09">
+				<xs:annotation>
+					<xs:documentation>Col·lecció editada per</xs:documentation>
+					<xs:documentation>Nom d&apos;un editor/a de sèrie quan el producte pertany a una col·lecció.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B10">
+				<xs:annotation>
+					<xs:documentation>Editat i traduït per</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B11">
+				<xs:annotation>
+					<xs:documentation>Cap editorial</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B12">
+				<xs:annotation>
+					<xs:documentation>Editor/a convidat/ada</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B13">
+				<xs:annotation>
+					<xs:documentation>Editor/a de volum (EV)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B14">
+				<xs:annotation>
+					<xs:documentation>Membre del consell editorial</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B15">
+				<xs:annotation>
+					<xs:documentation>Coordinació editorial de</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B16">
+				<xs:annotation>
+					<xs:documentation>Secretari/ària de redacció</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B17">
+				<xs:annotation>
+					<xs:documentation>Fundat per</xs:documentation>
+					<xs:documentation>Normalment l&apos;editor/a fundador/a d&apos;una publicació periòdica: Begruendet von.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B18">
+				<xs:annotation>
+					<xs:documentation>Preparat per publicar el</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B19">
+				<xs:annotation>
+					<xs:documentation>Editor/a associat/ada</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B20">
+				<xs:annotation>
+					<xs:documentation>Editor/a consultor/a</xs:documentation>
+					<xs:documentation>Utilitzeu-lo també per a «editor/a conseller».</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B21">
+				<xs:annotation>
+					<xs:documentation>Editor/a general</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B22">
+				<xs:annotation>
+					<xs:documentation>Escenificat per</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B23">
+				<xs:annotation>
+					<xs:documentation>Relator general</xs:documentation>
+					<xs:documentation>A Europa, un editor/a que es responsabilitza del contingut legal d&apos;un volum jurídic col·laboratiu.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B24">
+				<xs:annotation>
+					<xs:documentation>Editor/a literari/ària</xs:documentation>
+					<xs:documentation>Un editor/a que es responsabilitza d&apos;establir el text usat en l&apos;edició d&apos;una obra literària, on això es distingeix com a rol diferent (a Espanya, «editor/a literari»).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B25">
+				<xs:annotation>
+					<xs:documentation>Arranjat per (música)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B26">
+				<xs:annotation>
+					<xs:documentation>Editor/a tècnic/a</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B99">
+				<xs:annotation>
+					<xs:documentation>Altres adaptacions de</xs:documentation>
+					<xs:documentation>Altres tipus d&apos;adaptacions o edicions no especificades anteriorment.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="C01">
+				<xs:annotation>
+					<xs:documentation>Compilat per</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="C02">
+				<xs:annotation>
+					<xs:documentation>Seleccionat per</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="C99">
+				<xs:annotation>
+					<xs:documentation>Altres compilacions per</xs:documentation>
+					<xs:documentation>Altres tipus de compilacions no especificades anteriorment.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D01">
+				<xs:annotation>
+					<xs:documentation>Productor</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D02">
+				<xs:annotation>
+					<xs:documentation>Director</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D03">
+				<xs:annotation>
+					<xs:documentation>Director</xs:documentation>
+					<xs:documentation>Director d&apos;una actuació musical</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D99">
+				<xs:annotation>
+					<xs:documentation>Altra direcció per</xs:documentation>
+					<xs:documentation>Altres tipus de direcció no especificats anteriorment.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E01">
+				<xs:annotation>
+					<xs:documentation>Actor/actriu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E02">
+				<xs:annotation>
+					<xs:documentation>Ballarí/ina</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E03">
+				<xs:annotation>
+					<xs:documentation>Narrador/a</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E04">
+				<xs:annotation>
+					<xs:documentation>Comentarista</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E05">
+				<xs:annotation>
+					<xs:documentation>Solista vocal</xs:documentation>
+					<xs:documentation>Cantant etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E06">
+				<xs:annotation>
+					<xs:documentation>Solista instrumental</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E07">
+				<xs:annotation>
+					<xs:documentation>Llegit per</xs:documentation>
+					<xs:documentation>Lector d&apos;un llibre enregistrat, com un audiollibre.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E08">
+				<xs:annotation>
+					<xs:documentation>Representat per (orquestra, banda, grup)</xs:documentation>
+					<xs:documentation>Nom d&apos;un grup musical en rol d&apos;intèrpret.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E09">
+				<xs:annotation>
+					<xs:documentation>Orador/a</xs:documentation>
+					<xs:documentation>D&apos;un discurs, d&apos;una classe, etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E99">
+				<xs:annotation>
+					<xs:documentation>Representat per</xs:documentation>
+					<xs:documentation>Altres tipus de representacions no especificades anteriorment: utilitzeu-ho per una actuació enregistrada que no pertany a cap de les categories anteriors, p. ex. una actuació per un humorista.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="F01">
+				<xs:annotation>
+					<xs:documentation>Enregistrat / fotografiat per</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="F99">
+				<xs:annotation>
+					<xs:documentation>Altres enregistraments de</xs:documentation>
+					<xs:documentation>Altres tipus d&apos;enregistraments no especificats anteriorment.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Z01">
+				<xs:annotation>
+					<xs:documentation>Ajudat per</xs:documentation>
+					<xs:documentation>Es pot associar amb qualsevol rol de contribuïdor/a i en conseqüència la col·locació ha d&apos;anar segons la numeració de la seqüència del contribuïdor.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Z99">
+				<xs:annotation>
+					<xs:documentation>Altres</xs:documentation>
+					<xs:documentation>Altres responsabilitats creatives que no entren dins dels codis de la A a la F anteriors.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List18">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 18">Tipus de nom de persona / d&apos;organització</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>No especificat</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Pseudònim</xs:documentation>
+					<xs:documentation>Es pot utilitzar assignar un pseudònim conegut, quan el nom principal és un nom «real».</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Nom en control d&apos;autoritats</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Nom anterior</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Nom «real»</xs:documentation>
+					<xs:documentation>Pot ser utilitzat per assignar un nom real conegut, quan el nom principal és un pseudònim.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Transliteració d&apos;un nom</xs:documentation>
+					<xs:documentation>Només utilitzeu-lo en &lt;AlternativeName>, quan el nom i cognoms no estan especificats.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List19">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 19">Persona/es no identificada</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Desconegut/da</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Anònim</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>et al.</xs:documentation>
+					<xs:documentation>I d&apos;altres: altres contribuïdors no llistats.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Diversos autors/ores</xs:documentation>
+					<xs:documentation>Quan el producte és un conjunt de llibres de diversos autors/ores.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Veu sintetitzada - home</xs:documentation>
+					<xs:documentation>Utilitzeu-lo amb el codi de rol de contribuïdor E07 «llegit per», en audiollibres per a persones cegues.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Veu sintetitzada - dona</xs:documentation>
+					<xs:documentation>Utilitzeu-lo amb el codi de rol de contribuïdor E07 «llegit per», en audiollibres per a persones cegues.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Veu sintetitzada - no especificat</xs:documentation>
+					<xs:documentation>Utilitzeu-lo amb el codi de rol de contribuïdor E07 «llegit per», en audiollibres per a persones cegues.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List20">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 20">Rol de congrés</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="List21">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 21">Codi de tipus d&apos;edició</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ABR">
+				<xs:annotation>
+					<xs:documentation>Reduït</xs:documentation>
+					<xs:documentation>El contingut s&apos;ha escurçat: utilitzeu-lo per a obres reduïdes, escurçades, concises, condensades.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ACT">
+				<xs:annotation>
+					<xs:documentation>Edició per a actuació</xs:documentation>
+					<xs:documentation>Versió d&apos;una obra o d&apos;un guió per utilitzar-lo com a tal en una producció, normalment inclou directrius d&apos;escenificació juntament amb el text o el guió.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ADP">
+				<xs:annotation>
+					<xs:documentation>Adaptat</xs:documentation>
+					<xs:documentation>El contingut s&apos;adapta per a un altre propòsit o una altra audiència, o d&apos;un mitjà a un altre: utilitzat en adaptacions teatrals o novel·lístiques. Utilitzeu&lt;EditionStatement> per descriure la naturalesa exacta de l&apos;adaptació.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ALT">
+				<xs:annotation>
+					<xs:documentation>Alternatiu</xs:documentation>
+					<xs:documentation>No l&apos;utilitzeu. Aquest codi està en DESÚS, però es manté a la llista per qüestions de compatibilitat amb versions anteriors.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ANN">
+				<xs:annotation>
+					<xs:documentation>Amb anotacions</xs:documentation>
+					<xs:documentation>El contingut augmenta amb l&apos;addició de notes.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BLL">
+				<xs:annotation>
+					<xs:documentation>Edició bilingüe</xs:documentation>
+					<xs:documentation>Ambdues llengües s&apos;haurien d&apos;especificar en el grup «Llengües». Utilitzeu MLL per a edicions en més d&apos;una llengua.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BRL">
+				<xs:annotation>
+					<xs:documentation>Braille</xs:documentation>
+					<xs:documentation>Edició en braille.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CMB">
+				<xs:annotation>
+					<xs:documentation>Volum combinat</xs:documentation>
+					<xs:documentation>Una edició on dos o més llibres també publicats per separat es combinen en un únic volum; també conegut com a edició antològica.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CRI">
+				<xs:annotation>
+					<xs:documentation>Crítica</xs:documentation>
+					<xs:documentation>El contingut conté comentaris crítics sobre el text.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CSP">
+				<xs:annotation>
+					<xs:documentation>Col·lecció per a un curs</xs:documentation>
+					<xs:documentation>Contingut compilat per a un curs educatiu específic.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DGO">
+				<xs:annotation>
+					<xs:documentation>Original digital</xs:documentation>
+					<xs:documentation>Un producte digital que no té un equivalent imprès i que no s&apos;espera que en tingui un.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ENH">
+				<xs:annotation>
+					<xs:documentation>Millorat</xs:documentation>
+					<xs:documentation>Utilitzeu-ho per a publicacions que s&apos;han millorat amb text addicional, discurs, altres àudios, vídeos, contingut interactiu o un altre contingut.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ENL">
+				<xs:annotation>
+					<xs:documentation>Ampliat</xs:documentation>
+					<xs:documentation>Ja s&apos;ha ampliat o estès el contingut a partir d&apos;una edició anterior.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EXP">
+				<xs:annotation>
+					<xs:documentation>Censurat</xs:documentation>
+					<xs:documentation>El contingut «ofensiu» s&apos;elimina.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FAC">
+				<xs:annotation>
+					<xs:documentation>Facsímil</xs:documentation>
+					<xs:documentation>Reproducció exacta del contingut i la forma d&apos;una edició anterior.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FST">
+				<xs:annotation>
+					<xs:documentation>Liber Amicorum</xs:documentation>
+					<xs:documentation>Una col·lecció d&apos;escrits publicats en memòria d&apos;una persona, institució o societat.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ILL">
+				<xs:annotation>
+					<xs:documentation>Il·lustrat</xs:documentation>
+					<xs:documentation>El contingut conté un extens nombre d&apos;il·lustracions que no eren part d&apos;altres edicions.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LTE">
+				<xs:annotation>
+					<xs:documentation>Lletra gran / impressió gran</xs:documentation>
+					<xs:documentation>Edició impresa gran, font impresa entre 14 i 19 punts - vegeu també ULP.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MCP">
+				<xs:annotation>
+					<xs:documentation>Microimpressió</xs:documentation>
+					<xs:documentation>Una edició impresa en una font massa petita per ser llegida sense una lupa.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MDT">
+				<xs:annotation>
+					<xs:documentation>Producte amb llicència</xs:documentation>
+					<xs:documentation>Una edició publicada per coincidir amb l&apos;estrena d&apos;una pel·lícula, un programa de TV o un joc electrònic basat en la mateixa obra. Utilitzeu &lt;EditionStatement>per descriure la naturalesa exacta de la relació de llicència.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MLL">
+				<xs:annotation>
+					<xs:documentation>Edició multilingüe</xs:documentation>
+					<xs:documentation>Totes les llengües han d&apos;especificar-se en el grup «Llengües». Utilitzeu BLL per a edicions bilingües.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NED">
+				<xs:annotation>
+					<xs:documentation>Nova edició</xs:documentation>
+					<xs:documentation>Quan no es dóna una altra informació, o no hi ha disponible cap altre tipus de codificació.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NUM">
+				<xs:annotation>
+					<xs:documentation>Edició amb còpies numerades</xs:documentation>
+					<xs:documentation>Una edició limitada en la qual cada còpia és numerada individualment.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PRB">
+				<xs:annotation>
+					<xs:documentation>Edició anterior a l&apos;enquadernació</xs:documentation>
+					<xs:documentation>Als EUA, un llibre que anteriorment s&apos;ha enquadernat, normalment com a llibre de butxaca, i que es torna a enquadernar amb tapa dura per un altre proveïdor diferent de la institució publicadora. Vegeu també &lt;Publisher> i &lt;RelatedProduct> creats per a altres aspectes del tractament d&apos;edicions prèviament enquadernades a ONIX.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="REV">
+				<xs:annotation>
+					<xs:documentation>Revisat</xs:documentation>
+					<xs:documentation>Ja s&apos;ha revista el contingut a partir d&apos;una edició prèvia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SCH">
+				<xs:annotation>
+					<xs:documentation>Edició escolar</xs:documentation>
+					<xs:documentation>Una edició amb el propòsit concret de l&apos;ús escolar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SMP">
+				<xs:annotation>
+					<xs:documentation>Edició amb llenguatge simplificat</xs:documentation>
+					<xs:documentation>Una edició que utilitza llenguatge simplificat (Finès «Selkokirja»).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SPE">
+				<xs:annotation>
+					<xs:documentation>Edició especial</xs:documentation>
+					<xs:documentation>Utilitzeu-ho per a edicions d&apos;aniversari, de col·leccionista, de luxe, de regal, limitades, numerades autografiades. Utilitzeu &lt;EditionStatement> per descriure la naturalesa exacta de l&apos;edició especial.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="STU">
+				<xs:annotation>
+					<xs:documentation>Edició d&apos;estudiant</xs:documentation>
+					<xs:documentation>En la qual el text està disponible tant per a edicions per a estudiants com per a professors/ores.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TCH">
+				<xs:annotation>
+					<xs:documentation>Edició de professor/a</xs:documentation>
+					<xs:documentation>En la qual el text està disponible tant en l&apos;edició d&apos;estudiant com en la de professor/a; també utilitzeu-lo per a edicions d&apos;instructor o de director.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="UBR">
+				<xs:annotation>
+					<xs:documentation>Íntegra</xs:documentation>
+					<xs:documentation>El títol s&apos;ha publicat en una edició abreujada; també per a audiollibres, encara que ja existeixi una edició abreujada d&apos;audiollibre.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ULP">
+				<xs:annotation>
+					<xs:documentation>Tipografia extra gran</xs:documentation>
+					<xs:documentation>Per a versions impreses amb fonts de 20 punts o superiors, i amb fonts dissenyades per als disminuïts visuals - vegeu també LTE.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="UXP">
+				<xs:annotation>
+					<xs:documentation>Sense censura</xs:documentation>
+					<xs:documentation>Es torna a restaurar el contingut anteriorment considerat «ofensiu».</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VAR">
+				<xs:annotation>
+					<xs:documentation>Variorum</xs:documentation>
+					<xs:documentation>El contingut inclou notes de diverses persones, i/o inclou i compara diferents variants de textos de la mateixa obra.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List22">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 22">Codi de rol de llengua</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Llengua del text</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Llengua original d&apos;un text traduït</xs:documentation>
+					<xs:documentation>On el text en la llengua original NO forma part del producte actual.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Llengua dels resums</xs:documentation>
+					<xs:documentation>On la llengua és diferent de la del text: s&apos;usa principalment per a publicacions periòdiques.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Llengua dels drets</xs:documentation>
+					<xs:documentation>Llengua a la qual s&apos;apliquen els drets especificats.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Llengua exclosa dels drets</xs:documentation>
+					<xs:documentation>Llengua a la qual no se li apliquen els drets especificats.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Llengua original en una edició multilingüe</xs:documentation>
+					<xs:documentation>On el text de la llengua original és part d&apos;una edició bilingüe o multilingüe.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Llengua traduïda en una edició multilingüe</xs:documentation>
+					<xs:documentation>On el text en una llengua traduïda és part d&apos;una edició bilingüe o multilingüe.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Llengua de la pista d&apos;àudio</xs:documentation>
+					<xs:documentation>Per exemple, en un DVD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Llengua dels subtítols</xs:documentation>
+					<xs:documentation>Per exemple, en un DVD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List23">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 23">Codi de tipus d&apos;extensió</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Recompte de pàgines de contingut principal</xs:documentation>
+					<xs:documentation>La pàgina amb la numeració més alta en una única seqüència numerada de contingut principal, normalment la pàgina amb la numeració aràbiga més alta en un llibre. En llibres sense numeració a les pàgines o (encara que sigui poc freqüent) amb múltiples seqüències de numeració de contingut principal, és el nombre total de pàgines amb el contingut principal del llibre. Tingueu en compte que pot incloure pàgines numerades però en blanc (p. ex. pàgines inserides per assegurar que el capítol comença a la cara de davant d&apos;una pàgina) i pot excloure pàgines no numerades però amb contingut (per exemple, làmines o il·lustracions). Aquest codi o el de &quot;recompte de pàgines de contingut&quot; són els recomanats a l&apos;hora d&apos;indicar el nombre de pàgines en la majoria de llibres per al lector/a general. En el cas que el llibre inclogui una part substancial de contingut en els preliminars o en les seccions posteriors, es recomana incloure-hi, també, el recompte de pàgines preliminars i el recompte de pàgines de les seccions posteriors, o el total de pàgines numerades. Per a llibres amb un nombre substancial de làmines o d&apos;il·lustracions no numerades, es recomana incloure-hi el recompte del total de pàgines inserides no numerades quan sigui possible.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Nombre de paraules</xs:documentation>
+					<xs:documentation>Nombre de paraules d&apos;un text en llenguatge natural.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Recompte de pàgines preliminars</xs:documentation>
+					<xs:documentation>El nombre total de pàgines numerades (normalment amb números romans) que precedeixen el contingut principal d&apos;un llibre. Això normalment consisteix en diversos títols i pàgines impreses, taula de continguts, una introducció, pròleg, preàmbul, etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Recompte de pàgines en les seccions posteriors</xs:documentation>
+					<xs:documentation>El nombre total de pàgines numerades (normalment amb números romans) que van després del contingut principal d&apos;un llibre. Això normalment consisteix en un epíleg, apèndixs, notes finals, etc. S&apos;hi exclouen les pàgines en blanc (o de publicitat) que hi són només per qüestions d&apos;impressió i d&apos;enquadernació.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Total de pàgines numerades</xs:documentation>
+					<xs:documentation>La suma de totes les pàgines numerades amb números romans (i aràbics). Tingueu en compte que pot incloure pàgines numerades però en blanc (p. ex. pàgines inserides per assegurar que el capítol comença a la cara de davant d&apos;una pàgina) i pot excloure pàgines no numerades però amb contingut (per exemple, làmines o il·lustracions).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Recompte de pàgines de producció</xs:documentation>
+					<xs:documentation>El nombre total de pàgines en un llibre, incloent-hi les pàgines no numerades, el material de l&apos;inici i el final, etc. Inclou totes les pàgines en blanc del final que no tenen cap contingut i que hi són només per qüestions d&apos;impressió i d&apos;enquadernació.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Recompte absolut de pàgines</xs:documentation>
+					<xs:documentation>El nombre total de pàgines d&apos;un llibre comptant la portada com la pàgina 1. Aquest tipus de recompte de pàgines s&apos;ha d&apos;emprar només en publicacions digitals entregades amb paginació fixa.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Nombre de pàgines de la versió impresa</xs:documentation>
+					<xs:documentation>El nombre total de pàgines (equivalent al recompte de pàgines de contingut) en la versió impresa d&apos;un producte digital entregat sense paginació fixa.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Duració</xs:documentation>
+					<xs:documentation>Duració expressada en la unitat de mesura específica.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Nombre de pàgines orientatiu d&apos;un producte digital</xs:documentation>
+					<xs:documentation>Una estimació del nombre de «pàgines» en un producte digital entregat sense paginació fixa i sense equivalent imprès, que serveix com a indicador del volum d&apos;una obra. Equivalent al codi 08, però exclusiu per a productes digitals.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Recompte de pàgines de contingut</xs:documentation>
+					<xs:documentation>La suma de totes les pàgines numerades amb números romans (i aràbics) i de les pàgines no numerades. Suma de recompte de pàgines amb els codis 00, 03, 04 i 12, i també la suma de 05 i 12.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Recompte del total de pàgines inserides no numerades</xs:documentation>
+					<xs:documentation>El nombre total de pàgines no numerades que tinguin contingut principal d&apos;un llibre (per exemple làmines o il·lustracions que no estan numerades).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Mida del fitxer</xs:documentation>
+					<xs:documentation>La mida d&apos;un fitxer digital, expressada en la unitat de mesura específica.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List24">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 24">Codi d&apos;unitat de mesura</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Paraules</xs:documentation>
+					<xs:documentation>Paraules d&apos;un text amb llenguatge natural.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Pàgines</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Hores (nombre enter i amb decimals)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Minuts (nombre enter i amb decimals)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Segons (només enters)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Hores en format HHH</xs:documentation>
+					<xs:documentation>Ompliu-ho amb zeros si hi falta algun element.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Hores i minuts HHMM</xs:documentation>
+					<xs:documentation>Ompliu-ho amb zeros si hi falta algun element.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Hores minuts segons HHHMMSS</xs:documentation>
+					<xs:documentation>Ompliu-ho amb zeros si hi falta algun element.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Bytes (B)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Kbytes (kB)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Mbytes (MB)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List25">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 25">Il·lustracions i altres codis de tipus de contingut</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>No especificat, vegeu descripció</xs:documentation>
+					<xs:documentation>Vegeu descripció a l&apos;element &lt;IllustrationTypeDescription>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Il·lustracions en blanc i negre</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Il·lustracions a color</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Mitja tinta en blanc i negre</xs:documentation>
+					<xs:documentation>Inclou fotografies en blanc i negre.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Mitja tinta en color</xs:documentation>
+					<xs:documentation>Inclou fotografies a color.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Dibuix lineal en blanc i negre</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Dibuix lineal a color</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Taules en blanc i negre</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Taules a color</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Illustrations, unspecified</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Halftones, unspecified</xs:documentation>
+					<xs:documentation>Including photographs.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Tables, unspecified</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Line drawings, unspecified</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Halftones, duotone</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Maps</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Frontispiece</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Diagrams</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Figures</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Charts</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Recorded music items</xs:documentation>
+					<xs:documentation>Recorded music extracts or examples, or complete recorded work(s), accompanying textual or other content.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Printed music items</xs:documentation>
+					<xs:documentation>Printed music extracts or examples, or complete music score(s), accompanying textual or other content.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>Graphs</xs:documentation>
+					<xs:documentation>To be used in the mathematical sense of a diagram that represents numerical values plotted against an origin and axes, cf codes 16 and 18.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Plates, unspecified</xs:documentation>
+					<xs:documentation>&apos;Plates&apos; means illustrations that are on separate pages bound into the body of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Plates, black and white</xs:documentation>
+					<xs:documentation>&apos;Plates&apos; means illustrations that are on separate pages bound into the body of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Plates, color</xs:documentation>
+					<xs:documentation>&apos;Plates&apos; means illustrations that are on separate pages bound into the body of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Índex</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Bibliografia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>Inset maps</xs:documentation>
+					<xs:documentation>Larger-scale inset maps of places or features of interest included in a map product.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>GPS grids</xs:documentation>
+					<xs:documentation>GPS grids included in a map product.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List26">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 26">Main subject scheme identifier code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Dewey</xs:documentation>
+					<xs:documentation>Dewey Decimal Classification.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Abridged Dewey</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>LC classification</xs:documentation>
+					<xs:documentation>US Library of Congress classification.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>LC subject heading</xs:documentation>
+					<xs:documentation>US Library of Congress subject heading.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>NLM classification</xs:documentation>
+					<xs:documentation>US National Library of Medicine medical classification.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>MeSH heading</xs:documentation>
+					<xs:documentation>US National Library of Medicine Medical subject heading.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>NAL subject heading</xs:documentation>
+					<xs:documentation>US National Agricultural Library subject heading.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>AAT</xs:documentation>
+					<xs:documentation>Getty Art and Architecture Thesaurus heading.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>UDC</xs:documentation>
+					<xs:documentation>Universal Decimal Classification.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>BISAC Subject Heading</xs:documentation>
+					<xs:documentation>BISAC Subject Headings are used in the North American market to categorize books based on topical content. They serve as a guideline for shelving books in physical stores and browsing books in online stores. See &apos;http://www.bisg.org/what-we-do-cat-20-classification-schemes.php&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>BISAC region code</xs:documentation>
+					<xs:documentation>A geographical qualifier used with a BISAC subject category.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>BIC subject category</xs:documentation>
+					<xs:documentation>For all BIC subject codes and qualifiers, see &apos;http://www.bic.org.uk/7/BIC-Standard-Subject-Categories/&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>BIC geographical qualifier</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>BIC language qualifier (language as subject)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>BIC time period qualifier</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>BIC educational purpose qualifier</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>BIC reading level and special interest qualifier</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>DDC-Sachgruppen der Deutschen Nationalbibliografie</xs:documentation>
+					<xs:documentation>Used for German National Bibliography since 2004 (100 subjects). Is different from value 30. See http://www.d-nb.de/service/pdf/ddc_wv_aktuell.pdf (in German) or http://www.d-nb.de/eng/service/pdf/ddc_wv_aktuell_eng.pdf (English).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>LC fiction genre heading</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Paraules clau</xs:documentation>
+					<xs:documentation>Where multiple keywords or keyword phrases are sent in a single instance of the &lt;SubjectHeadingText> element, it is recommended that they should be separated by semi-colons (this is consistent with Library of Congress preferred practice).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>BIC children&apos;s book marketing category</xs:documentation>
+					<xs:documentation>See &apos;http://www.bic.org.uk/8/Children&apos;s-Books-Marketing-Classifications/&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>BISAC Merchandising Theme</xs:documentation>
+					<xs:documentation>BISAC Merchandising Themes are used in addition to BISAC Subject Headings to denote an audience to which a work may be of particular appeal, a time of year or event for which a work may be especially appropriate, or to further describe fictional works that have been subject-coded by genre.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Publisher&apos;s own category code</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Proprietary subject scheme</xs:documentation>
+					<xs:documentation>As specified in &lt;SubjectSchemeName>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Tabla de materias ISBN</xs:documentation>
+					<xs:documentation>Latin America.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Warengruppen-Systematik des deutschen Buchhandels</xs:documentation>
+					<xs:documentation>See &apos;http://www.boersenverein.de/sixcms/media.php/976/WGSneuVersion2_0.pdf&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>SWD</xs:documentation>
+					<xs:documentation>Schlagwortnormdatei - Subject Headings Authority File in the German-speaking countries. See http://www.d-nb.de/standardisierung/normdateien/swd.htm (in German) and http://www.d-nb.de/eng/standardisierung/normdateien/swd.htm (English).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>Thèmes Electre</xs:documentation>
+					<xs:documentation>Subject classification used by Electre (France).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="29">
+				<xs:annotation>
+					<xs:documentation>CLIL</xs:documentation>
+					<xs:documentation>France, see Appendix in http://www.clil.org/information/telechargementDoc.html?action=ouvrir&amp;id=313 (in French).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>DNB-Sachgruppen</xs:documentation>
+					<xs:documentation>Deutsche Bibliothek subject groups. Used for German National Bibliography until 2003 (65 subjects). Is different from value 18. See &apos;http://www.d-nb.de/service/pdf/ddc_wv_alt_neu.pdf&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>NUGI</xs:documentation>
+					<xs:documentation>Nederlandse Uniforme Genre-Indeling (former Dutch book trade classification).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>NUR</xs:documentation>
+					<xs:documentation>Nederlandstalige Uniforme Rubrieksindeling (Dutch book trade classification, from 2002),see http://reeks.boekwinkeltjes.nl/downloads/NUR-lijst.pdf (in Dutch).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>ECPA Christian Book Category</xs:documentation>
+					<xs:documentation>ECPA Christian Product Category Book Codes, consisting of up to three x 3-letter blocks, for Super Category, Primary Category and Sub-Category. See &apos;http://www.ecpa.org/ECPA/cbacategories.xls&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>SISO</xs:documentation>
+					<xs:documentation>Schema Indeling Systematische Catalogus Openbare Bibliotheken (Dutch library classification).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="35">
+				<xs:annotation>
+					<xs:documentation>Korean Decimal Classification (KDC)</xs:documentation>
+					<xs:documentation>A modified Dewey Decimal Classification used in the Republic of Korea.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="36">
+				<xs:annotation>
+					<xs:documentation>DDC Deutsch 22</xs:documentation>
+					<xs:documentation>German Translation of Dewey Decimal Classification 22. Also known as DDC 22 ger. See &apos;http://www.ddc-deutsch.de/produkte/uebersichten/&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="37">
+				<xs:annotation>
+					<xs:documentation>Bokgrupper</xs:documentation>
+					<xs:documentation>Norwegian book trade product categories (4701).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="38">
+				<xs:annotation>
+					<xs:documentation>Varegrupper</xs:documentation>
+					<xs:documentation>Norwegian bookselling subject categories (4702).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="39">
+				<xs:annotation>
+					<xs:documentation>Læreplaner</xs:documentation>
+					<xs:documentation>Norwegian school curriculum version (4703).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="40">
+				<xs:annotation>
+					<xs:documentation>Nippon Decimal Classification</xs:documentation>
+					<xs:documentation>Japanese subject classification scheme.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="41">
+				<xs:annotation>
+					<xs:documentation>BSQ</xs:documentation>
+					<xs:documentation>BookSelling Qualifier: Russian book trade classification.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="42">
+				<xs:annotation>
+					<xs:documentation>ANELE Materias</xs:documentation>
+					<xs:documentation>Spain: subject coding scheme of the Asociación Nacional de Editores de Libros y Material de Enseñanza.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="43">
+				<xs:annotation>
+					<xs:documentation>Skolefag</xs:documentation>
+					<xs:documentation>Norwegian primary and secondary school subject categories (4705).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="44">
+				<xs:annotation>
+					<xs:documentation>Videregående</xs:documentation>
+					<xs:documentation>Norwegian list of categories used in higher secondary education and vocational training (4706).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="45">
+				<xs:annotation>
+					<xs:documentation>Undervisningsmateriell</xs:documentation>
+					<xs:documentation>Norwegian list of categories for books and other material used in education (4707).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="46">
+				<xs:annotation>
+					<xs:documentation>Norsk DDK</xs:documentation>
+					<xs:documentation>Norwegian version of Dewey Decimal Classification.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="47">
+				<xs:annotation>
+					<xs:documentation>Varugrupper</xs:documentation>
+					<xs:documentation>Swedish bookselling subject categories.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="48">
+				<xs:annotation>
+					<xs:documentation>SAB</xs:documentation>
+					<xs:documentation>Swedish classification scheme.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="49">
+				<xs:annotation>
+					<xs:documentation>Läromedel</xs:documentation>
+					<xs:documentation>Swedish bookselling educational subject.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="50">
+				<xs:annotation>
+					<xs:documentation>Förhandsbeskrivning</xs:documentation>
+					<xs:documentation>Swedish publishers preliminary subject classification.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="51">
+				<xs:annotation>
+					<xs:documentation>Spanish ISBN UDC subset</xs:documentation>
+					<xs:documentation>Controlled subset of UDC codes used by the Spanish ISBN Agency.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="52">
+				<xs:annotation>
+					<xs:documentation>ECI subject categories</xs:documentation>
+					<xs:documentation>Subject categories defined by El Corte Inglés and used widely in the Spanish book trade.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="53">
+				<xs:annotation>
+					<xs:documentation>Soggetto CCE</xs:documentation>
+					<xs:documentation>Classificazione commerciale editoriale (Italian book trade subject category based on BIC).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="54">
+				<xs:annotation>
+					<xs:documentation>Qualificatore geografico CCE</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="55">
+				<xs:annotation>
+					<xs:documentation>Qualificatore di lingua CCE</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="56">
+				<xs:annotation>
+					<xs:documentation>Qualificatore di periodo storico CCE</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="57">
+				<xs:annotation>
+					<xs:documentation>Qualificatore di livello scolastico CCE</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="58">
+				<xs:annotation>
+					<xs:documentation>Qualificatore di età di lettura CCE</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="59">
+				<xs:annotation>
+					<xs:documentation>VdS Bildungsmedien Fächer</xs:documentation>
+					<xs:documentation>Subject code list of the German association of educational media publishers.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="60">
+				<xs:annotation>
+					<xs:documentation>Fagkoder</xs:documentation>
+					<xs:documentation>Undervisningsdirektoratets fagkoder for kunnskapsløftet I videregående (Norwegian educational curriculum for secondary schools) (4708).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="61">
+				<xs:annotation>
+					<xs:documentation>JEL classification</xs:documentation>
+					<xs:documentation>Journal of Economic Literature classification scheme.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="62">
+				<xs:annotation>
+					<xs:documentation>CSH</xs:documentation>
+					<xs:documentation>National Library of Canada subject heading (English).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="63">
+				<xs:annotation>
+					<xs:documentation>RVM</xs:documentation>
+					<xs:documentation>Répertoire de vedettes-matière (Bibliothèque et Archives Canada et Bibliothèque de l&apos;Université Laval) (French).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="64">
+				<xs:annotation>
+					<xs:documentation>YSA</xs:documentation>
+					<xs:documentation>Yleinen suomalainen asiasanasto: Finnish General Thesaurus. See http://onki.fi/fi/browser/ (in Finnish).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="65">
+				<xs:annotation>
+					<xs:documentation>Allärs</xs:documentation>
+					<xs:documentation>Allmän tesaurus på svenska: Swedish translation of the Finnish General Thesaurus. See http://onki.fi/fi/browser/ (in Finnish).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="66">
+				<xs:annotation>
+					<xs:documentation>YKL</xs:documentation>
+					<xs:documentation>Yleisten kirjastojen luokitusjärjestelmä: Finnish Public Libraries Classification System. See http://ykl.kirjastot.fi/ (in Finnish).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="67">
+				<xs:annotation>
+					<xs:documentation>MUSA</xs:documentation>
+					<xs:documentation>Musiikin asiasanasto: Finnish Music Thesaurus. See http://onki.fi/fi/browser/ (in Finnish).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="68">
+				<xs:annotation>
+					<xs:documentation>CILLA</xs:documentation>
+					<xs:documentation>Specialtesaurus för musik: Swedish translation of the Finnish Music Thesaurus. See http://onki.fi/fi/browser/ (in Finnish).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="69">
+				<xs:annotation>
+					<xs:documentation>Kaunokki</xs:documentation>
+					<xs:documentation>Fiktiivisen aineiston asiasanasto: Finnish thesaurus for fiction. See http://kaunokki.kirjastot.fi/ (in Finnish).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="70">
+				<xs:annotation>
+					<xs:documentation>Bella</xs:documentation>
+					<xs:documentation>Specialtesaurus för fiktivt material: Swedish translation of the Finnish thesaurus for fiction. See http://kaunokki.kirjastot.fi/sv-FI/ (in Finnish).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="71">
+				<xs:annotation>
+					<xs:documentation>YSO</xs:documentation>
+					<xs:documentation>Yleinen suomalainen ontologia: Finnish General Upper Ontology. See http://onki.fi/fi/browser/ (In Finnish).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="72">
+				<xs:annotation>
+					<xs:documentation>Paikkatieto ontologia</xs:documentation>
+					<xs:documentation>Finnish Place Ontology. See http://onki.fi/fi/browser/ (in Finnish).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="73">
+				<xs:annotation>
+					<xs:documentation>Suomalainen kirja-alan luokitus</xs:documentation>
+					<xs:documentation>Finnish book trade categorisation.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="74">
+				<xs:annotation>
+					<xs:documentation>Sears</xs:documentation>
+					<xs:documentation>Sears List of Subject Headings.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="75">
+				<xs:annotation>
+					<xs:documentation>BIC E4L</xs:documentation>
+					<xs:documentation>BIC E4Libraries Category Headings, see &apos;http://www.bic.org.uk/51/E4libraries-Subject-Category-Headings/&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="76">
+				<xs:annotation>
+					<xs:documentation>CSR</xs:documentation>
+					<xs:documentation>Code Sujet Rayon: subject categories used by bookstores in France.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="77">
+				<xs:annotation>
+					<xs:documentation>Suomalainen oppiaineluokitus</xs:documentation>
+					<xs:documentation>Finnish school subject categories.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="78">
+				<xs:annotation>
+					<xs:documentation>Japanese book trade C-Code</xs:documentation>
+					<xs:documentation>See &apos;http://www.asahi-net.or.jp/~ax2s-kmtn/ref/ccode.html&apos; (in Japanese).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="79">
+				<xs:annotation>
+					<xs:documentation>Japanese book trade Genre Code</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="80">
+				<xs:annotation>
+					<xs:documentation>Fiktiivisen aineiston lisäluokitus</xs:documentation>
+					<xs:documentation>Finnish fiction genre classification. See http://ykl.kirjastot.fi/fi-FI/lisaluokat/ (in Finnish).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="85">
+				<xs:annotation>
+					<xs:documentation>Postal code</xs:documentation>
+					<xs:documentation>Location defined by postal code. Format is two-letter country code (from List 91), space, postal code. Note some postal codes themselves contain spaces, eg &apos;GB N7 9DP&apos; or &apos;US 10125&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="86">
+				<xs:annotation>
+					<xs:documentation>GeoNames ID</xs:documentation>
+					<xs:documentation>ID number for geographical place, as defined at http://www.geonames.org (eg 2825297 is Stuttgart, Germany, see http://www.geonames.org/2825297).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="87">
+				<xs:annotation>
+					<xs:documentation>NewBooks Subject Classification</xs:documentation>
+					<xs:documentation>Used for classification of academic and specialist publication in German-speaking countries. See http://www.newbooks-services.com/de/top/unternehmensportrait/klassifikation-und-mapping.html (German) and http://www.newbooks-services.com/en/top/about-newbooks/classification-mapping.html (English).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List27">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 27">Subject scheme identifier code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Dewey</xs:documentation>
+					<xs:documentation>Dewey Decimal Classification.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Abridged Dewey</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>LC classification</xs:documentation>
+					<xs:documentation>US Library of Congress classification.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>LC subject heading</xs:documentation>
+					<xs:documentation>US Library of Congress subject heading.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>NLM classification</xs:documentation>
+					<xs:documentation>US National Library of Medicine medical classification.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>MeSH heading</xs:documentation>
+					<xs:documentation>US National Library of Medicine Medical subject heading.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>NAL subject heading</xs:documentation>
+					<xs:documentation>US National Agricultural Library subject heading.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>AAT</xs:documentation>
+					<xs:documentation>Getty Art and Architecture Thesaurus heading.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>UDC</xs:documentation>
+					<xs:documentation>Universal Decimal Classification.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>BISAC Subject Heading</xs:documentation>
+					<xs:documentation>BISAC Subject Headings are used in the North American market to categorize books based on topical content. They serve as a guideline for shelving books in physical stores and browsing books in online stores. See &apos;http://www.bisg.org/what-we-do-cat-20-classification-schemes.php&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>BISAC region code</xs:documentation>
+					<xs:documentation>A geographical qualifier used with a BISAC subject category.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>BIC subject category</xs:documentation>
+					<xs:documentation>For all BIC subject codes and qualifiers, see &apos;http://www.bic.org.uk/7/BIC-Standard-Subject-Categories/&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>BIC geographical qualifier</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>BIC language qualifier (language as subject)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>BIC time period qualifier</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>BIC educational purpose qualifier</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>BIC reading level and special interest qualifier</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>DDC-Sachgruppen der Deutschen Nationalbibliografie</xs:documentation>
+					<xs:documentation>Used for German National Bibliography since 2004 (100 subjects). Is different from value 30. See http://www.d-nb.de/service/pdf/ddc_wv_aktuell.pdf (in German) or http://www.d-nb.de/eng/service/pdf/ddc_wv_aktuell_eng.pdf (English).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>LC fiction genre heading</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Paraules clau</xs:documentation>
+					<xs:documentation>Where multiple keywords or keyword phrases are sent in a single instance of the &lt;SubjectHeadingText> element, it is recommended that they should be separated by semi-colons (this is consistent with Library of Congress preferred practice).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>BIC children&apos;s book marketing category</xs:documentation>
+					<xs:documentation>See &apos;http://www.bic.org.uk/8/Children&apos;s-Books-Marketing-Classifications/&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>BISAC Merchandising Theme</xs:documentation>
+					<xs:documentation>BISAC Merchandising Themes are used in addition to BISAC Subject Headings to denote an audience to which a work may be of particular appeal, a time of year or event for which a work may be especially appropriate, or to further describe fictional works that have been subject-coded by genre.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Publisher&apos;s own category code</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Proprietary subject scheme</xs:documentation>
+					<xs:documentation>As specified in &lt;SubjectSchemeName>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Tabla de materias ISBN</xs:documentation>
+					<xs:documentation>Latin America.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Warengruppen-Systematik des deutschen Buchhandels</xs:documentation>
+					<xs:documentation>See http://www.boersenverein.de/sixcms/media.php/976/WGSneuVersion2_0.pdf (in German).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>SWD</xs:documentation>
+					<xs:documentation>Schlagwortnormdatei - Subject Headings Authority File in the German-speaking countries. See http://www.d-nb.de/standardisierung/normdateien/swd.htm (in German) and http://www.d-nb.de/eng/standardisierung/normdateien/swd.htm (English).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>Thèmes Electre</xs:documentation>
+					<xs:documentation>Subject classification used by Electre (France).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="29">
+				<xs:annotation>
+					<xs:documentation>CLIL</xs:documentation>
+					<xs:documentation>France, see Appendix in http://www.clil.org/information/telechargementDoc.html?action=ouvrir&amp;id=313 (in French).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>DNB-Sachgruppen</xs:documentation>
+					<xs:documentation>Deutsche Bibliothek subject groups. Used for German National Bibliography until 2003 (65 subjects). Is different from value 18. See http://www.d-nb.de/service/pdf/ddc_wv_alt_neu.pdf (in German).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>NUGI</xs:documentation>
+					<xs:documentation>Nederlandse Uniforme Genre-Indeling (former Dutch book trade classification).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>NUR</xs:documentation>
+					<xs:documentation>Nederlandstalige Uniforme Rubrieksindeling (Dutch book trade classification, from 2002, see http://reeks.boekwinkeltjes.nl/downloads/NUR-lijst.pdf (in Dutch).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>ECPA Christian Book Category</xs:documentation>
+					<xs:documentation>ECPA Christian Product Category Book Codes, consisting of up to three x 3-letter blocks, for Super Category, Primary Category and Sub-Category. See &apos;http://www.ecpa.org/ECPA/cbacategories.xls&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>SISO</xs:documentation>
+					<xs:documentation>Schema Indeling Systematische Catalogus Openbare Bibliotheken (Dutch library classification).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="35">
+				<xs:annotation>
+					<xs:documentation>Korean Decimal Classification (KDC)</xs:documentation>
+					<xs:documentation>A modified Dewey Decimal Classification used in the Republic of Korea.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="36">
+				<xs:annotation>
+					<xs:documentation>DDC Deutsch 22</xs:documentation>
+					<xs:documentation>German Translation of Dewey Decimal Classification 22. Also known as DDC 22 ger. See &apos;http://www.ddc-deutsch.de/produkte/uebersichten/&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="37">
+				<xs:annotation>
+					<xs:documentation>Bokgrupper</xs:documentation>
+					<xs:documentation>Norwegian book trade product categories (4701).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="38">
+				<xs:annotation>
+					<xs:documentation>Varegrupper</xs:documentation>
+					<xs:documentation>Norwegian bookselling subject categories (4702).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="39">
+				<xs:annotation>
+					<xs:documentation>Læreplaner</xs:documentation>
+					<xs:documentation>Norwegian school curriculum version (4703).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="40">
+				<xs:annotation>
+					<xs:documentation>Nippon Decimal Classification</xs:documentation>
+					<xs:documentation>Japanese subject classification scheme.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="41">
+				<xs:annotation>
+					<xs:documentation>BSQ</xs:documentation>
+					<xs:documentation>BookSelling Qualifier: Russian book trade classification.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="42">
+				<xs:annotation>
+					<xs:documentation>ANELE Materias</xs:documentation>
+					<xs:documentation>Spain: subject coding scheme of the Asociación Nacional de Editores de Libros y Material de Enseñanza.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="43">
+				<xs:annotation>
+					<xs:documentation>Skolefag</xs:documentation>
+					<xs:documentation>Norwegian primary and secondary school subject categories (4705).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="44">
+				<xs:annotation>
+					<xs:documentation>Videregående</xs:documentation>
+					<xs:documentation>Norwegian list of categories used in higher secondary education and vocational training (4706).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="45">
+				<xs:annotation>
+					<xs:documentation>Undervisningsmateriell</xs:documentation>
+					<xs:documentation>Norwegian list of categories for books and other material used in education (4707).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="46">
+				<xs:annotation>
+					<xs:documentation>Norsk DDK</xs:documentation>
+					<xs:documentation>Norwegian version of Dewey Decimal Classification.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="47">
+				<xs:annotation>
+					<xs:documentation>Varugrupper</xs:documentation>
+					<xs:documentation>Swedish bookselling subject categories.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="48">
+				<xs:annotation>
+					<xs:documentation>SAB</xs:documentation>
+					<xs:documentation>Swedish classification scheme.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="49">
+				<xs:annotation>
+					<xs:documentation>Läromedel</xs:documentation>
+					<xs:documentation>Swedish bookselling educational subject.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="50">
+				<xs:annotation>
+					<xs:documentation>Förhandsbeskrivning</xs:documentation>
+					<xs:documentation>Swedish publishers preliminary subject classification.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="51">
+				<xs:annotation>
+					<xs:documentation>Spanish ISBN UDC subset</xs:documentation>
+					<xs:documentation>Controlled subset of UDC codes used by the Spanish ISBN Agency.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="52">
+				<xs:annotation>
+					<xs:documentation>ECI subject categories</xs:documentation>
+					<xs:documentation>Subject categories defined by El Corte Inglés and used widely in the Spanish book trade.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="53">
+				<xs:annotation>
+					<xs:documentation>Soggetto CCE</xs:documentation>
+					<xs:documentation>Classificazione commerciale editoriale (Italian book trade subject category based on BIC). CCE documentation available at &apos;http://www.ie-online.it/CCE2_2.0.pdf&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="54">
+				<xs:annotation>
+					<xs:documentation>Qualificatore geografico CCE</xs:documentation>
+					<xs:documentation>CCE Geographical qualifier.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="55">
+				<xs:annotation>
+					<xs:documentation>Qualificatore di lingua CCE</xs:documentation>
+					<xs:documentation>CCE Language qualifier.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="56">
+				<xs:annotation>
+					<xs:documentation>Qualificatore di periodo storico CCE</xs:documentation>
+					<xs:documentation>CCE Time Period qualifier.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="57">
+				<xs:annotation>
+					<xs:documentation>Qualificatore di livello scolastico CCE</xs:documentation>
+					<xs:documentation>CCE Educational Purpose qualifier.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="58">
+				<xs:annotation>
+					<xs:documentation>Qualificatore di età di lettura CCE</xs:documentation>
+					<xs:documentation>CCE Reading Level Qualifier.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="59">
+				<xs:annotation>
+					<xs:documentation>VdS Bildungsmedien Fächer</xs:documentation>
+					<xs:documentation>Subject code list of the German association of educational media publishers.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="60">
+				<xs:annotation>
+					<xs:documentation>Fagkoder</xs:documentation>
+					<xs:documentation>Undervisningsdirektoratets fagkoder for kunnskapsløftet I videregående (Norwegian educational curriculum for secondary schools) (4708).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="61">
+				<xs:annotation>
+					<xs:documentation>JEL classification</xs:documentation>
+					<xs:documentation>Journal of Economic Literature classification scheme.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="62">
+				<xs:annotation>
+					<xs:documentation>CSH</xs:documentation>
+					<xs:documentation>National Library of Canada subject heading (English).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="63">
+				<xs:annotation>
+					<xs:documentation>RVM</xs:documentation>
+					<xs:documentation>Répertoire de vedettes-matière (Bibliothèque et Archives Canada et Bibliothèque de l&apos;Université Laval) (French).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="64">
+				<xs:annotation>
+					<xs:documentation>YSA</xs:documentation>
+					<xs:documentation>Yleinen suomalainen asiasanasto: Finnish General Thesaurus. See http://onki.fi/fi/browser/ (in Finnish).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="65">
+				<xs:annotation>
+					<xs:documentation>Allärs</xs:documentation>
+					<xs:documentation>Allmän tesaurus på svenska: Swedish translation of the Finnish General Thesaurus. See http://onki.fi/fi/browser/ (in Finnish).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="66">
+				<xs:annotation>
+					<xs:documentation>YKL</xs:documentation>
+					<xs:documentation>Yleisten kirjastojen luokitusjärjestelmä: Finnish Public Libraries Classification System. See http://ykl.kirjastot.fi/ (in Finnish).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="67">
+				<xs:annotation>
+					<xs:documentation>MUSA</xs:documentation>
+					<xs:documentation>Musiikin asiasanasto: Finnish Music Thesaurus. See http://onki.fi/fi/browser/ (in Finnish).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="68">
+				<xs:annotation>
+					<xs:documentation>CILLA</xs:documentation>
+					<xs:documentation>Specialtesaurus för musik: Swedish translation of the Finnish Music Thesaurus. See http://onki.fi/fi/browser/ (in Finnish).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="69">
+				<xs:annotation>
+					<xs:documentation>Kaunokki</xs:documentation>
+					<xs:documentation>Fiktiivisen aineiston asiasanasto: Finnish thesaurus for fiction. See http://kaunokki.kirjastot.fi/ (in Finnish).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="70">
+				<xs:annotation>
+					<xs:documentation>Bella</xs:documentation>
+					<xs:documentation>Specialtesaurus för fiktivt material: Swedish translation of the Finnish thesaurus for fiction. See http://kaunokki.kirjastot.fi/sv-FI/ (in Finnish).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="71">
+				<xs:annotation>
+					<xs:documentation>YSO</xs:documentation>
+					<xs:documentation>Yleinen suomalainen ontologia: Finnish General Upper Ontology. See http://onki.fi/fi/browser/ (In Finnish).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="72">
+				<xs:annotation>
+					<xs:documentation>Paikkatieto ontologia</xs:documentation>
+					<xs:documentation>Finnish Place Ontology. See http://onki.fi/fi/browser/ (in Finnish).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="73">
+				<xs:annotation>
+					<xs:documentation>Suomalainen kirja-alan luokitus</xs:documentation>
+					<xs:documentation>Finnish book trade categorisation.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="74">
+				<xs:annotation>
+					<xs:documentation>Sears</xs:documentation>
+					<xs:documentation>Sears List of Subject Headings.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="75">
+				<xs:annotation>
+					<xs:documentation>BIC E4L</xs:documentation>
+					<xs:documentation>BIC E4Libraries Category Headings, see &apos;http://www.bic.org.uk/51/E4libraries-Subject-Category-Headings/&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="76">
+				<xs:annotation>
+					<xs:documentation>CSR</xs:documentation>
+					<xs:documentation>Code Sujet Rayon: subject categories used by bookstores in France.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="77">
+				<xs:annotation>
+					<xs:documentation>Suomalainen oppiaineluokitus</xs:documentation>
+					<xs:documentation>Finnish school subject categories.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="78">
+				<xs:annotation>
+					<xs:documentation>Japanese book trade C-Code</xs:documentation>
+					<xs:documentation>See &apos;http://www.asahi-net.or.jp/~ax2s-kmtn/ref/ccode.html&apos; (in Japanese).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="79">
+				<xs:annotation>
+					<xs:documentation>Japanese book trade Genre Code</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="80">
+				<xs:annotation>
+					<xs:documentation>Fiktiivisen aineiston lisäluokitus</xs:documentation>
+					<xs:documentation>Finnish fiction genre classification. See http://ykl.kirjastot.fi/fi-FI/lisaluokat/ (in Finnish).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="81">
+				<xs:annotation>
+					<xs:documentation>Arabic Subject heading scheme</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="82">
+				<xs:annotation>
+					<xs:documentation>Arabized BIC subject category</xs:documentation>
+					<xs:documentation>Arabized version of BIC subject category scheme developed by ElKotob.com.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="83">
+				<xs:annotation>
+					<xs:documentation>Arabized LC subject headings</xs:documentation>
+					<xs:documentation>Arabized version of Library of Congress scheme.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="84">
+				<xs:annotation>
+					<xs:documentation>Bibliotheca Alexandrina Subject Headings</xs:documentation>
+					<xs:documentation>Classification scheme used by Library of Alexandria.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="85">
+				<xs:annotation>
+					<xs:documentation>Postal code</xs:documentation>
+					<xs:documentation>Location defined by postal code. Format is two-letter country code (from List 91), space, postal code. Note some postal codes themselves contain spaces, eg &apos;GB N7 9DP&apos; or &apos;US 10125&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="86">
+				<xs:annotation>
+					<xs:documentation>GeoNames ID</xs:documentation>
+					<xs:documentation>ID number for geographical place, as defined at http://www.geonames.org (eg 2825297 is Stuttgart, Germany, see http://www.geonames.org/2825297).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="87">
+				<xs:annotation>
+					<xs:documentation>NewBooks Subject Classification</xs:documentation>
+					<xs:documentation>Used for classification of academic and specialist publication in German-speaking countries. See http://www.newbooks-services.com/de/top/unternehmensportrait/klassifikation-und-mapping.html (German) and http://www.newbooks-services.com/en/top/about-newbooks/classification-mapping.html (English).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="88">
+				<xs:annotation>
+					<xs:documentation>Chinese Library Classification</xs:documentation>
+					<xs:documentation>Subject classification maintained by the Editorial Board of Chinese Library Classification. See http://cct.nlc.gov.cn for access to details of the scheme.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="89">
+				<xs:annotation>
+					<xs:documentation>NTCPDSAC Classification</xs:documentation>
+					<xs:documentation>Subject classification for Books, Audiovisual products and E-publications formulated by China National Technical Committee 505.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List28">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 28">Audience code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>General/trade</xs:documentation>
+					<xs:documentation>For a non-specialist adult audience.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Children/juvenile</xs:documentation>
+					<xs:documentation>For a juvenile audience, not specifically for any educational purpose.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Young adult</xs:documentation>
+					<xs:documentation>For a teenage audience, not specifically for any educational purpose.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Primary and secondary/elementary and high school</xs:documentation>
+					<xs:documentation>Kindergarten, pre-school, primary/elementary or secondary/high school education.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>College/higher education</xs:documentation>
+					<xs:documentation>For universities and colleges of further and higher education.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Professional and scholarly</xs:documentation>
+					<xs:documentation>For an expert adult audience, including academic research.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>ELT/ESL</xs:documentation>
+					<xs:documentation>Intended for use in teaching English as a second language.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Adult education</xs:documentation>
+					<xs:documentation>For centres providing academic, vocational or recreational courses for adults.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List29">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 29">Audience code type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>ONIX audience codes</xs:documentation>
+					<xs:documentation>Using List 28.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Propietari</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>MPAA rating</xs:documentation>
+					<xs:documentation>Motion Picture Association of America rating applied to movies.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>BBFC rating</xs:documentation>
+					<xs:documentation>British Board of Film Classification rating applied to movies.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>FSK rating</xs:documentation>
+					<xs:documentation>German FSK (Freiwillige Selbstkontrolle der Filmwirtschaft) rating applied to movies.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>BTLF audience code</xs:documentation>
+					<xs:documentation>French Canadian audience code list, used by BTLF for Memento.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Electre audience code</xs:documentation>
+					<xs:documentation>Audience code used by Electre (France).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>ANELE Tipo</xs:documentation>
+					<xs:documentation>Spain: educational audience and material type code of the Asociación Nacional de Editores de Libros y Material de Enseñanza.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>AVI</xs:documentation>
+					<xs:documentation>Code list used to specify reading levels for children&apos;s books, used in Flanders, and formerly in the Netherlands - see also code 18.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>USK rating</xs:documentation>
+					<xs:documentation>German USK (Unterhaltungssoftware Selbstkontrolle) rating applied to video or computer games.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>AWS</xs:documentation>
+					<xs:documentation>Audience code used in Flanders.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Schulform</xs:documentation>
+					<xs:documentation>Type of school: codelist maintained by VdS Bildungsmedien eV, the German association of educational media publishers.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Bundesland</xs:documentation>
+					<xs:documentation>School region: codelist maintained by VdS Bildungsmedien eV, the German association of educational media publishers, indicating where products are licensed to be used in schools.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Ausbildungsberuf</xs:documentation>
+					<xs:documentation>Occupation: codelist for vocational training materials, maintained by VdS Bildungsmedien eV, the German association of educational media publishers.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Suomalainen kouluasteluokitus</xs:documentation>
+					<xs:documentation>Finnish school or college level.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>CBG age guidance</xs:documentation>
+					<xs:documentation>UK Publishers Association, Children&apos;s Book Group, coded indication of intended reader age, carried on book covers.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Nielsen Book audience code</xs:documentation>
+					<xs:documentation>Audience code used in Nielsen Book Services.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>AVI (revised)</xs:documentation>
+					<xs:documentation>Code list used to specify reading levels for children&apos;s books, used in the Netherlands - see also code 09.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Lexile measure</xs:documentation>
+					<xs:documentation>Lexile measure (the measure in &lt;ComplexityCode> may optionally be prefixed by the Lexile code). Examples might be &apos;880L&apos;, &apos;AD0L&apos; or &apos;HL600L&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Fry Readability score</xs:documentation>
+					<xs:documentation>Fry readability metric based on number of sentences and syllables per 100 words. Expressed as a number from 1 to 15 in &lt;AudienceCodeValue>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List30">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 30">Audience range qualifier</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>US school grade range</xs:documentation>
+					<xs:documentation>Values for &lt;AudienceRangeValue> are specified in List 77.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>UK school grade</xs:documentation>
+					<xs:documentation>Values are defined by BIC for England and Wales, Scotland and N Ireland.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Reading speed, words per minute</xs:documentation>
+					<xs:documentation>Values in &lt;AudienceRangeValue> must be integers.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Interest age, months</xs:documentation>
+					<xs:documentation>For use up to 30 months only: values in &lt;AudienceRangeValue> must be integers.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Interest age, years</xs:documentation>
+					<xs:documentation>Values in &lt;AudienceRangeValue> must be integers.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Reading age, years</xs:documentation>
+					<xs:documentation>Values in &lt;AudienceRangeValue> must be integers.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Spanish school grade</xs:documentation>
+					<xs:documentation>Spain: combined grade and region code, maintained by the Ministerio de Educación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Skoletrinn</xs:documentation>
+					<xs:documentation>Norwegian educational grades (4704).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>Nivå</xs:documentation>
+					<xs:documentation>Swedish educational qualifier (code).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Italian school grade</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Schulform</xs:documentation>
+					<xs:documentation>DEPRECATED - assigned in error: see List 29.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Bundesland</xs:documentation>
+					<xs:documentation>DEPRECATED - assigned in error: see List 29.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Ausbildungsberuf</xs:documentation>
+					<xs:documentation>DEPRECATED - assigned in error: see List 29.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Canadian school grade range</xs:documentation>
+					<xs:documentation>Values for &lt;AudienceRangeValue> are specified in List 77.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>Finnish school grade range</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>Finnish Upper secondary school course</xs:documentation>
+					<xs:documentation>Lukion kurssi.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="29">
+				<xs:annotation>
+					<xs:documentation>Chinese School Grade code</xs:documentation>
+					<xs:documentation>Values are P, K, 1-17 (including college-level audiences).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List31">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 31">Audience range precision</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Exact</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Des del</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Per a</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List32">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 32">Complexity scheme identifier</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Lexile code</xs:documentation>
+					<xs:documentation>DEPRECATED in ONIX 3 - use &lt;Audience> instead.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Lexile number</xs:documentation>
+					<xs:documentation>DEPRECATED in ONIX 3 - use &lt;Audience> instead.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Fry Readability score</xs:documentation>
+					<xs:documentation>DEPRECATED in ONIX 3 - Use &lt;Audience> instead. Fry readability metric based on number of sentences and syllables per 100 words. Expressed as a number from 1 to 15 in &lt;ComplexityCode>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List33">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 33">Other text type code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Main description</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Short description/annotation</xs:documentation>
+					<xs:documentation>Limited to a maximum of 350 characters.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Long description</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Table of contents</xs:documentation>
+					<xs:documentation>Used for a table of contents sent as a single text field, which may or may not carry structure expressed through HTML etc. Alternatively, a fully structured table of contents may be sent by using the &lt;ContentItem> composite.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Review quote, restricted length</xs:documentation>
+					<xs:documentation>A review quote that is restricted to a maximum length agreed between the sender and receiver of an ONIX file.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Quote from review of previous edition</xs:documentation>
+					<xs:documentation>A review quote taken from a review of a previous edition of the work.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Review text</xs:documentation>
+					<xs:documentation>Full text of a review of the product.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Review quote</xs:documentation>
+					<xs:documentation>A quote from a review of the product.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Promotional &apos;headline&apos;</xs:documentation>
+					<xs:documentation>A promotional phrase which is intended to headline a description of the product.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Previous review quote</xs:documentation>
+					<xs:documentation>A quote from a review of a previous work by the same author(s) or in the same series.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Comentaris de l’autor/a</xs:documentation>
+					<xs:documentation>May be part of Reading Group Guide material: for other commentary, see code 42.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Description for reader</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Biographical note</xs:documentation>
+					<xs:documentation>A note referring to all contributors to a product - NOT linked to a single contributor.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Description for Reading Group Guide</xs:documentation>
+					<xs:documentation>For linking to a complete Reading Group Guide, see code 41.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Discussion question for Reading Group Guide</xs:documentation>
+					<xs:documentation>Each instance must carry a single question: for linking to a complete Reading Group Guide, see code 41.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Competing titles</xs:documentation>
+					<xs:documentation>Free text listing of other titles with which the product is in competition: although this text might not appear in &apos;public&apos; ONIX records, it could be required where ONIX Is used as a communication format within a group of publishing and distribution companies.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Flap copy</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Back cover copy</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Funció</xs:documentation>
+					<xs:documentation>Text describing a feature of a product to which the publisher wishes to draw attention for promotional purposes. Each separate feature should be described by a separate repeat, so that formatting can be applied at the discretion of the receiver of the ONIX record.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>New feature</xs:documentation>
+					<xs:documentation>As code 19, but used for a feature which is new in a new edition of the product.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>Publisher&apos;s notice</xs:documentation>
+					<xs:documentation>A statement included by a publisher in fulfillment of its contractual obligations, such as a disclaimer, sponsor statement, or legal notice of any sort. Note that the inclusion of such a notice cannot and does not imply that a user of the ONIX record is obliged to reproduce it.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Índex</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Excerpt from book</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>First chapter</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Description for sales people</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Description for press or other media</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>Description for subsidiary rights department</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>Description for teachers/educators</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>Unpublished endorsement</xs:documentation>
+					<xs:documentation>A quote usually provided by a celebrity to promote a new book, not from a review.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>Description for bookstore</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>Description for library</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>Introduction or preface</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>Full text</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="35">
+				<xs:annotation>
+					<xs:documentation>Promotional text</xs:documentation>
+					<xs:documentation>Promotional text not covered elsewhere.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="40">
+				<xs:annotation>
+					<xs:documentation>Author interview / QandA</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="41">
+				<xs:annotation>
+					<xs:documentation>Reading Group Guide</xs:documentation>
+					<xs:documentation>Complete guide: see also codes 14 and 15.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="42">
+				<xs:annotation>
+					<xs:documentation>Commentary / discussion</xs:documentation>
+					<xs:documentation>Other than author comments: see code 11.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="43">
+				<xs:annotation>
+					<xs:documentation>Short description for series or set</xs:documentation>
+					<xs:documentation>(of which the product is a part.) Limited to a maximum of 350 characters.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="44">
+				<xs:annotation>
+					<xs:documentation>Long description for series or set</xs:documentation>
+					<xs:documentation>(of which the product is a part.)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="99">
+				<xs:annotation>
+					<xs:documentation>Country of final manufacture</xs:documentation>
+					<xs:documentation>A single ISO 3166-1 country code from List 91 designating the country of final manufacture of the product. (This functionality is provided as a workaround in ONIX 2.1. ONIX 3.0 has specific provision for country of manufacture as a separate element.).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List34">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 34">Text format code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>ASCII text</xs:documentation>
+					<xs:documentation>DEPRECATED: use code 06 or 07 as appropriate.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>SGML</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>HTML</xs:documentation>
+					<xs:documentation>Other than XHTML.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>XML</xs:documentation>
+					<xs:documentation>Other than XHTML.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>PDF</xs:documentation>
+					<xs:documentation>DEPRECATED: was formerly assigned both to PDF and to XHTML.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>XHTML</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Default text format</xs:documentation>
+					<xs:documentation>Default: text in the encoding declared at the head of the message or in the XML default (UTF-8 or UTF-16) if there is no explicit declaration.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Basic ASCII text</xs:documentation>
+					<xs:documentation>Plain text containing no tags of any kind, except for the tags &amp;amp; and &amp;lt; that XML insists must be used to represent ampersand and less-than characters in text; and with the character set limited to the ASCII range, i.e. valid UTF-8 characters whose character number lies between 32 (space) and 126 (tilde).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>PDF</xs:documentation>
+					<xs:documentation>Replaces 04 for the &lt;TextFormat> element, but cannot of course be used as a textformat attribute.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Microsoft rich text format (RTF)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Microsoft Word binary format (DOC)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>ECMA 376 WordprocessingML</xs:documentation>
+					<xs:documentation>Office Open XML file format / OOXML / DOCX.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>ISO 26300 ODF</xs:documentation>
+					<xs:documentation>ISO Open Document Format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Corel Wordperfect binary format (DOC)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>EPUB</xs:documentation>
+					<xs:documentation>The Open Publication Structure / OPS Container Format standard of the International Digital Publishing Forum (IDPF) [File extension .epub].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>XPS</xs:documentation>
+					<xs:documentation>XML Paper Specification.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List35">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 35">Text link type code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>URL</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Mòdul DOI</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>PURL</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Mòdul URN</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>FTP address</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>filename</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List36">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 36">Front cover image file format code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>GIF</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>JPEG</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>TIF</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List37">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 37">Front cover image file link type code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>URL</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Mòdul DOI</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>PURL</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Mòdul URN</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>FTP address</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>filename</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List38">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 38">Image/audio/video file type code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Whole product</xs:documentation>
+					<xs:documentation>Link to a location where the whole product may be found - used for epublications.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Application: software demo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Image: whole cover</xs:documentation>
+					<xs:documentation>Includes cover, back cover, spine and - where appropriate - any flaps. Quality unspecified: if sending both a standard quality and a high quality image, use 03 for standard quality and 05 for high quality.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Image: front cover</xs:documentation>
+					<xs:documentation>Quality unspecified: if sending both a standard quality and a high quality image, use 04 for standard quality and 06 for high quality.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Image: whole cover, high quality</xs:documentation>
+					<xs:documentation>Should have a minimum resolution of 300 dpi when rendered at the intended size for display or print.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Image: front cover, high quality</xs:documentation>
+					<xs:documentation>Should have a minimum resolution of 300 dpi when rendered at the intended size for display or print.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Image: front cover thumbnail</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Image: contributor(s)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Image: for series</xs:documentation>
+					<xs:documentation>Use for an image, other than a logo, that is part of the &apos;branding&apos; of a series.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Image: series logo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Image: product logo</xs:documentation>
+					<xs:documentation>Use only for a logo which is specific to an individual product.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Image: publisher logo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Image: imprint logo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Image: table of contents</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Image: sample content</xs:documentation>
+					<xs:documentation>Use for inside page image for book, or screenshot for software or game (revised definition from Issue 8).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Image: back cover</xs:documentation>
+					<xs:documentation>Quality unspecified: if sending both a standard quality and a high quality image, use 24 for standard quality and 26 for high quality.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Image: back cover, high quality</xs:documentation>
+					<xs:documentation>Should have a minimum resolution of 300 dpi when rendered at the intended size for display or print.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Image: back cover thumbnail</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>Image: other cover material</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>Image: promotional material</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="29">
+				<xs:annotation>
+					<xs:documentation>Video segment: unspecified</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>Audio segment: unspecified</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>Video: author presentation / commentary</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>Video: author interview</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>Video: author reading</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>Video: cover material</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="35">
+				<xs:annotation>
+					<xs:documentation>Video: sample content</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="36">
+				<xs:annotation>
+					<xs:documentation>Video: promotional material</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="37">
+				<xs:annotation>
+					<xs:documentation>Video: review</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="38">
+				<xs:annotation>
+					<xs:documentation>Video: other commentary / discussion</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="41">
+				<xs:annotation>
+					<xs:documentation>Audio: author presentation / commentary</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="42">
+				<xs:annotation>
+					<xs:documentation>Audio: author interview</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="43">
+				<xs:annotation>
+					<xs:documentation>Audio: author reading</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="44">
+				<xs:annotation>
+					<xs:documentation>Audio: sample content</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="45">
+				<xs:annotation>
+					<xs:documentation>Audio: promotional material</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="46">
+				<xs:annotation>
+					<xs:documentation>Audio: review</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="47">
+				<xs:annotation>
+					<xs:documentation>Audio: other commentary / discussion</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="51">
+				<xs:annotation>
+					<xs:documentation>Application: sample content</xs:documentation>
+					<xs:documentation>Use for &apos;look inside&apos; facility or &apos;widget&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="52">
+				<xs:annotation>
+					<xs:documentation>Application: promotional material</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List39">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 39">Image/audio/video file format code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>GIF</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>JPEG</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>PDF</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>TIF</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>RealAudio 28.8</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>MP3</xs:documentation>
+					<xs:documentation>MPEG-1/2 Audio Layer III file.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>MPEG-4</xs:documentation>
+					<xs:documentation>MPEG-4 container format (.mp4, .m4a).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>PNG</xs:documentation>
+					<xs:documentation>Portable Network Graphics bitmapped image format (.png).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>WMA</xs:documentation>
+					<xs:documentation>Windows Media Audio format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>AAC</xs:documentation>
+					<xs:documentation>Advanced Audio Codec format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>WAV</xs:documentation>
+					<xs:documentation>Waveform audio file.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>AIFF</xs:documentation>
+					<xs:documentation>Audio Interchange File Format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>WMV</xs:documentation>
+					<xs:documentation>Windows Media Video format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>OGG</xs:documentation>
+					<xs:documentation>Ogg container format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>AVI</xs:documentation>
+					<xs:documentation>Audio Video Interleaved container format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>MOV</xs:documentation>
+					<xs:documentation>Quicktime container format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Flash</xs:documentation>
+					<xs:documentation>Flash container format (includes .flv, .swf, .f4v etc).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>3GP</xs:documentation>
+					<xs:documentation>3GP container format (.3gp, 3g2).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>WebM</xs:documentation>
+					<xs:documentation>WebM container format (includes .webm and .mkv).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List40">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 40">Image/audio/video file link type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>URL</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Mòdul DOI</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>PURL</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Mòdul URN</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>FTP address</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>filename</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List41">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 41">Prize or award achievement code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Winner</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Runner-up</xs:documentation>
+					<xs:documentation>Named as being in second place.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Commended</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Short-listed</xs:documentation>
+					<xs:documentation>Nominated by the judging process to be one of the final &apos;short-list&apos; from which the winner is selected.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Long-listed</xs:documentation>
+					<xs:documentation>Nominated by the judging process to be one of the preliminary &apos;long-list&apos; from which first a short-list and then the winner is selected.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Joint winner</xs:documentation>
+					<xs:documentation>Or co-winner.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List42">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 42">Text item type code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Textual work</xs:documentation>
+					<xs:documentation>A complete work which is published as a content item in a product which carries two or more such works, eg when two or three novels are published in a single omnibus volume.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Front matter</xs:documentation>
+					<xs:documentation>Text components such as Preface, Introduction etc which appear as preliminaries to the main body of text content in a product.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Body matter</xs:documentation>
+					<xs:documentation>Text components such as Part, Chapter, Section etc which appear as part of the main body of text content in a product.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Back matter</xs:documentation>
+					<xs:documentation>Text components such as Index which appear after the main body of text in a product.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Serial item, miscellaneous or unspecified</xs:documentation>
+					<xs:documentation>For journals.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Research article</xs:documentation>
+					<xs:documentation>For journals.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Review article</xs:documentation>
+					<xs:documentation>For journals.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Fitxer</xs:documentation>
+					<xs:documentation>For journals.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Short communication</xs:documentation>
+					<xs:documentation>For journals.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Erratum</xs:documentation>
+					<xs:documentation>For journals.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Resum</xs:documentation>
+					<xs:documentation>For journals.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Book review (or review of other publication)</xs:documentation>
+					<xs:documentation>For journals.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Editorial</xs:documentation>
+					<xs:documentation>For journals.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Product review</xs:documentation>
+					<xs:documentation>For journals.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Índex</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>Obituary</xs:documentation>
+					<xs:documentation>For journals.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List43">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 43">Text item identifier type code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Propietari</xs:documentation>
+					<xs:documentation>For example, a publisher&apos;s own identifier.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>GTIN-13</xs:documentation>
+					<xs:documentation>Formerly known as the EAN-13 (unhyphenated).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Mòdul DOI</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>PII</xs:documentation>
+					<xs:documentation>Publisher item identifier.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>SICI</xs:documentation>
+					<xs:documentation>For serial items only.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>ISBN-13</xs:documentation>
+					<xs:documentation>(unhyphenated).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List44">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 44">Name code type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Propietari</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Propietari</xs:documentation>
+					<xs:documentation>DEPRECATED - use 01.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>DNB publisher identifier</xs:documentation>
+					<xs:documentation>Deutsche Nationalbibliothek publisher identifier.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Börsenverein Verkehrsnummer</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>German ISBN Agency publisher identifier</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>GLN</xs:documentation>
+					<xs:documentation>GS1 global location number (formerly EAN location number).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>SAN</xs:documentation>
+					<xs:documentation>Book trade Standard Address Number - US, UK etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Centraal Boekhuis Relatie ID</xs:documentation>
+					<xs:documentation>Trading party identifier used in the Netherlands.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Fondscode Boekenbank</xs:documentation>
+					<xs:documentation>Flemish publisher code.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Y-tunnus</xs:documentation>
+					<xs:documentation>Business Identity Code (Finland). See http://www.ytj.fi/ (in Finnish).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>ISNI</xs:documentation>
+					<xs:documentation>International Standard Name Identifier. See &apos;http://www.isni.org/&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>PND</xs:documentation>
+					<xs:documentation>Personennamendatei - person name authority file used by Deutsche Nationalbibliothek and in other German-speaking countries. See http://www.d-nb.de/standardisierung/normdateien/pnd.htm (German) or http://www.d-nb.de/eng/standardisierung/normdateien/pnd.htm (English).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>LCCN</xs:documentation>
+					<xs:documentation>A control number assigned to a Library of Congress Name Authority record.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Japanese Publisher identifier</xs:documentation>
+					<xs:documentation>Publisher identifier administered by Japanese ISBN Agency.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>GKD</xs:documentation>
+					<xs:documentation>Gemeinsame Körperschaftsdatei - Corporate Body Authority File in the German-speaking countries. See http://www.d-nb.de/standardisierung/normdateien/gkd.htm (German) or http://www.d-nb.de/eng/standardisierung/normdateien/gkd.htm (English).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>ORCID</xs:documentation>
+					<xs:documentation>Open Researcher and Contributor ID. See &apos;http://www.orcid.org/&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>GAPP Publisher Identifier</xs:documentation>
+					<xs:documentation>Publisher identifier maintained by the Chinese ISBN Agency (GAPP).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>VAT Identity Number</xs:documentation>
+					<xs:documentation>Identifier for a business organization for VAT purposes, eg within the EU&apos;s VIES system. See http://ec.europa.eu/taxation_customs/vies/faqvies.do for EU VAT ID formats, which vary from country to country. Generally these consist of a two-letter country code followed by the 8-12 digits of the national VAT ID. Some countries include one or two letters within their VAT ID. See http://en.wikipedia.org/wiki/VAT_identification_number for non-EU countries that maintain similar identifiers. Spaces, dashes etc should be omitted.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>JP Distribution Identifier</xs:documentation>
+					<xs:documentation>4-digit business organization identifier controlled by the Japanese Publication Wholesalers Association.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List45">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 45">Publishing role code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Institució editora</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Co-publisher</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Patrocinadors</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Publisher of original-language version</xs:documentation>
+					<xs:documentation>Of a translated work.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Host/distributor of electronic content</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Published for/on behalf of</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Published in association with</xs:documentation>
+					<xs:documentation>Use also for &apos;Published in cooperation with&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Published on behalf of</xs:documentation>
+					<xs:documentation>DEPRECATED: use code 06.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>New or acquiring publisher</xs:documentation>
+					<xs:documentation>When ownership of a product or title is transferred from one publisher to another.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Publishing group</xs:documentation>
+					<xs:documentation>The group to which a publisher (publishing role 01) belongs: use only if a publisher has been identified with role code 01.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Publisher of facsimile original</xs:documentation>
+					<xs:documentation>The publisher of the edition of which a product is a facsimile.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Repackager of prebound edition</xs:documentation>
+					<xs:documentation>The repackager of a prebound edition that has been assigned its own identifier. (In the US, a &apos;prebound edition&apos; is a book that was previously bound, normally as a paperback, and has been rebound with a library-quality hardcover binding by a supplier other than the original publisher.) Required when the &lt;EditionType> is coded PRB. The original publisher should be named as the &apos;publisher&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Former publisher</xs:documentation>
+					<xs:documentation>When ownership of a product or title is transferred from one publisher to another (complement of code 09).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List46">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 46">Sales rights type code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Sales rights unknown or unstated for any reason</xs:documentation>
+					<xs:documentation>May only be used with the ONIX 3 &lt;ROWSalesRightsType> element.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>For unrestricted sale with exclusive rights in the specified countries or territories</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>For unrestricted sale with non-exclusive rights in the specified countries or territories</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Not for sale in the specified countries or territories (reason unspecified)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Not for sale in the specified countries (but publisher holds exclusive rights in those countries or territories)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Not for sale in the specified countries (publisher holds non-exclusive rights in those countries or territories)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Not for sale in the specified countries (because publisher does not hold rights in those countries or territories)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>For sale with exclusive rights in the specified countries or territories (sales restriction applies)</xs:documentation>
+					<xs:documentation>Only for use with ONIX 3.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>For sale with non-exclusive rights in the specified countries or territories (sales restriction applies)</xs:documentation>
+					<xs:documentation>Only for use with ONIX 3.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List47">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 47">Rights region</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="000">
+				<xs:annotation>
+					<xs:documentation>World</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="001">
+				<xs:annotation>
+					<xs:documentation>World except territories specified elsewhere in rights statements</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="002">
+				<xs:annotation>
+					<xs:documentation>UK airports</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="003">
+				<xs:annotation>
+					<xs:documentation>UK &apos;open market&apos;</xs:documentation>
+					<xs:documentation>Use when an open market edition is published under its own ISBN.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List48">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 48">Measure type code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Alçada</xs:documentation>
+					<xs:documentation>For a book, the spine height when standing on a shelf. For a folded map, the height when folded. In general, the height of a product in the form in which it is presented or packaged for retail sale.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Amplada</xs:documentation>
+					<xs:documentation>For a book, the horizontal dimension of the cover when standing upright. For a folded map, the width when folded. In general, the width of a product in the form in which it is presented or packaged for retail sale.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Gruix</xs:documentation>
+					<xs:documentation>For a book, the thickness of the spine. For a folded map, the thickness when folded. In general, the thickness or depth of a product in the form in which it is presented or packaged for retail sale.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Page trim height</xs:documentation>
+					<xs:documentation>Not recommended for general use.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Page trim width</xs:documentation>
+					<xs:documentation>Not recommended for general use.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Unit weight</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Diameter (sphere)</xs:documentation>
+					<xs:documentation>Of a globe, for example.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Unfolded/unrolled sheet height</xs:documentation>
+					<xs:documentation>The height of a folded or rolled sheet map, poster etc when unfolded.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Unfolded/unrolled sheet width</xs:documentation>
+					<xs:documentation>The width of a folded or rolled sheet map, poster etc when unfolded.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Diameter (tube or cylinder)</xs:documentation>
+					<xs:documentation>The diameter of the cross-section of a tube or cylinder, usually carrying a rolled sheet product. Use 01 &apos;height&apos; for the height or length of the tube.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Rolled sheet package side measure</xs:documentation>
+					<xs:documentation>The length of a side of the cross-section of a long triangular or square package, usually carrying a rolled sheet product. Use 01 &apos;height&apos; for the height or length of the package.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List49">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 49">Region code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AU-CT">
+				<xs:annotation>
+					<xs:documentation>Australian Capital Territory</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AU-NS">
+				<xs:annotation>
+					<xs:documentation>New South Wales</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AU-NT">
+				<xs:annotation>
+					<xs:documentation>Northern Territory</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AU-QL">
+				<xs:annotation>
+					<xs:documentation>Queensland</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AU-SA">
+				<xs:annotation>
+					<xs:documentation>South Australia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AU-TS">
+				<xs:annotation>
+					<xs:documentation>Tasmania</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AU-VI">
+				<xs:annotation>
+					<xs:documentation>Victoria</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AU-WA">
+				<xs:annotation>
+					<xs:documentation>Western Australia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA-AB">
+				<xs:annotation>
+					<xs:documentation>Alberta</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA-BC">
+				<xs:annotation>
+					<xs:documentation>British Columbia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA-MB">
+				<xs:annotation>
+					<xs:documentation>Manitoba</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA-NB">
+				<xs:annotation>
+					<xs:documentation>New Brunswick</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA-NL">
+				<xs:annotation>
+					<xs:documentation>Newfoundland and Labrador</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA-NS">
+				<xs:annotation>
+					<xs:documentation>Nova Scotia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA-NT">
+				<xs:annotation>
+					<xs:documentation>Northwest Territories</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA-NU">
+				<xs:annotation>
+					<xs:documentation>Nunavut</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA-ON">
+				<xs:annotation>
+					<xs:documentation>Ontario</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA-PE">
+				<xs:annotation>
+					<xs:documentation>Prince Edward Island</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA-QC">
+				<xs:annotation>
+					<xs:documentation>Quebec</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA-SK">
+				<xs:annotation>
+					<xs:documentation>Saskatchewan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA-YT">
+				<xs:annotation>
+					<xs:documentation>Yukon Territory</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ES-CN">
+				<xs:annotation>
+					<xs:documentation>Canary Islands</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GB-AIR">
+				<xs:annotation>
+					<xs:documentation>UK airside</xs:documentation>
+					<xs:documentation>Airside outlets at UK international airports only.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GB-APS">
+				<xs:annotation>
+					<xs:documentation>UK airports</xs:documentation>
+					<xs:documentation>All UK airports, including both airside and other outlets.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GB-CHA">
+				<xs:annotation>
+					<xs:documentation>Channel Islands</xs:documentation>
+					<xs:documentation>DEPRECATED, replaced by country codes GG - Guernsey, and JE - Jersey.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GB-ENG">
+				<xs:annotation>
+					<xs:documentation>England</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GB-EWS">
+				<xs:annotation>
+					<xs:documentation>England, Wales, Scotland</xs:documentation>
+					<xs:documentation>UK excluding Northern Ireland.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GB-IOM">
+				<xs:annotation>
+					<xs:documentation>Isle of Man</xs:documentation>
+					<xs:documentation>DEPRECATED, replaced by country code IM - Isle of Man.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GB-NIR">
+				<xs:annotation>
+					<xs:documentation>Northern Ireland</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GB-SCT">
+				<xs:annotation>
+					<xs:documentation>Scotland</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GB-WLS">
+				<xs:annotation>
+					<xs:documentation>Wales</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-AK">
+				<xs:annotation>
+					<xs:documentation>Alaska</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-AL">
+				<xs:annotation>
+					<xs:documentation>Alabama</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-AR">
+				<xs:annotation>
+					<xs:documentation>Arkansas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-AZ">
+				<xs:annotation>
+					<xs:documentation>Arizona</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-CA">
+				<xs:annotation>
+					<xs:documentation>California</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-CO">
+				<xs:annotation>
+					<xs:documentation>Colorado</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-CT">
+				<xs:annotation>
+					<xs:documentation>Connecticut</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-DC">
+				<xs:annotation>
+					<xs:documentation>District of Columbia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-DE">
+				<xs:annotation>
+					<xs:documentation>Delaware</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-FL">
+				<xs:annotation>
+					<xs:documentation>Florida</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-GA">
+				<xs:annotation>
+					<xs:documentation>Georgia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-HI">
+				<xs:annotation>
+					<xs:documentation>Hawaii</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-IA">
+				<xs:annotation>
+					<xs:documentation>Iowa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-ID">
+				<xs:annotation>
+					<xs:documentation>Idaho</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-IL">
+				<xs:annotation>
+					<xs:documentation>Illinois</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-IN">
+				<xs:annotation>
+					<xs:documentation>Indiana</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-KS">
+				<xs:annotation>
+					<xs:documentation>Kansas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-KY">
+				<xs:annotation>
+					<xs:documentation>Kentucky</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-LA">
+				<xs:annotation>
+					<xs:documentation>Louisiana</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-MA">
+				<xs:annotation>
+					<xs:documentation>Massachusetts</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-MD">
+				<xs:annotation>
+					<xs:documentation>Maryland</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-ME">
+				<xs:annotation>
+					<xs:documentation>Maine</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-MI">
+				<xs:annotation>
+					<xs:documentation>Michigan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-MN">
+				<xs:annotation>
+					<xs:documentation>Minnesota</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-MO">
+				<xs:annotation>
+					<xs:documentation>Missouri</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-MS">
+				<xs:annotation>
+					<xs:documentation>Mississippi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-MT">
+				<xs:annotation>
+					<xs:documentation>Montana</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-NC">
+				<xs:annotation>
+					<xs:documentation>North Carolina</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-ND">
+				<xs:annotation>
+					<xs:documentation>North Dakota</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-NE">
+				<xs:annotation>
+					<xs:documentation>Nebraska</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-NH">
+				<xs:annotation>
+					<xs:documentation>New Hampshire</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-NJ">
+				<xs:annotation>
+					<xs:documentation>New Jersey</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-NM">
+				<xs:annotation>
+					<xs:documentation>New Mexico</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-NV">
+				<xs:annotation>
+					<xs:documentation>Nevada</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-NY">
+				<xs:annotation>
+					<xs:documentation>New York</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-OH">
+				<xs:annotation>
+					<xs:documentation>Ohio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-OK">
+				<xs:annotation>
+					<xs:documentation>Oklahoma</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-OR">
+				<xs:annotation>
+					<xs:documentation>Oregon</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-PA">
+				<xs:annotation>
+					<xs:documentation>Pennsylvania</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-RI">
+				<xs:annotation>
+					<xs:documentation>Rhode Island</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-SC">
+				<xs:annotation>
+					<xs:documentation>South Carolina</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-SD">
+				<xs:annotation>
+					<xs:documentation>South Dakota</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-TN">
+				<xs:annotation>
+					<xs:documentation>Tennessee</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-TX">
+				<xs:annotation>
+					<xs:documentation>Texas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-UT">
+				<xs:annotation>
+					<xs:documentation>Utah</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-VA">
+				<xs:annotation>
+					<xs:documentation>Virginia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-VT">
+				<xs:annotation>
+					<xs:documentation>Vermont</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-WA">
+				<xs:annotation>
+					<xs:documentation>Washington</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-WI">
+				<xs:annotation>
+					<xs:documentation>Wisconsin</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-WV">
+				<xs:annotation>
+					<xs:documentation>West Virginia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-WY">
+				<xs:annotation>
+					<xs:documentation>Wyoming</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ECZ">
+				<xs:annotation>
+					<xs:documentation>Eurozone</xs:documentation>
+					<xs:documentation>Countries geographically within continental Europe which use the Euro as their sole currency. At the time of writing, this is a synonym for &apos;AT BE CY EE FI FR DE ES GR IE IT LU MT NL PT SI SK&apos; (the official Eurozone 17), plus &apos;AD MC SM VA ME&apos; (other Euro-using countries in continental Europe). Note some other territories using the Euro, but outside continental Europe are excluded from this list, and may need to be specified separately. Only valid in ONIX 3, and only within Block 6.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ROW">
+				<xs:annotation>
+					<xs:documentation>Rest of world</xs:documentation>
+					<xs:documentation>World except as otherwise specified. NOT USED in ONIX 3.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WORLD">
+				<xs:annotation>
+					<xs:documentation>World</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List50">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 50">Measure unit code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="cm">
+				<xs:annotation>
+					<xs:documentation>Centimeters</xs:documentation>
+					<xs:documentation>Millimeters are the preferred metric unit of length.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gr">
+				<xs:annotation>
+					<xs:documentation>Grams</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="in">
+				<xs:annotation>
+					<xs:documentation>Inches (US)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kg">
+				<xs:annotation>
+					<xs:documentation>Kilograms</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lb">
+				<xs:annotation>
+					<xs:documentation>Pounds (US)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mm">
+				<xs:annotation>
+					<xs:documentation>Millimeters</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="oz">
+				<xs:annotation>
+					<xs:documentation>Ounces (US)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="px">
+				<xs:annotation>
+					<xs:documentation>Pixels</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List51">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 51">Product relation code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>No especificat</xs:documentation>
+					<xs:documentation>&lt;Product> is related to &lt;RelatedProduct> in a way that cannot be specified by another code value.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Includes</xs:documentation>
+					<xs:documentation>&lt;Product> includes &lt;RelatedProduct>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Is part of</xs:documentation>
+					<xs:documentation>&lt;Product> is part of &lt;RelatedProduct>: use for &apos;also available as part of&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Replaces</xs:documentation>
+					<xs:documentation>&lt;Product> replaces, or is new edition of, &lt;RelatedProduct>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Replaced by</xs:documentation>
+					<xs:documentation>&lt;Product> is replaced by, or has new edition, &lt;RelatedProduct> (reciprocal of code 03).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Alternative format</xs:documentation>
+					<xs:documentation>&lt;Product> is available in an alternative format as &lt;RelatedProduct> - indicates an alternative format of the same content which is or may be available.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Has ancillary product</xs:documentation>
+					<xs:documentation>&lt;Product> has an ancillary or supplementary product &lt;RelatedProduct>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Is ancillary to</xs:documentation>
+					<xs:documentation>&lt;Product> is ancillary or supplementary to &lt;RelatedProduct>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Is remaindered as</xs:documentation>
+					<xs:documentation>&lt;Product> is remaindered as &lt;RelatedProduct>, when a remainder merchant assigns its own identifier to the product.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Is remainder of</xs:documentation>
+					<xs:documentation>&lt;Product> was originally sold as &lt;RelatedProduct>, indicating the publisher&apos;s original identifier for a title which is offered as a remainder under a different identifier (reciprocal of code 09).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Is other-language version of</xs:documentation>
+					<xs:documentation>&lt;Product> is an other-language version of &lt;RelatedProduct>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Publisher&apos;s suggested alternative</xs:documentation>
+					<xs:documentation>&lt;Product> has a publisher&apos;s suggested alternative &lt;RelatedProduct>, which does not, however, carry the same content (cf 05 and 06).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Epublication based on (print product)</xs:documentation>
+					<xs:documentation>&lt;Product> is an epublication based on printed product &lt;RelatedProduct>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Epublication is distributed as</xs:documentation>
+					<xs:documentation>&lt;Product> is an epublication &apos;rendered&apos; as &lt;RelatedProduct>: use in ONIX 2.1 only when the &lt;Product> record describes a package of electronic content which is available in multiple &apos;renderings&apos; (coded 000 in &lt;EpubTypeCode>): NOT USED in ONIX 3.0.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Epublication is a rendering of</xs:documentation>
+					<xs:documentation>&lt;Product> is a &apos;rendering&apos; of an epublication &lt;RelatedProduct>: use in ONIX 2.1 only when the &lt;Product> record describes a specific rendering of an epublication content package, to identify the package: NOT USED in ONIX 3.0.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>POD replacement for</xs:documentation>
+					<xs:documentation>&lt;Product> is a POD replacement for &lt;RelatedProduct>. &lt;RelatedProduct> is an out-of-print product replaced by a print-on-demand version under a new ISBN.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Replaced by POD</xs:documentation>
+					<xs:documentation>&lt;Product> is replaced by POD &lt;RelatedProduct>. &lt;RelatedProduct> is a print-on-demand replacement, under a new ISBN, for an out-of-print &lt;Product> (reciprocal of code 16).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Is special edition of</xs:documentation>
+					<xs:documentation>&lt;Product> is a special edition of &lt;RelatedProduct>. Used for a special edition (German: Sonderausgabe) with different cover, binding etc - more than &apos;alternative format&apos; - which may be available in limited quantity and for a limited time.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Has special edition</xs:documentation>
+					<xs:documentation>&lt;Product> has a special edition &lt;RelatedProduct> (reciprocal of code 18).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Is prebound edition of</xs:documentation>
+					<xs:documentation>&lt;Product> is a prebound edition of &lt;RelatedProduct> (in the US, a prebound edition is &apos;a book that was previously bound and has been rebound with a library quality hardcover binding. In almost all commercial cases, the book in question began as a paperback.&apos;).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>Is original of prebound edition</xs:documentation>
+					<xs:documentation>&lt;Product> is the regular edition of which &lt;RelatedProduct> is a prebound edition.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Product by same author</xs:documentation>
+					<xs:documentation>&lt;Product> and &lt;RelatedProduct> have a common author.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Similar product</xs:documentation>
+					<xs:documentation>&lt;RelatedProduct> is another product that is suggested as similar to &lt;Product> (&apos;if you liked &lt;Product>, you may also like &lt;RelatedProduct>&apos;).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Is facsimile of</xs:documentation>
+					<xs:documentation>&lt;Product> is a facsimile edition of &lt;RelatedProduct>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Is original of facsimile</xs:documentation>
+					<xs:documentation>&lt;Product> is the original edition from which a facsimile edition &lt;RelatedProduct> is taken (reciprocal of code 25).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Is license for</xs:documentation>
+					<xs:documentation>&lt;Product> is a license for a digital &lt;RelatedProduct>, traded or supplied separately.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>Electronic version available as</xs:documentation>
+					<xs:documentation>&lt;RelatedProduct> is an electronic version of print &lt;Product> (reciprocal of code 13).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>Enhanced version available as</xs:documentation>
+					<xs:documentation>&lt;RelatedProduct> is an &apos;enhanced&apos; version of &lt;Product>, with additional content. Typically used to link an enhanced e-book to its original &apos;unenhanced&apos; equivalent, but not specifically limited to linking e-books - for example, may be used to link illustrated and non-illustrated print books. &lt;Product> and &lt;RelatedProduct> should share the same &lt;ProductForm>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="29">
+				<xs:annotation>
+					<xs:documentation>Basic version available as</xs:documentation>
+					<xs:documentation>&lt;RelatedProduct> is a basic version of &lt;Product> (reciprocal of code 28). &lt;Product> and &lt;RelatedProduct> should share the same &lt;ProductForm>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>Product in same collection</xs:documentation>
+					<xs:documentation>&lt;RelatedProduct> and &lt;Product> are part of the same collection (eg two products in same series or set).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List52">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 52">Supply-to region code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="004">
+				<xs:annotation>
+					<xs:documentation>UK &apos;open market&apos;</xs:documentation>
+					<xs:documentation>When the same ISBN is used for open market and UK editions.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List53">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 53">Returns conditions code type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Propietari</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>French book trade returns conditions code</xs:documentation>
+					<xs:documentation>Maintained by CLIL (Commission Interprofessionnel du Livre).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>BISAC Returnable Indicator code</xs:documentation>
+					<xs:documentation>Maintained by BISAC: see List 66.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>UK book trade returns conditions code</xs:documentation>
+					<xs:documentation>NOT CURRENTLY USED - BIC has decided that it will not maintain a code list for this purpose, since returns conditions are usually at least partly based on the trading relationship.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List54">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 54">Availability status code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AB">
+				<xs:annotation>
+					<xs:documentation>Cancel·lat</xs:documentation>
+					<xs:documentation>Publication abandoned after having been announced.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AD">
+				<xs:annotation>
+					<xs:documentation>Available direct from publisher only</xs:documentation>
+					<xs:documentation>Apply direct to publisher, item not available to trade.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CS">
+				<xs:annotation>
+					<xs:documentation>Availability uncertain</xs:documentation>
+					<xs:documentation>Check with customer service.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EX">
+				<xs:annotation>
+					<xs:documentation>No longer stocked by us</xs:documentation>
+					<xs:documentation>Wholesaler or vendor only.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IP">
+				<xs:annotation>
+					<xs:documentation>Disponibles</xs:documentation>
+					<xs:documentation>In-print and in stock.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MD">
+				<xs:annotation>
+					<xs:documentation>Manufactured on demand</xs:documentation>
+					<xs:documentation>May be accompanied by an estimated average time to supply.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NP">
+				<xs:annotation>
+					<xs:documentation>Not yet published</xs:documentation>
+					<xs:documentation>MUST be accompanied by an expected availability date.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NY">
+				<xs:annotation>
+					<xs:documentation>Newly catalogued, not yet in stock</xs:documentation>
+					<xs:documentation>Wholesaler or vendor only: MUST be accompanied by expected availability date.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="OF">
+				<xs:annotation>
+					<xs:documentation>Other format available</xs:documentation>
+					<xs:documentation>This format is out of print, but another format is available: should be accompanied by an identifier for the alternative product.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="OI">
+				<xs:annotation>
+					<xs:documentation>Out of stock indefinitely</xs:documentation>
+					<xs:documentation>No current plan to reprint.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="OP">
+				<xs:annotation>
+					<xs:documentation>Out of print</xs:documentation>
+					<xs:documentation>Discontinued, deleted from catalogue.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="OR">
+				<xs:annotation>
+					<xs:documentation>Replaced by new edition</xs:documentation>
+					<xs:documentation>This edition is out of print, but a new edition has been or will soon be published: should be accompanied by an identifier for the new edition.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PP">
+				<xs:annotation>
+					<xs:documentation>Publication postponed indefinitely</xs:documentation>
+					<xs:documentation>Publication has been announced, and subsequently postponed with no new date.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RF">
+				<xs:annotation>
+					<xs:documentation>Refer to another supplier</xs:documentation>
+					<xs:documentation>Supply of this item has been transferred to another publisher or distributor: should be accompanied by an identifier for the new supplier.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RM">
+				<xs:annotation>
+					<xs:documentation>Remaindered</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RP">
+				<xs:annotation>
+					<xs:documentation>Reprinting</xs:documentation>
+					<xs:documentation>MUST be accompanied by an expected availability date.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RU">
+				<xs:annotation>
+					<xs:documentation>Reprinting, undated</xs:documentation>
+					<xs:documentation>Use instead of RP as a last resort, only if it is really impossible to give an expected availability date.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TO">
+				<xs:annotation>
+					<xs:documentation>Special order</xs:documentation>
+					<xs:documentation>This item is not stocked but has to be specially ordered from a supplier (eg import item not stocked locally): may be accompanied by an estimated average time to supply.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TP">
+				<xs:annotation>
+					<xs:documentation>Temporarily out of stock because publisher cannot supply</xs:documentation>
+					<xs:documentation>Wholesaler or vendor only.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TU">
+				<xs:annotation>
+					<xs:documentation>Temporarily unavailable</xs:documentation>
+					<xs:documentation>MUST be accompanied by an expected availability date.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="UR">
+				<xs:annotation>
+					<xs:documentation>Unavailable, awaiting reissue</xs:documentation>
+					<xs:documentation>The item is out of stock but will be reissued under the same ISBN: MUST be accompanied by an expected availability date and by the reissue date in the &lt;Reissue> composite. See notes on the &lt;Reissue> composite for details on treatment of availability status during reissue.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WR">
+				<xs:annotation>
+					<xs:documentation>Will be remaindered as of (date)</xs:documentation>
+					<xs:documentation>MUST be accompanied by the remainder date.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WS">
+				<xs:annotation>
+					<xs:documentation>Withdrawn from sale</xs:documentation>
+					<xs:documentation>Typically, withdrawn indefinitely for legal reasons.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List55">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 55">Date format</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>YYYYMMDD</xs:documentation>
+					<xs:documentation>Year month day (default).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>YYYYMM</xs:documentation>
+					<xs:documentation>Year and month.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>YYYYWW</xs:documentation>
+					<xs:documentation>Year and week number.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>YYYYQ</xs:documentation>
+					<xs:documentation>Year and quarter (Q = 1, 2, 3, 4).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>YYYYS</xs:documentation>
+					<xs:documentation>Year and season (S = 1, 2, 3, 4, with 1 = &apos;Spring&apos;).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>YYYY</xs:documentation>
+					<xs:documentation>Year.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>YYYYMMDDYYYYMMDD</xs:documentation>
+					<xs:documentation>Spread of exact dates.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>YYYYMMYYYYMM</xs:documentation>
+					<xs:documentation>Spread of months.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>YYYYWWYYYYWW</xs:documentation>
+					<xs:documentation>Spread of week numbers.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>YYYYQYYYYQ</xs:documentation>
+					<xs:documentation>Spread of quarters.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>YYYYSYYYYS</xs:documentation>
+					<xs:documentation>Spread of seasons.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>YYYYYYYY</xs:documentation>
+					<xs:documentation>Spread of years.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Text string</xs:documentation>
+					<xs:documentation>For complex, approximate or uncertain dates.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>YYYYMMDDThhmm</xs:documentation>
+					<xs:documentation>Exact time. Use ONLY when exact times with hour/minute precision are relevant. By default, time is local to the sender. Alternatively, the time may be suffixed with an optional &apos;Z&apos; for UTC times, or with &apos;+&apos; or &apos;-&apos; and an hhmm timezone offset from UTC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>YYYYMMDDThhmmss</xs:documentation>
+					<xs:documentation>Exact time. Use ONLY when exact times with second precision are relevant. By default, time is local to the sender. Alternatively, the time may be suffixed with an optional &apos;Z&apos; for UTC times, or with &apos;+&apos; or &apos;-&apos; and an hhmm timezone offset from UTC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>YYYYMMDD (H)</xs:documentation>
+					<xs:documentation>Year month day (Hijri calendar).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>YYYYMM (H)</xs:documentation>
+					<xs:documentation>Year and month (Hijri calendar).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>YYYY (H)</xs:documentation>
+					<xs:documentation>Year (Hijri calendar).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>Text string (H)</xs:documentation>
+					<xs:documentation>For complex, approximate or uncertain dates (Hijri calendar), text would usually be in Arabic script.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List56">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 56">Audience restriction flag</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="R">
+				<xs:annotation>
+					<xs:documentation>Restrictions apply, see note</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="X">
+				<xs:annotation>
+					<xs:documentation>Indiziert</xs:documentation>
+					<xs:documentation>Indexed for the German market - in Deutschland indiziert.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List57">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 57">Unpriced item type code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Free of charge</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Price to be announced</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Not sold separately</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Contact supplier</xs:documentation>
+					<xs:documentation>May be used for books that do not carry a recommended retail price, when an ONIX file is &apos;broadcast&apos; rather than sent one-to-one to a single trading partner; or for digital products offered on subscription or with pricing which is too complex to specify in ONIX.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Not sold as set</xs:documentation>
+					<xs:documentation>When a collection that is not sold as a set nevertheless has its own ONIX record.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List58">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 58">Price type code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>RRP excluding tax</xs:documentation>
+					<xs:documentation>RRP excluding any sales tax or value-added tax.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>RRP including tax</xs:documentation>
+					<xs:documentation>RRP including sales or value-added tax if applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Fixed retail price excluding tax</xs:documentation>
+					<xs:documentation>In countries where retail price maintenance applies by law to certain products: not used in USA.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Fixed retail price including tax</xs:documentation>
+					<xs:documentation>In countries where retail price maintenance applies by law to certain products: not used in USA.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Supplier&apos;s net price excluding tax</xs:documentation>
+					<xs:documentation>Unit price charged by supplier to reseller excluding any sales tax or value-added tax: goods for retail sale.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Supplier&apos;s net price excluding tax: rental goods</xs:documentation>
+					<xs:documentation>Unit price charged by supplier to reseller / rental outlet, excluding any sales tax or value-added tax: goods for rental (used for video and DVD).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Supplier&apos;s net price including tax</xs:documentation>
+					<xs:documentation>Unit price charged by supplier to reseller including any sales tax or value-added tax if applicable: goods for retail sale.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Supplier&apos;s alternative net price excluding tax</xs:documentation>
+					<xs:documentation>Unit price charged by supplier to a specified class of reseller excluding any sales tax or value-added tax: goods for retail sale (this value is for use only in countries, eg Finland, where trade practice requires two different net prices to be listed for different classes of resellers, and where national guidelines specify how the code should be used).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Supplier&apos;s alternative net price including tax</xs:documentation>
+					<xs:documentation>Unit price charged by supplier to a specified class of reseller including any sales tax or value-added tax: goods for retail sale (this value is for use only in countries, eg Finland, where trade practice requires two different net prices to be listed for different classes of resellers, and where national guidelines specify how the code should be used).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Special sale RRP excluding tax</xs:documentation>
+					<xs:documentation>Special sale RRP excluding any sales tax or value-added tax. Note &apos;special sales&apos; are sales where terms and conditions are different from normal trade sales, when for example products that are normally sold on a sale-or-return basis are sold on firm-sale terms, or where a particular product is tailored for a specific retail outlet (often termed a &apos;premium&apos; product). Further details of the modified terms and conditioins should be given in &lt;PriceTypeDescription>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Special sale RRP including tax</xs:documentation>
+					<xs:documentation>Special sale RRP including sales or value-added tax if applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Special sale fixed retail price excluding tax</xs:documentation>
+					<xs:documentation>In countries where retail price maintenance applies by law to certain products: not used in USA.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Special sale fixed retail price including tax</xs:documentation>
+					<xs:documentation>In countries where retail price maintenance applies by law to certain products: not used in USA.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Supplier&apos;s net price for special sale excluding tax</xs:documentation>
+					<xs:documentation>Unit price charged by supplier to reseller for special sale excluding any sales tax or value-added tax.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Supplier&apos;s net price for special sale including tax</xs:documentation>
+					<xs:documentation>Unit price charged by supplier to reseller for special sale including any sales tax or value-added tax.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>Pre-publication RRP excluding tax</xs:documentation>
+					<xs:documentation>Pre-publication RRP excluding any sales tax or value-added tax.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Pre-publication RRP including tax</xs:documentation>
+					<xs:documentation>Pre-publication RRP including sales or value-added tax if applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Pre-publication fixed retail price excluding tax</xs:documentation>
+					<xs:documentation>In countries where retail price maintenance applies by law to certain products: not used in USA.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Pre-publication fixed retail price including tax</xs:documentation>
+					<xs:documentation>In countries where retail price maintenance applies by law to certain products: not used in USA.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Supplier&apos;s pre-publication net price excluding tax</xs:documentation>
+					<xs:documentation>Unit price charged by supplier to reseller pre-publication excluding any sales tax or value-added tax.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>Supplier&apos;s pre-publication net price including tax</xs:documentation>
+					<xs:documentation>Unit price charged by supplier to reseller pre-publication including any sales tax or value-added tax.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>Freight-pass-through RRP excluding tax</xs:documentation>
+					<xs:documentation>In the US, books are sometimes supplied on &apos;freight-pass-through&apos; terms, where a price that is different from the RRP is used as the basis for calculating the supplier&apos;s charge to a reseller. To make it clear when such terms are being invoked, code 31 is used instead of code 01 to indicate the RRP. Code 32 is used for the &apos;billing price&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>Freight-pass-through billing price excluding tax</xs:documentation>
+					<xs:documentation>When freight-pass-through terms apply, the price on which the supplier&apos;s charge to a reseller is calculated, ie the price to which trade discount terms are applied. See also code 31.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="41">
+				<xs:annotation>
+					<xs:documentation>Publishers retail price excluding tax</xs:documentation>
+					<xs:documentation>For a product supplied on agency terms, the retail price set by the publisher, excluding any sales tax or value-added tax.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="42">
+				<xs:annotation>
+					<xs:documentation>Publishers retail price including tax</xs:documentation>
+					<xs:documentation>For a product supplied on agency terms, the retail price set by the publisher, including sales or value-added tax if applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List59">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 59">Price type qualifier</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Member/subscriber price</xs:documentation>
+					<xs:documentation>Price applies to a designated group membership.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Export price</xs:documentation>
+					<xs:documentation>Price applies to sales outside the territory in which the supplier is located.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Reduced price applicable when the item is purchased as part of a set (or series, or collection)</xs:documentation>
+					<xs:documentation>Use in cases where there is no combined price, but a lower price is offered for each part if the whole set / series / collection is purchased (either at one time, as part of a continuing commitment, or in a single purchase).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Voucher price</xs:documentation>
+					<xs:documentation>In the Netherlands (or any other market where similar arrangements exist): a reduced fixed price available for a limited time on presentation of a voucher or coupon published in a specified medium, eg a newspaper. Should be accompanied by Price Type code 13 and additional detail in &lt;PriceTypeDescription>, and by validity dates in &lt;PriceEffectiveFrom> and &lt;PriceEffectiveUntil> (ONIX 2.1) or in the &lt;PriceDate> composite (ONIX 3.0).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Consumer price</xs:documentation>
+					<xs:documentation>Price for individual consumer sale only.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Corporate price</xs:documentation>
+					<xs:documentation>Price for sale to libraries or other corporate or institutional customers.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Reservation order price</xs:documentation>
+					<xs:documentation>Price valid for a specified period prior to publication. Orders placed prior to the end of the period are guaranteed to be delivered to the retailer before the nominal publication date. The price may or may not be different from the &apos;normal&apos; price, which carries no such delivery guarantee. Must be accompanied by a &lt;PriceEffectiveUntil> date (or equivalent &lt;PriceDate> composite in ONIX 3), and should also be accompanied by a &apos;normal&apos; price.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Promotional offer price</xs:documentation>
+					<xs:documentation>Temporary &apos;Special offer&apos; price. Must be accompanied by &lt;PriceEffectiveFrom> and &lt;PriceEffectiveUntil> dates (or equivalent &lt;PriceDate> composites in ONIX 3), and may also be accompanied by a &apos;normal&apos; price.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List60">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 60">Unit of pricing code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Per copy of whole product</xs:documentation>
+					<xs:documentation>Per defecte.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Per page for printed loose-leaf content only</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List61">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 61">Price status code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>No especificat</xs:documentation>
+					<xs:documentation>Per defecte.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Provisional</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Firm</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List62">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 62">Tax rate, coded</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="H">
+				<xs:annotation>
+					<xs:documentation>Higher rate</xs:documentation>
+					<xs:documentation>Specifies that tax is applied at a higher rate than standard.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P">
+				<xs:annotation>
+					<xs:documentation>Tax paid at source (Italy)</xs:documentation>
+					<xs:documentation>Under Italian tax rules, VAT on books may be paid at source by the publisher, and subsequent transactions through the supply chain are tax-exempt.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="R">
+				<xs:annotation>
+					<xs:documentation>Lower rate</xs:documentation>
+					<xs:documentation>Specifies that tax is applied at a lower rate than standard.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="S">
+				<xs:annotation>
+					<xs:documentation>Standard rate</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Z">
+				<xs:annotation>
+					<xs:documentation>Zero-rated</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List63">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 63">Intermediary supplier availability</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="List64">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 64">Publishing status</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>No especificat</xs:documentation>
+					<xs:documentation>Status is not specified (as distinct from unknown): the default if the &lt;PublishingStatus> element is not sent. Also to be used in applications where the element is considered mandatory, but the sender of the ONIX message chooses not to pass on status information.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Cancel·lat</xs:documentation>
+					<xs:documentation>The product was announced, and subsequently abandoned; the &lt;PublicationDate> element must not be sent.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Forthcoming</xs:documentation>
+					<xs:documentation>Not yet published, must be accompanied by expected date in &lt;PublicationDate>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Postponed indefinitely</xs:documentation>
+					<xs:documentation>The product was announced, and subsequently postponed with no expected publication date; the &lt;Publication Date> element (ONIX 2.1), or its equivalent as a date composite in ONIX 3.0, must not be sent.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Activa</xs:documentation>
+					<xs:documentation>The product was published, and is still active in the sense that the publisher will accept orders for it, though it may or may not be immediately available, for which see &lt;SupplyDetail>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>No longer our product</xs:documentation>
+					<xs:documentation>Ownership of the product has been transferred to another publisher (with details of acquiring publisher if possible in PR.19 (ONIX 2.1) OR P.19 (ONIX 3.0)).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Out of stock indefinitely</xs:documentation>
+					<xs:documentation>The product was active, but is now inactive in the sense that (a) the publisher cannot fulfill orders for it, though stock may still be available elsewhere in the supply chain, and (b) there are no current plans to bring it back into stock. Use this code for &apos;reprint under consideration&apos;. Code 06 does not specifically imply that returns are or are not still accepted.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Out of print</xs:documentation>
+					<xs:documentation>The product was active, but is now permanently inactive in the sense that (a) the publisher will not accept orders for it, though stock may still be available elsewhere in the supply chain, and (b) the product will not be made available again under the same ISBN. Code 07 normally implies that the publisher will not accept returns beyond a specified date.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Inactiva</xs:documentation>
+					<xs:documentation>The product was active, but is now permanently or indefinitely inactive in the sense that the publisher will not accept orders for it, though stock may still be available elsewhere in the supply chain. Code 08 covers both of codes 06 and 07, and may be used where the distinction between those values is either unnecessary or meaningless.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Desconegut/da</xs:documentation>
+					<xs:documentation>The sender of the ONIX record does not know the current publishing status.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Remaindered</xs:documentation>
+					<xs:documentation>The product is no longer available from the current publisher, under the current ISBN, at the current price. It may be available to be traded through another channel. A Publishing Status code 10 &apos;Remaindered&apos; usually but not always means that the publisher has decided to sell off excess inventory of the book. Copies of books that are remaindered are often made available in the supply chain at a reduced price. However, such remainders are often sold under a product identifier that differs from the ISBN on the full-priced copy of the book. A Publishing Status code 10 &apos;Remaindered&apos; on a given product record may or may not be followed by a Publishing Status code 06 &apos;Out of Stock Indefinitely&apos; or 07 &apos;Out of Print&apos;: the practise varies from one publisher to another. Some publishers may revert to a Publishing Status code 04 &apos;Active&apos; if a desired inventory level on the product in question has subsequently been reached. No change in rights should ever be inferred from this (or any other) Publishing Status code value.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Withdrawn from sale</xs:documentation>
+					<xs:documentation>Withdrawn, typically for legal reasons or to avoid giving offence.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Recalled</xs:documentation>
+					<xs:documentation>Recalled for reasons of consumer safety. Deprecated, use code 15 instead.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Recalled</xs:documentation>
+					<xs:documentation>Recalled for reasons of consumer safety.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Temporarily withdrawn from sale</xs:documentation>
+					<xs:documentation>Withdrawn temporarily, typically for quality or technical reasons. In ONIX 3.0, must be accompanied by expected availability date coded &apos;22&apos; within the &lt;PublishingDate> composite, except in exceptional circumstances where no date is known.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List65">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 65">Product availability</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Cancel·lat</xs:documentation>
+					<xs:documentation>Cancelled: product was announced, and subsequently abandoned.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Not yet available</xs:documentation>
+					<xs:documentation>Not yet available (requires &lt;ExpectedShipDate>, except in exceptional circumstances where no date is known).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Awaiting stock</xs:documentation>
+					<xs:documentation>Not yet available, but will be a stock item when available (requires &lt;ExpectedShipDate>, except in exceptional circumstances where no date is known). Used particularly for imports which have been published in the country of origin but have not yet arrived in the importing country.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Not yet available, will be POD</xs:documentation>
+					<xs:documentation>Not yet available, to be published as print-on-demand only. May apply either to a POD successor to an existing conventional edition, when the successor will be published under a different ISBN (normally because different trade terms apply); or to a title that is being published as a POD original.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Disponibles</xs:documentation>
+					<xs:documentation>Available from us (form of availability unspecified).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>In stock</xs:documentation>
+					<xs:documentation>Available from us as a stock item.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>To order</xs:documentation>
+					<xs:documentation>Available from us as a non-stock item, by special order.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>POD</xs:documentation>
+					<xs:documentation>Available from us by print-on-demand.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>Temporarily unavailable</xs:documentation>
+					<xs:documentation>Temporarily unavailable: temporarily unavailable from us (reason unspecified) (requires expected date, either as &lt;ExpectedShipDate> (ONIX 2.1) or as &lt;SupplyDate> with &lt;SupplyDateRole> coded &apos;08&apos; (ONIX 3.0), except in exceptional circumstances where no date is known).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>Out of stock</xs:documentation>
+					<xs:documentation>Stock item, temporarily out of stock (requires expected date, either as &lt;ExpectedShipDate> (ONIX 2.1) or as &lt;SupplyDate> with &lt;SupplyDateRole> coded &apos;08&apos; (ONIX 3.0), except in exceptional circumstances where no date is known).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>Reprinting</xs:documentation>
+					<xs:documentation>Temporarily unavailable, reprinting (requires expected date, either as &lt;ExpectedShipDate> (ONIX 2.1) or as &lt;SupplyDate> with &lt;SupplyDateRole> coded &apos;08&apos; (ONIX 3.0), except in exceptional circumstances where no date is known).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>Awaiting reissue</xs:documentation>
+					<xs:documentation>Temporarily unavailable, awaiting reissue (requires the &lt;Reissue> composite, and expected date, either as &lt;ExpectedShipDate> (ONIX 2.1) or as &lt;SupplyDate> with &lt;SupplyDateRole> coded &apos;08&apos; (ONIX 3.0), except in exceptional circumstances where no date is known).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>Temporarily withdrawn from sale</xs:documentation>
+					<xs:documentation>May be for quality or technical reasons. Requires expected availability date, either as &lt;ExpectedShipDate> (ONIX 2.1) or as &lt;SupplyDate> with &lt;SupplyDateRole> coded &apos;08&apos; (ONIX 3.0), except in exceptional circumstances where no date is known.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="40">
+				<xs:annotation>
+					<xs:documentation>Not available (reason unspecified)</xs:documentation>
+					<xs:documentation>Not available from us (for any reason).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="41">
+				<xs:annotation>
+					<xs:documentation>Not available, replaced by new product</xs:documentation>
+					<xs:documentation>This product is unavailable, but a successor product or edition is or will be available from us (identify successor in &lt;RelatedProduct>).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="42">
+				<xs:annotation>
+					<xs:documentation>Not available, other format available</xs:documentation>
+					<xs:documentation>This product is unavailable, but the same content is or will be available from us in an alternative format (identify other format product in &lt;RelatedProduct>).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="43">
+				<xs:annotation>
+					<xs:documentation>No longer supplied by us</xs:documentation>
+					<xs:documentation>Identify new supplier in &lt;NewSupplier> if possible.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="44">
+				<xs:annotation>
+					<xs:documentation>Apply direct</xs:documentation>
+					<xs:documentation>Not available to trade, apply direct to publisher.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="45">
+				<xs:annotation>
+					<xs:documentation>Not sold separately</xs:documentation>
+					<xs:documentation>Must be bought as part of a set (identify set in &lt;RelatedProduct>).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="46">
+				<xs:annotation>
+					<xs:documentation>Withdrawn from sale</xs:documentation>
+					<xs:documentation>May be for legal reasons or to avoid giving offence.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="47">
+				<xs:annotation>
+					<xs:documentation>Remaindered</xs:documentation>
+					<xs:documentation>Remaindered.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="48">
+				<xs:annotation>
+					<xs:documentation>Not available, replaced by POD</xs:documentation>
+					<xs:documentation>Out of print, but a print-on-demand edition is or will be available under a different ISBN. Use only when the POD successor has a different ISBN, normally because different trade terms apply.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="49">
+				<xs:annotation>
+					<xs:documentation>Recalled</xs:documentation>
+					<xs:documentation>Recalled for reasons of consumer safety.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="50">
+				<xs:annotation>
+					<xs:documentation>Not sold as set</xs:documentation>
+					<xs:documentation>When a collection that is not sold as a set nevertheless has its own ONIX record.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="51">
+				<xs:annotation>
+					<xs:documentation>Not available, publisher indicates OP</xs:documentation>
+					<xs:documentation>This product is unavailable, no successor product or alternative format is available or planned. Use this code only when the publisher has indicated the product is out of print.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="52">
+				<xs:annotation>
+					<xs:documentation>Not available, publisher no longer sells product in this market</xs:documentation>
+					<xs:documentation>This product is unavailable in this market, no successor product or alternative format is available or planned. Use this code when a publisher has indicated the product is permanently unavailable (in this market) while remaining available elsewhere.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="97">
+				<xs:annotation>
+					<xs:documentation>No recent update received</xs:documentation>
+					<xs:documentation>Sender has not received any recent update for this product from the publisher/supplier (for use when the sender is a data aggregator): the definition of &apos;recent&apos; must be specified by the aggregator, or by agreement between parties to an exchange.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="98">
+				<xs:annotation>
+					<xs:documentation>No longer receiving updates</xs:documentation>
+					<xs:documentation>Sender is no longer receiving any updates from the publisher/supplier of this product (for use when the sender is a data aggregator).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="99">
+				<xs:annotation>
+					<xs:documentation>Contact supplier</xs:documentation>
+					<xs:documentation>Availability not known to sender.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List66">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 66">BISAC returnable indicator</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="N">
+				<xs:annotation>
+					<xs:documentation>No, not returnable</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Y">
+				<xs:annotation>
+					<xs:documentation>Yes, returnable, full copies only</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="S">
+				<xs:annotation>
+					<xs:documentation>Yes, returnable, stripped cover</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="C">
+				<xs:annotation>
+					<xs:documentation>Conditional</xs:documentation>
+					<xs:documentation>Contact publisher for requirements and/or authorization.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List67">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 67">Market date role</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Publication date</xs:documentation>
+					<xs:documentation>The nominal date of publication in this market. If there is a strict embargo on retail sales before the expected date, it should be specified separately as an embargo date.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Embargo date</xs:documentation>
+					<xs:documentation>If there is an embargo on retail sales in this market before a certain date, the date from which the embargo is lifted and retail sales are permitted.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List68">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 68">Market publishing status</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>No especificat</xs:documentation>
+					<xs:documentation>Status is not specified (as distinct from unknown): the default if the &lt;MarketPublishingStatus> element is not sent.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Cancel·lat</xs:documentation>
+					<xs:documentation>The product was announced for publication in this market, and subsequently abandoned.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Forthcoming</xs:documentation>
+					<xs:documentation>Not yet published in this market, should be accompanied by expected local publication date..</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Postponed indefinitely</xs:documentation>
+					<xs:documentation>The product was announced for publication in this market, and subsequently postponed with no expected local publication date.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Activa</xs:documentation>
+					<xs:documentation>The product was published in this market, and is still active in the sense that the publisher will accept orders for it, though it may or may not be immediately available, for which see &lt;SupplyDetail>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>No longer our product</xs:documentation>
+					<xs:documentation>Responsibility for the product in this market has been transferred elsewhere.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Out of stock indefinitely</xs:documentation>
+					<xs:documentation>The product was active, but is now inactive in the sense that (a) no further stock is expected to be made available in this market, though stock may still be available elsewhere in the supply chain, and (b) there are no current plans to bring it back into stock.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Out of print</xs:documentation>
+					<xs:documentation>The product was active, but is now permanently inactive in the sense that (a) no further stock is expected to be made available in this market, though stock may still be available elsewhere in the supply chain, and (b) the product will not be made available again under the same ISBN.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Inactiva</xs:documentation>
+					<xs:documentation>The product was active, but is now permanently or indefinitely inactive in the sense that no further stock is expected to be made available in this market, though stock may still be available elsewhere in the supply chain. Code 08 covers both of codes 06 and 07, and may be used where the distinction between those values is either unnecessary or meaningless.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Desconegut/da</xs:documentation>
+					<xs:documentation>The sender of the ONIX record does not know the current publishing status in this market.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Remaindered</xs:documentation>
+					<xs:documentation>The product is no longer available in this market from the local publisher, under the current ISBN, at the current price. It may be available to be traded through another channel, usually at a reduced price.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Withdrawn from sale</xs:documentation>
+					<xs:documentation>Withdrawn from sale in this market, typically for legal reasons.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Not available in this market</xs:documentation>
+					<xs:documentation>Either no rights are held for the product in this market, or for other reasons the publisher has decided not to make it available in this market.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Active, but not sold separately</xs:documentation>
+					<xs:documentation>The product is published in this market and active but, as a publishing decision, it is not sold separately - only in an assembly or as part of a package.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Active, with market restrictions</xs:documentation>
+					<xs:documentation>The product is published in this market and active, but is not available to all customer types, typically because the market is split between exclusive sales agents for different market segments. In ONIX 2.1, should be accompanied by a free-text statement in &lt;MarketRestrictionDetail> describing the nature of the restriction. In ONIX 3.0, the &lt;SalesRestriction> composite in Group P.24 should be used.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Recalled</xs:documentation>
+					<xs:documentation>Recalled in this market for reasons of consumer safety.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Temporarily withdrawn from sale</xs:documentation>
+					<xs:documentation>Temporarily withdrawn from sale in this market, typically for quality or technical reasons. In ONIX 3.0, must be accompanied by expected availability date coded &apos;22&apos; within the &lt;MarketPublishingDate> composite, except in exceptional circumstances where no date is known.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List69">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 69">Agent role</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Exclusive sales agent</xs:documentation>
+					<xs:documentation>Publisher&apos;s exclusive sales agent in a specified territory.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Non-exclusive sales agent</xs:documentation>
+					<xs:documentation>Publisher&apos;s non-exclusive sales agent in a specified territory.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Local publisher</xs:documentation>
+					<xs:documentation>Publisher for a specified territory.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Sales agent</xs:documentation>
+					<xs:documentation>Publisher&apos;s sales agent in a specific territory. Use only where exclusive / non-exclusive status is not known. Prefer 05 or 06 as appropriate, where possible.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List70">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 70">Stock quantity code type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Propietari</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>APA stock quantity code</xs:documentation>
+					<xs:documentation>Code scheme defined by the Australian Publishers Association.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List71">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 71">Sales restriction type code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Unspecified - see text</xs:documentation>
+					<xs:documentation>Restriction must be described in &lt;SalesRestrictionDetail> (ONIX 2.1) or &lt;SalesRestrictionNote> (ONIX 3.0).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Retailer exclusive / own brand</xs:documentation>
+					<xs:documentation>For sale only through designated retailer. Retailer must be identified or named in an instance of the &lt;SalesOutlet> composite. Use only when it is not possible to assign the more explicit code 04 or 05.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Office supplies edition</xs:documentation>
+					<xs:documentation>For editions sold only though office supplies wholesalers. Retailer(s) and/or distributor(s) may be identified or named in an instance of the &lt;SalesOutlet> composite.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Internal publisher use only: do not list</xs:documentation>
+					<xs:documentation>For an ISBN that is assigned for a publisher&apos;s internal purposes.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Retailer exclusive</xs:documentation>
+					<xs:documentation>For sale only through designated retailer, though not under retailer&apos;s own brand/imprint. Retailer must be identified or named in an instance of the &lt;SalesOutlet> composite.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Retailer own brand</xs:documentation>
+					<xs:documentation>For sale only through designated retailer under retailer&apos;s own brand/imprint. Retailer must be identified or named in an instance of the &lt;SalesOutlet> composite.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Library edition</xs:documentation>
+					<xs:documentation>For sale to libraries only; not for sale through retail trade.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Schools only edition</xs:documentation>
+					<xs:documentation>For sale directly to schools only; not for sale through retail trade.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Indiziert</xs:documentation>
+					<xs:documentation>Indexed for the German market - in Deutschland indiziert.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Not for sale to libraries</xs:documentation>
+					<xs:documentation>Expected to apply in particular to digital products for consumer sale where the publisher does not permit the product to be supplied to libraries who provide an ebook loan service.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Edició per a mitjans de notícies</xs:documentation>
+					<xs:documentation>Per a edicions que es venen només en quioscs.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List72">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 72">Thesis type code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Habilitationsschrift</xs:documentation>
+					<xs:documentation>Professorial dissertation (thesis for postdoctoral lecturing qualification).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Dissertationsschrift</xs:documentation>
+					<xs:documentation>Doctoral thesis.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Staatsexamensarbeit</xs:documentation>
+					<xs:documentation>State examination thesis.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Magisterarbeit</xs:documentation>
+					<xs:documentation>Magisters degree thesis.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Diplomarbeit</xs:documentation>
+					<xs:documentation>Diploma degree thesis.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Bachelorarbeit</xs:documentation>
+					<xs:documentation>Bachelors degree thesis.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Masterarbeit</xs:documentation>
+					<xs:documentation>Masters degree thesis.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List73">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 73">Website role</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Unspecified, see website description</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Publisher&apos;s corporate website</xs:documentation>
+					<xs:documentation>See also codes 17 and 18.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Publisher&apos;s website for a specified work</xs:documentation>
+					<xs:documentation>A publisher&apos;s informative and/or promotional webpage relating to a specified work (book, journal, online resource or other publication type).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Online hosting service home page</xs:documentation>
+					<xs:documentation>A webpage giving access to an online content hosting service as a whole.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Journal home page</xs:documentation>
+					<xs:documentation>A webpage giving general information about a serial, in print or electronic format or both.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Online resource &apos;available content&apos; page</xs:documentation>
+					<xs:documentation>A webpage giving direct access to the content that is available online for a specified resource version. Generally used for content available online under subscription terms.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Contributor&apos;s own website</xs:documentation>
+					<xs:documentation>A webpage maintained by an author or other contributor about her/his publications and personal background.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Publisher&apos;s website relating to specified contributor</xs:documentation>
+					<xs:documentation>A publisher&apos;s webpage devoted to a specific author or other contributor.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Other publisher&apos;s website relating to specified contributor</xs:documentation>
+					<xs:documentation>A webpage devoted to a specific author or other contributor, and maintained by a publisher other than the publisher of the item described in the ONIX record.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Third-party website relating to specified contributor</xs:documentation>
+					<xs:documentation>A webpage devoted to a specific author or other contributor, and maintained by a third party (eg a fan site).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Contributor&apos;s own website for specified work</xs:documentation>
+					<xs:documentation>A webpage maintained by an author or other contributor and specific to an individual work.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Other publisher&apos;s website relating to specified work</xs:documentation>
+					<xs:documentation>A webpage devoted to an individual work, and maintained by a publisher other than the publisher of the item described in the ONIX record.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Third-party website relating to specified work</xs:documentation>
+					<xs:documentation>A webpage devoted to an individual work, and maintained by a third party (eg a fan site).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Contributor&apos;s own website for group or series of works</xs:documentation>
+					<xs:documentation>A webpage maintained by an author or other contributor and specific to a group or series of works.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Publisher&apos;s website relating to group or series of works</xs:documentation>
+					<xs:documentation>A publisher&apos;s webpage devoted to a group or series of works.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Other publisher&apos;s website relating to group or series of works</xs:documentation>
+					<xs:documentation>A webpage devoted to a group or series of works, and maintained by a publisher other than the publisher of the item described in the ONIX record.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Third-party website relating to group or series of works (eg a fan site)</xs:documentation>
+					<xs:documentation>A webpage devoted to a group or series of works, and maintained by a third party (eg a fan site).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Publisher&apos;s B2B website</xs:documentation>
+					<xs:documentation>Use instead of code 01 to specify a publisher&apos;s website for trade users.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Publisher&apos;s B2C website</xs:documentation>
+					<xs:documentation>Use instead of code 01 to specify a publisher&apos;s website for end customers (consumers).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Author blog</xs:documentation>
+					<xs:documentation>For example, a Blogger or Tumblr URL, a Wordpress website or other blog URL.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Web page for author presentation / commentary</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Web page for author interview</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Web page for author reading</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>Web page for cover material</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>Web page for sample content</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="29">
+				<xs:annotation>
+					<xs:documentation>Web page for full content</xs:documentation>
+					<xs:documentation>Use this value in the &lt;Website> composite in &lt;SupplyDetail> when sending a link to a webpage at which a digital product is available for download and/or online access.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>Web page for other commentary / discussion</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>Transfer-URL</xs:documentation>
+					<xs:documentation>URL needed by the German National Library for direct access, harvesting and storage of an electronic resource.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>DOI Website Link</xs:documentation>
+					<xs:documentation>Link needed by German Books in Print (VLB) for DOI registration and ONIX DOI conversion.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>Supplier&apos;s corporate website</xs:documentation>
+					<xs:documentation>A corporate website operated by a distributor or other supplier (not the publisher).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>Supplier&apos;s B2B website</xs:documentation>
+					<xs:documentation>A website operated by a distributor or other supplier (not the publisher) and aimed at trade customers.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="35">
+				<xs:annotation>
+					<xs:documentation>Supplier&apos;s B2C website</xs:documentation>
+					<xs:documentation>A website operated by a distributor or other supplier (not the publisher) and aimed at consumers.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="36">
+				<xs:annotation>
+					<xs:documentation>Supplier&apos;s website for a specified work</xs:documentation>
+					<xs:documentation>A distributor or supplier&apos;s webpage describing a specified work.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="37">
+				<xs:annotation>
+					<xs:documentation>Supplier&apos;s B2B website for a specified work</xs:documentation>
+					<xs:documentation>A distributor or supplier&apos;s webpage describing a specified work, and aimed at trade customers.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="38">
+				<xs:annotation>
+					<xs:documentation>Supplier&apos;s B2C website for a specified work</xs:documentation>
+					<xs:documentation>A distributor or supplier&apos;s webpage describing a specified work, and aimed at consumers.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="39">
+				<xs:annotation>
+					<xs:documentation>Supplier&apos;s website for a group or series of works</xs:documentation>
+					<xs:documentation>A distributor or supplier&apos;s webpage describing a group or series of works.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="40">
+				<xs:annotation>
+					<xs:documentation>URL of full metadata description</xs:documentation>
+					<xs:documentation>For example an ONIX or MARC record for the product, available online.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="41">
+				<xs:annotation>
+					<xs:documentation>Social networking URL for specific work or product</xs:documentation>
+					<xs:documentation>For example, a Facebook, Google+ or Twitter URL for the product or work.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="42">
+				<xs:annotation>
+					<xs:documentation>Author&apos;s social networking URL</xs:documentation>
+					<xs:documentation>For example, a Facebook, Google+ or Twitter page.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="43">
+				<xs:annotation>
+					<xs:documentation>Publisher&apos;s social networking URL</xs:documentation>
+					<xs:documentation>For example, a Facebook, Google+ or Twitter page.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="44">
+				<xs:annotation>
+					<xs:documentation>Social networking URL for specific article, chapter or content item</xs:documentation>
+					<xs:documentation>For example, a Facebook, Google+ or Twitter page. Use only in the context of a specific content item (eg within &lt;ContentItem>).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List74">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 74">Language code - ISO 639-2/B</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="aar">
+				<xs:annotation>
+					<xs:documentation>Afar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="abk">
+				<xs:annotation>
+					<xs:documentation>Abkhaz</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ace">
+				<xs:annotation>
+					<xs:documentation>Achinese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ach">
+				<xs:annotation>
+					<xs:documentation>Acoli</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ada">
+				<xs:annotation>
+					<xs:documentation>Adangme</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ady">
+				<xs:annotation>
+					<xs:documentation>Adygei</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="afa">
+				<xs:annotation>
+					<xs:documentation>Afro-Asiatic languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="afh">
+				<xs:annotation>
+					<xs:documentation>Afrihili</xs:documentation>
+					<xs:documentation>Artificial language.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="afr">
+				<xs:annotation>
+					<xs:documentation>Afrikaans</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ain">
+				<xs:annotation>
+					<xs:documentation>Ainu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="aka">
+				<xs:annotation>
+					<xs:documentation>Akan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="akk">
+				<xs:annotation>
+					<xs:documentation>Akkadian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="alb">
+				<xs:annotation>
+					<xs:documentation>Albanian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ale">
+				<xs:annotation>
+					<xs:documentation>Aleut</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="alg">
+				<xs:annotation>
+					<xs:documentation>Algonquian languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="alt">
+				<xs:annotation>
+					<xs:documentation>Southern Altai</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="amh">
+				<xs:annotation>
+					<xs:documentation>Amharic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ang">
+				<xs:annotation>
+					<xs:documentation>English, Old (ca. 450-1100)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="anp">
+				<xs:annotation>
+					<xs:documentation>Angika</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="apa">
+				<xs:annotation>
+					<xs:documentation>Apache languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ara">
+				<xs:annotation>
+					<xs:documentation>Arabic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="arc">
+				<xs:annotation>
+					<xs:documentation>Official Aramaic; Imperial Aramaic (700-300 BCE)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="arg">
+				<xs:annotation>
+					<xs:documentation>Aragonese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="arm">
+				<xs:annotation>
+					<xs:documentation>Armenian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="arn">
+				<xs:annotation>
+					<xs:documentation>Mapudungun; Mapuche</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="arp">
+				<xs:annotation>
+					<xs:documentation>Arapaho</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="art">
+				<xs:annotation>
+					<xs:documentation>Artificial languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="arw">
+				<xs:annotation>
+					<xs:documentation>Arawak</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="asm">
+				<xs:annotation>
+					<xs:documentation>Assamese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ast">
+				<xs:annotation>
+					<xs:documentation>Asturian; Bable; Leonese; Asturleonese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ath">
+				<xs:annotation>
+					<xs:documentation>Athapascan languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="aus">
+				<xs:annotation>
+					<xs:documentation>Australian languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ava">
+				<xs:annotation>
+					<xs:documentation>Avaric</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ave">
+				<xs:annotation>
+					<xs:documentation>Avestan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="awa">
+				<xs:annotation>
+					<xs:documentation>Awadhi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="aym">
+				<xs:annotation>
+					<xs:documentation>Aymara</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="aze">
+				<xs:annotation>
+					<xs:documentation>Azerbaijani</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bad">
+				<xs:annotation>
+					<xs:documentation>Banda languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bai">
+				<xs:annotation>
+					<xs:documentation>Bamileke languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bak">
+				<xs:annotation>
+					<xs:documentation>Bashkir</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bal">
+				<xs:annotation>
+					<xs:documentation>Baluchi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bam">
+				<xs:annotation>
+					<xs:documentation>Bambara</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ban">
+				<xs:annotation>
+					<xs:documentation>Balinese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="baq">
+				<xs:annotation>
+					<xs:documentation>Basque</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bas">
+				<xs:annotation>
+					<xs:documentation>Basa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bat">
+				<xs:annotation>
+					<xs:documentation>Baltic languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bej">
+				<xs:annotation>
+					<xs:documentation>Beja; Bedawiyet</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bel">
+				<xs:annotation>
+					<xs:documentation>Belarusian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bem">
+				<xs:annotation>
+					<xs:documentation>Bemba</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ben">
+				<xs:annotation>
+					<xs:documentation>Bengali</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ber">
+				<xs:annotation>
+					<xs:documentation>Berber languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bho">
+				<xs:annotation>
+					<xs:documentation>Bhojpuri</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bih">
+				<xs:annotation>
+					<xs:documentation>Bihari languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bik">
+				<xs:annotation>
+					<xs:documentation>Bikol</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bin">
+				<xs:annotation>
+					<xs:documentation>Bini; Edo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bis">
+				<xs:annotation>
+					<xs:documentation>Bislama</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bla">
+				<xs:annotation>
+					<xs:documentation>Siksika</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bnt">
+				<xs:annotation>
+					<xs:documentation>Bantu languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bos">
+				<xs:annotation>
+					<xs:documentation>Bosnian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bra">
+				<xs:annotation>
+					<xs:documentation>Braj</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bre">
+				<xs:annotation>
+					<xs:documentation>Breton</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="btk">
+				<xs:annotation>
+					<xs:documentation>Batak languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bua">
+				<xs:annotation>
+					<xs:documentation>Buriat</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bug">
+				<xs:annotation>
+					<xs:documentation>Buginese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bul">
+				<xs:annotation>
+					<xs:documentation>Bulgarian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bur">
+				<xs:annotation>
+					<xs:documentation>Burmese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="byn">
+				<xs:annotation>
+					<xs:documentation>Blin; Bilin</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cad">
+				<xs:annotation>
+					<xs:documentation>Caddo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cai">
+				<xs:annotation>
+					<xs:documentation>Central American Indian languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="car">
+				<xs:annotation>
+					<xs:documentation>Galibi Carib</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cat">
+				<xs:annotation>
+					<xs:documentation>Catalan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cau">
+				<xs:annotation>
+					<xs:documentation>Caucasian languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ceb">
+				<xs:annotation>
+					<xs:documentation>Cebuano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cel">
+				<xs:annotation>
+					<xs:documentation>Celtic languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cha">
+				<xs:annotation>
+					<xs:documentation>Chamorro</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="chb">
+				<xs:annotation>
+					<xs:documentation>Chibcha</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="che">
+				<xs:annotation>
+					<xs:documentation>Chechen</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="chg">
+				<xs:annotation>
+					<xs:documentation>Chagatai</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="chi">
+				<xs:annotation>
+					<xs:documentation>Chinese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="chk">
+				<xs:annotation>
+					<xs:documentation>Chuukese (Truk)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="chm">
+				<xs:annotation>
+					<xs:documentation>Mari</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="chn">
+				<xs:annotation>
+					<xs:documentation>Chinook jargon</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cho">
+				<xs:annotation>
+					<xs:documentation>Choctaw</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="chp">
+				<xs:annotation>
+					<xs:documentation>Chipewyan; Dene Suline</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="chr">
+				<xs:annotation>
+					<xs:documentation>Cherokee</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="chu">
+				<xs:annotation>
+					<xs:documentation>Church Slavic; Old Slavonic; Church Slavonic; Old Bulgarian; Old Church Slavonic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="chv">
+				<xs:annotation>
+					<xs:documentation>Chuvash</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="chy">
+				<xs:annotation>
+					<xs:documentation>Cheyenne</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cmc">
+				<xs:annotation>
+					<xs:documentation>Chamic languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cop">
+				<xs:annotation>
+					<xs:documentation>Coptic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cor">
+				<xs:annotation>
+					<xs:documentation>Cornish</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cos">
+				<xs:annotation>
+					<xs:documentation>Corsican</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cpe">
+				<xs:annotation>
+					<xs:documentation>Creoles and pidgins, English-based</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cpf">
+				<xs:annotation>
+					<xs:documentation>Creoles and pidgins, French-based</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cpp">
+				<xs:annotation>
+					<xs:documentation>Creoles and pidgins, Portuguese-based</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cre">
+				<xs:annotation>
+					<xs:documentation>Cree</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="crh">
+				<xs:annotation>
+					<xs:documentation>Crimean Turkish; Crimean Tatar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="crp">
+				<xs:annotation>
+					<xs:documentation>Creoles and pidgins</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="csb">
+				<xs:annotation>
+					<xs:documentation>Kashubian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cus">
+				<xs:annotation>
+					<xs:documentation>Cushitic languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cze">
+				<xs:annotation>
+					<xs:documentation>Czech</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="dak">
+				<xs:annotation>
+					<xs:documentation>Dakota</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="dan">
+				<xs:annotation>
+					<xs:documentation>Danish</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="dar">
+				<xs:annotation>
+					<xs:documentation>Dargwa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="day">
+				<xs:annotation>
+					<xs:documentation>Land Dayak languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="del">
+				<xs:annotation>
+					<xs:documentation>Delaware</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="den">
+				<xs:annotation>
+					<xs:documentation>Slave (Athapascan)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="dgr">
+				<xs:annotation>
+					<xs:documentation>Dogrib</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="din">
+				<xs:annotation>
+					<xs:documentation>Dinka</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="div">
+				<xs:annotation>
+					<xs:documentation>Divehi; Dhivehi; Maldivian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="doi">
+				<xs:annotation>
+					<xs:documentation>Dogri</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="dra">
+				<xs:annotation>
+					<xs:documentation>Dravidian languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="dsb">
+				<xs:annotation>
+					<xs:documentation>Lower Sorbian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="dua">
+				<xs:annotation>
+					<xs:documentation>Duala</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="dum">
+				<xs:annotation>
+					<xs:documentation>Dutch, Middle (ca. 1050-1350)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="dut">
+				<xs:annotation>
+					<xs:documentation>Dutch; Flemish</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="dyu">
+				<xs:annotation>
+					<xs:documentation>Dyula</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="dzo">
+				<xs:annotation>
+					<xs:documentation>Dzongkha</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="efi">
+				<xs:annotation>
+					<xs:documentation>Efik</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="egy">
+				<xs:annotation>
+					<xs:documentation>Egyptian (Ancient)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="eka">
+				<xs:annotation>
+					<xs:documentation>Ekajuk</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="elx">
+				<xs:annotation>
+					<xs:documentation>Elamite</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="eng">
+				<xs:annotation>
+					<xs:documentation>Català</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="enm">
+				<xs:annotation>
+					<xs:documentation>English, Middle (1100-1500)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="epo">
+				<xs:annotation>
+					<xs:documentation>Esperanto</xs:documentation>
+					<xs:documentation>Artificial language.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="est">
+				<xs:annotation>
+					<xs:documentation>Estonian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ewe">
+				<xs:annotation>
+					<xs:documentation>Ewe</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ewo">
+				<xs:annotation>
+					<xs:documentation>Ewondo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="fan">
+				<xs:annotation>
+					<xs:documentation>Fang</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="fao">
+				<xs:annotation>
+					<xs:documentation>Faroese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="fat">
+				<xs:annotation>
+					<xs:documentation>Fanti</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="fij">
+				<xs:annotation>
+					<xs:documentation>Fijian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="fil">
+				<xs:annotation>
+					<xs:documentation>Filipino; Pilipino</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="fin">
+				<xs:annotation>
+					<xs:documentation>Finnish</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="fiu">
+				<xs:annotation>
+					<xs:documentation>Finno-Ugrian languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="fon">
+				<xs:annotation>
+					<xs:documentation>Fon</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="fre">
+				<xs:annotation>
+					<xs:documentation>French</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="frm">
+				<xs:annotation>
+					<xs:documentation>French, Middle (ca. 1400-1600)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="fro">
+				<xs:annotation>
+					<xs:documentation>French, Old (ca. 842-1400)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="frr">
+				<xs:annotation>
+					<xs:documentation>Northern Frisian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="frs">
+				<xs:annotation>
+					<xs:documentation>Eastern Frisian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="fry">
+				<xs:annotation>
+					<xs:documentation>Western Frisian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ful">
+				<xs:annotation>
+					<xs:documentation>Fulah</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="fur">
+				<xs:annotation>
+					<xs:documentation>Friulian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gaa">
+				<xs:annotation>
+					<xs:documentation>Gã</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gay">
+				<xs:annotation>
+					<xs:documentation>Gayo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gba">
+				<xs:annotation>
+					<xs:documentation>Gbaya</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gem">
+				<xs:annotation>
+					<xs:documentation>Germanic languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="geo">
+				<xs:annotation>
+					<xs:documentation>Georgian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ger">
+				<xs:annotation>
+					<xs:documentation>German</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gez">
+				<xs:annotation>
+					<xs:documentation>Ethiopic (Ge&apos;ez)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gil">
+				<xs:annotation>
+					<xs:documentation>Gilbertese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gla">
+				<xs:annotation>
+					<xs:documentation>Scottish Gaelic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gle">
+				<xs:annotation>
+					<xs:documentation>Irish</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="glg">
+				<xs:annotation>
+					<xs:documentation>Galician</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="glv">
+				<xs:annotation>
+					<xs:documentation>Manx</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gmh">
+				<xs:annotation>
+					<xs:documentation>German, Middle High (ca. 1050-1500)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="goh">
+				<xs:annotation>
+					<xs:documentation>German, Old High (ca. 750-1050)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gon">
+				<xs:annotation>
+					<xs:documentation>Gondi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gor">
+				<xs:annotation>
+					<xs:documentation>Gorontalo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="got">
+				<xs:annotation>
+					<xs:documentation>Gothic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="grb">
+				<xs:annotation>
+					<xs:documentation>Grebo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="grc">
+				<xs:annotation>
+					<xs:documentation>Greek, Ancient (to 1453)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gre">
+				<xs:annotation>
+					<xs:documentation>Greek, Modern (1453-)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="grn">
+				<xs:annotation>
+					<xs:documentation>Guarani</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gsw">
+				<xs:annotation>
+					<xs:documentation>Swiss German; Alemannic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="guj">
+				<xs:annotation>
+					<xs:documentation>Gujarati</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gwi">
+				<xs:annotation>
+					<xs:documentation>Gwich&apos;in</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="hai">
+				<xs:annotation>
+					<xs:documentation>Haida</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="hat">
+				<xs:annotation>
+					<xs:documentation>Haitian French Creole</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="hau">
+				<xs:annotation>
+					<xs:documentation>Hausa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="haw">
+				<xs:annotation>
+					<xs:documentation>Hawaiian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="heb">
+				<xs:annotation>
+					<xs:documentation>Hebrew</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="her">
+				<xs:annotation>
+					<xs:documentation>Herero</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="hil">
+				<xs:annotation>
+					<xs:documentation>Hiligaynon</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="him">
+				<xs:annotation>
+					<xs:documentation>Himachali languages; Western Pahari languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="hin">
+				<xs:annotation>
+					<xs:documentation>Hindi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="hit">
+				<xs:annotation>
+					<xs:documentation>Hittite</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="hmn">
+				<xs:annotation>
+					<xs:documentation>Hmong; Mong</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="hmo">
+				<xs:annotation>
+					<xs:documentation>Hiri Motu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="hrv">
+				<xs:annotation>
+					<xs:documentation>Croatian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="hsb">
+				<xs:annotation>
+					<xs:documentation>Upper Sorbian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="hun">
+				<xs:annotation>
+					<xs:documentation>Hungarian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="hup">
+				<xs:annotation>
+					<xs:documentation>Hupa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="iba">
+				<xs:annotation>
+					<xs:documentation>Iban</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ibo">
+				<xs:annotation>
+					<xs:documentation>Igbo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ice">
+				<xs:annotation>
+					<xs:documentation>Icelandic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ido">
+				<xs:annotation>
+					<xs:documentation>Ido</xs:documentation>
+					<xs:documentation>Artificial language.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="iii">
+				<xs:annotation>
+					<xs:documentation>Sichuan Yi; Nuosu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ijo">
+				<xs:annotation>
+					<xs:documentation>Ijo languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="iku">
+				<xs:annotation>
+					<xs:documentation>Inuktitut</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ile">
+				<xs:annotation>
+					<xs:documentation>Interlingue; Occidental</xs:documentation>
+					<xs:documentation>Artificial language.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ilo">
+				<xs:annotation>
+					<xs:documentation>Iloko</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ina">
+				<xs:annotation>
+					<xs:documentation>Interlingua (International Auxiliary Language Association)</xs:documentation>
+					<xs:documentation>Artificial language.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="inc">
+				<xs:annotation>
+					<xs:documentation>Indic languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ind">
+				<xs:annotation>
+					<xs:documentation>Indonesian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ine">
+				<xs:annotation>
+					<xs:documentation>Indo-European languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="inh">
+				<xs:annotation>
+					<xs:documentation>Ingush</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ipk">
+				<xs:annotation>
+					<xs:documentation>Inupiaq</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ira">
+				<xs:annotation>
+					<xs:documentation>Iranian languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="iro">
+				<xs:annotation>
+					<xs:documentation>Iroquoian languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ita">
+				<xs:annotation>
+					<xs:documentation>Italian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="jav">
+				<xs:annotation>
+					<xs:documentation>Javanese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="jbo">
+				<xs:annotation>
+					<xs:documentation>Lojban</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="jpn">
+				<xs:annotation>
+					<xs:documentation>Japanese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="jpr">
+				<xs:annotation>
+					<xs:documentation>Judeo-Persian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="jrb">
+				<xs:annotation>
+					<xs:documentation>Judeo-Arabic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kaa">
+				<xs:annotation>
+					<xs:documentation>Kara-Kalpak</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kab">
+				<xs:annotation>
+					<xs:documentation>Kabyle</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kac">
+				<xs:annotation>
+					<xs:documentation>Kachin; Jingpho</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kal">
+				<xs:annotation>
+					<xs:documentation>Kalâtdlisut; Greenlandic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kam">
+				<xs:annotation>
+					<xs:documentation>Kamba</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kan">
+				<xs:annotation>
+					<xs:documentation>Kannada</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kar">
+				<xs:annotation>
+					<xs:documentation>Karen languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kas">
+				<xs:annotation>
+					<xs:documentation>Kashmiri</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kau">
+				<xs:annotation>
+					<xs:documentation>Kanuri</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kaw">
+				<xs:annotation>
+					<xs:documentation>Kawi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kaz">
+				<xs:annotation>
+					<xs:documentation>Kazakh</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kbd">
+				<xs:annotation>
+					<xs:documentation>Kabardian (Circassian)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kha">
+				<xs:annotation>
+					<xs:documentation>Khasi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="khi">
+				<xs:annotation>
+					<xs:documentation>Khoisan languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="khm">
+				<xs:annotation>
+					<xs:documentation>Central Khmer</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kho">
+				<xs:annotation>
+					<xs:documentation>Khotanese; Sakan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kik">
+				<xs:annotation>
+					<xs:documentation>Kikuyu; Gikuyu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kin">
+				<xs:annotation>
+					<xs:documentation>Kinyarwanda</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kir">
+				<xs:annotation>
+					<xs:documentation>Kirghiz; Kyrgyz</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kmb">
+				<xs:annotation>
+					<xs:documentation>Kimbundu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kok">
+				<xs:annotation>
+					<xs:documentation>Konkani</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kom">
+				<xs:annotation>
+					<xs:documentation>Komi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kon">
+				<xs:annotation>
+					<xs:documentation>Kongo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kor">
+				<xs:annotation>
+					<xs:documentation>Korean</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kos">
+				<xs:annotation>
+					<xs:documentation>Kusaiean (Caroline Islands)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kpe">
+				<xs:annotation>
+					<xs:documentation>Kpelle</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="krc">
+				<xs:annotation>
+					<xs:documentation>Karachay-Balkar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="krl">
+				<xs:annotation>
+					<xs:documentation>Karelian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kro">
+				<xs:annotation>
+					<xs:documentation>Kru languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kru">
+				<xs:annotation>
+					<xs:documentation>Kurukh</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kua">
+				<xs:annotation>
+					<xs:documentation>Kuanyama</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kum">
+				<xs:annotation>
+					<xs:documentation>Kumyk</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kur">
+				<xs:annotation>
+					<xs:documentation>Kurdish</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kut">
+				<xs:annotation>
+					<xs:documentation>Kutenai</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lad">
+				<xs:annotation>
+					<xs:documentation>Ladino</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lah">
+				<xs:annotation>
+					<xs:documentation>Lahnda</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lam">
+				<xs:annotation>
+					<xs:documentation>Lamba</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lao">
+				<xs:annotation>
+					<xs:documentation>Lao</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lat">
+				<xs:annotation>
+					<xs:documentation>Latin</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lav">
+				<xs:annotation>
+					<xs:documentation>Latvian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lez">
+				<xs:annotation>
+					<xs:documentation>Lezgian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lim">
+				<xs:annotation>
+					<xs:documentation>Limburgish</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lin">
+				<xs:annotation>
+					<xs:documentation>Lingala</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lit">
+				<xs:annotation>
+					<xs:documentation>Lithuanian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lol">
+				<xs:annotation>
+					<xs:documentation>Mongo-Nkundu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="loz">
+				<xs:annotation>
+					<xs:documentation>Lozi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ltz">
+				<xs:annotation>
+					<xs:documentation>Luxembourgish; Letzeburgesch</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lua">
+				<xs:annotation>
+					<xs:documentation>Luba-Lulua</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lub">
+				<xs:annotation>
+					<xs:documentation>Luba-Katanga</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lug">
+				<xs:annotation>
+					<xs:documentation>Ganda</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lui">
+				<xs:annotation>
+					<xs:documentation>Luiseño</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lun">
+				<xs:annotation>
+					<xs:documentation>Lunda</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="luo">
+				<xs:annotation>
+					<xs:documentation>Luo (Kenya and Tanzania)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lus">
+				<xs:annotation>
+					<xs:documentation>Lushai</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mac">
+				<xs:annotation>
+					<xs:documentation>Macedonian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mad">
+				<xs:annotation>
+					<xs:documentation>Madurese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mag">
+				<xs:annotation>
+					<xs:documentation>Magahi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mah">
+				<xs:annotation>
+					<xs:documentation>Marshallese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mai">
+				<xs:annotation>
+					<xs:documentation>Maithili</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mak">
+				<xs:annotation>
+					<xs:documentation>Makasar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mal">
+				<xs:annotation>
+					<xs:documentation>Malayalam</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="man">
+				<xs:annotation>
+					<xs:documentation>Mandingo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mao">
+				<xs:annotation>
+					<xs:documentation>Maori</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="map">
+				<xs:annotation>
+					<xs:documentation>Austronesian languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mar">
+				<xs:annotation>
+					<xs:documentation>Marathi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mas">
+				<xs:annotation>
+					<xs:documentation>Masai</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="may">
+				<xs:annotation>
+					<xs:documentation>Malay</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mdf">
+				<xs:annotation>
+					<xs:documentation>Moksha</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mdr">
+				<xs:annotation>
+					<xs:documentation>Mandar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="men">
+				<xs:annotation>
+					<xs:documentation>Mende</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mga">
+				<xs:annotation>
+					<xs:documentation>Irish, Middle (ca. 1100-1550)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mic">
+				<xs:annotation>
+					<xs:documentation>Mi&apos;kmaq; Micmac</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="min">
+				<xs:annotation>
+					<xs:documentation>Minangkabau</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mis">
+				<xs:annotation>
+					<xs:documentation>Uncoded languages</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mkh">
+				<xs:annotation>
+					<xs:documentation>Mon-Khmer languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mlg">
+				<xs:annotation>
+					<xs:documentation>Malagasy</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mlt">
+				<xs:annotation>
+					<xs:documentation>Maltese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mnc">
+				<xs:annotation>
+					<xs:documentation>Manchu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mni">
+				<xs:annotation>
+					<xs:documentation>Manipuri</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mno">
+				<xs:annotation>
+					<xs:documentation>Manobo languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="moh">
+				<xs:annotation>
+					<xs:documentation>Mohawk</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mol">
+				<xs:annotation>
+					<xs:documentation>Moldavian; Moldovan</xs:documentation>
+					<xs:documentation>DEPRECATED - use rum.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mon">
+				<xs:annotation>
+					<xs:documentation>Mongolian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mos">
+				<xs:annotation>
+					<xs:documentation>Mooré; Mossi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mul">
+				<xs:annotation>
+					<xs:documentation>Multiple languages</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mun">
+				<xs:annotation>
+					<xs:documentation>Munda languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mus">
+				<xs:annotation>
+					<xs:documentation>Creek</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mwl">
+				<xs:annotation>
+					<xs:documentation>Mirandese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mwr">
+				<xs:annotation>
+					<xs:documentation>Marwari</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="myn">
+				<xs:annotation>
+					<xs:documentation>Mayan languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="myv">
+				<xs:annotation>
+					<xs:documentation>Erzya</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nah">
+				<xs:annotation>
+					<xs:documentation>Nahuatl languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nai">
+				<xs:annotation>
+					<xs:documentation>North American Indian languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nap">
+				<xs:annotation>
+					<xs:documentation>Neapolitan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nau">
+				<xs:annotation>
+					<xs:documentation>Nauruan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nav">
+				<xs:annotation>
+					<xs:documentation>Navajo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nbl">
+				<xs:annotation>
+					<xs:documentation>Ndebele, South</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nde">
+				<xs:annotation>
+					<xs:documentation>Ndebele, North</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ndo">
+				<xs:annotation>
+					<xs:documentation>Ndonga</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nds">
+				<xs:annotation>
+					<xs:documentation>Low German; Low Saxon</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nep">
+				<xs:annotation>
+					<xs:documentation>Nepali</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="new">
+				<xs:annotation>
+					<xs:documentation>Newari; Nepal Bhasa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nia">
+				<xs:annotation>
+					<xs:documentation>Nias</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nic">
+				<xs:annotation>
+					<xs:documentation>Niger-Kordofanian languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="niu">
+				<xs:annotation>
+					<xs:documentation>Niuean</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nno">
+				<xs:annotation>
+					<xs:documentation>Norwegian Nynorsk</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nob">
+				<xs:annotation>
+					<xs:documentation>Norwegian Bokmål</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nog">
+				<xs:annotation>
+					<xs:documentation>Nogai</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="non">
+				<xs:annotation>
+					<xs:documentation>Old Norse</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nor">
+				<xs:annotation>
+					<xs:documentation>Norwegian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nqo">
+				<xs:annotation>
+					<xs:documentation>N&apos;Ko</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nso">
+				<xs:annotation>
+					<xs:documentation>Pedi; Sepedi; Northern Sotho</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nub">
+				<xs:annotation>
+					<xs:documentation>Nubian languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nwc">
+				<xs:annotation>
+					<xs:documentation>Classical Newari; Old Newari; Classical Nepal Bhasa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nya">
+				<xs:annotation>
+					<xs:documentation>Chichewa; Chewa; Nyanja</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nym">
+				<xs:annotation>
+					<xs:documentation>Nyamwezi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nyn">
+				<xs:annotation>
+					<xs:documentation>Nyankole</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nyo">
+				<xs:annotation>
+					<xs:documentation>Nyoro</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nzi">
+				<xs:annotation>
+					<xs:documentation>Nzima</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="oci">
+				<xs:annotation>
+					<xs:documentation>Occitan (post 1500)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="oji">
+				<xs:annotation>
+					<xs:documentation>Ojibwa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ori">
+				<xs:annotation>
+					<xs:documentation>Oriya</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="orm">
+				<xs:annotation>
+					<xs:documentation>Oromo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="osa">
+				<xs:annotation>
+					<xs:documentation>Osage</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="oss">
+				<xs:annotation>
+					<xs:documentation>Ossetian; Ossetic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ota">
+				<xs:annotation>
+					<xs:documentation>Turkish, Ottoman</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="oto">
+				<xs:annotation>
+					<xs:documentation>Otomian languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="paa">
+				<xs:annotation>
+					<xs:documentation>Papuan languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="pag">
+				<xs:annotation>
+					<xs:documentation>Pangasinan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="pal">
+				<xs:annotation>
+					<xs:documentation>Pahlavi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="pam">
+				<xs:annotation>
+					<xs:documentation>Pampanga; Kapampangan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="pan">
+				<xs:annotation>
+					<xs:documentation>Panjabi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="pap">
+				<xs:annotation>
+					<xs:documentation>Papiamento</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="pau">
+				<xs:annotation>
+					<xs:documentation>Palauan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="peo">
+				<xs:annotation>
+					<xs:documentation>Old Persian (ca. 600-400 B.C.)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="per">
+				<xs:annotation>
+					<xs:documentation>Persian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="phi">
+				<xs:annotation>
+					<xs:documentation>Philippine languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="phn">
+				<xs:annotation>
+					<xs:documentation>Phoenician</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="pli">
+				<xs:annotation>
+					<xs:documentation>Pali</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="pol">
+				<xs:annotation>
+					<xs:documentation>Polish</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="pon">
+				<xs:annotation>
+					<xs:documentation>Ponapeian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="por">
+				<xs:annotation>
+					<xs:documentation>Portuguese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="pra">
+				<xs:annotation>
+					<xs:documentation>Prakrit languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="pro">
+				<xs:annotation>
+					<xs:documentation>Provençal, Old (to 1500); Occitan, Old (to 1500)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="pus">
+				<xs:annotation>
+					<xs:documentation>Pushto; Pashto</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="qar">
+				<xs:annotation>
+					<xs:documentation>Aranés</xs:documentation>
+					<xs:documentation>ONIX local code.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="qav">
+				<xs:annotation>
+					<xs:documentation>Valencian</xs:documentation>
+					<xs:documentation>ONIX local code.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="que">
+				<xs:annotation>
+					<xs:documentation>Quechua</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="raj">
+				<xs:annotation>
+					<xs:documentation>Rajasthani</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="rap">
+				<xs:annotation>
+					<xs:documentation>Rapanui</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="rar">
+				<xs:annotation>
+					<xs:documentation>Rarotongan; Cook Islands Maori</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="roa">
+				<xs:annotation>
+					<xs:documentation>Romance languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="roh">
+				<xs:annotation>
+					<xs:documentation>Romansh</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="rom">
+				<xs:annotation>
+					<xs:documentation>Romany</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="rum">
+				<xs:annotation>
+					<xs:documentation>Romanian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="run">
+				<xs:annotation>
+					<xs:documentation>Rundi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="rup">
+				<xs:annotation>
+					<xs:documentation>Aromanian; Arumanian; Macedo-Romanian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="rus">
+				<xs:annotation>
+					<xs:documentation>Russian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sad">
+				<xs:annotation>
+					<xs:documentation>Sandawe</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sag">
+				<xs:annotation>
+					<xs:documentation>Sango</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sah">
+				<xs:annotation>
+					<xs:documentation>Yakut</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sai">
+				<xs:annotation>
+					<xs:documentation>South American Indian languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sal">
+				<xs:annotation>
+					<xs:documentation>Salishan languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sam">
+				<xs:annotation>
+					<xs:documentation>Samaritan Aramaic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="san">
+				<xs:annotation>
+					<xs:documentation>Sanskrit</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sas">
+				<xs:annotation>
+					<xs:documentation>Sasak</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sat">
+				<xs:annotation>
+					<xs:documentation>Santali</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="scc">
+				<xs:annotation>
+					<xs:documentation>Serbian</xs:documentation>
+					<xs:documentation>DEPRECATED - use srp.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="scn">
+				<xs:annotation>
+					<xs:documentation>Sicilian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sco">
+				<xs:annotation>
+					<xs:documentation>Scots (lallans)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="scr">
+				<xs:annotation>
+					<xs:documentation>Croatian</xs:documentation>
+					<xs:documentation>DEPRECATED - use hrv.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sel">
+				<xs:annotation>
+					<xs:documentation>Selkup</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sem">
+				<xs:annotation>
+					<xs:documentation>Semitic languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sga">
+				<xs:annotation>
+					<xs:documentation>Irish, Old (to 1100)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sgn">
+				<xs:annotation>
+					<xs:documentation>Sign languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="shn">
+				<xs:annotation>
+					<xs:documentation>Shan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sid">
+				<xs:annotation>
+					<xs:documentation>Sidamo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sin">
+				<xs:annotation>
+					<xs:documentation>Sinhala; Sinhalese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sio">
+				<xs:annotation>
+					<xs:documentation>Siouan languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sit">
+				<xs:annotation>
+					<xs:documentation>Sino-Tibetan languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sla">
+				<xs:annotation>
+					<xs:documentation>Slavic languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="slo">
+				<xs:annotation>
+					<xs:documentation>Slovak</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="slv">
+				<xs:annotation>
+					<xs:documentation>Slovenian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sma">
+				<xs:annotation>
+					<xs:documentation>Southern Sami</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sme">
+				<xs:annotation>
+					<xs:documentation>Northern Sami</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="smi">
+				<xs:annotation>
+					<xs:documentation>Sami languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="smj">
+				<xs:annotation>
+					<xs:documentation>Lule Sami</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="smn">
+				<xs:annotation>
+					<xs:documentation>Inari Sami</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="smo">
+				<xs:annotation>
+					<xs:documentation>Samoan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sms">
+				<xs:annotation>
+					<xs:documentation>Skolt Sami</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sna">
+				<xs:annotation>
+					<xs:documentation>Shona</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="snd">
+				<xs:annotation>
+					<xs:documentation>Sindhi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="snk">
+				<xs:annotation>
+					<xs:documentation>Soninke</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sog">
+				<xs:annotation>
+					<xs:documentation>Sogdian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="som">
+				<xs:annotation>
+					<xs:documentation>Somali</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="son">
+				<xs:annotation>
+					<xs:documentation>Songhai languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sot">
+				<xs:annotation>
+					<xs:documentation>Sotho; Sesotho</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="spa">
+				<xs:annotation>
+					<xs:documentation>Spanish</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="srd">
+				<xs:annotation>
+					<xs:documentation>Sardinian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="srn">
+				<xs:annotation>
+					<xs:documentation>Sranan Tongo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="srp">
+				<xs:annotation>
+					<xs:documentation>Serbian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="srr">
+				<xs:annotation>
+					<xs:documentation>Serer</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ssa">
+				<xs:annotation>
+					<xs:documentation>Nilo-Saharan languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ssw">
+				<xs:annotation>
+					<xs:documentation>Swazi; Swati</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="suk">
+				<xs:annotation>
+					<xs:documentation>Sukuma</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sun">
+				<xs:annotation>
+					<xs:documentation>Sundanese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sus">
+				<xs:annotation>
+					<xs:documentation>Susu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sux">
+				<xs:annotation>
+					<xs:documentation>Sumerian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="swa">
+				<xs:annotation>
+					<xs:documentation>Swahili</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="swe">
+				<xs:annotation>
+					<xs:documentation>Swedish</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="syc">
+				<xs:annotation>
+					<xs:documentation>Classical Syriac</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="syr">
+				<xs:annotation>
+					<xs:documentation>Syriac</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tah">
+				<xs:annotation>
+					<xs:documentation>Tahitian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tai">
+				<xs:annotation>
+					<xs:documentation>Tai languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tam">
+				<xs:annotation>
+					<xs:documentation>Tamil</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tat">
+				<xs:annotation>
+					<xs:documentation>Tatar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tel">
+				<xs:annotation>
+					<xs:documentation>Telugu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tem">
+				<xs:annotation>
+					<xs:documentation>Temne; Time</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ter">
+				<xs:annotation>
+					<xs:documentation>Terena</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tet">
+				<xs:annotation>
+					<xs:documentation>Tetum</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tgk">
+				<xs:annotation>
+					<xs:documentation>Tajik</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tgl">
+				<xs:annotation>
+					<xs:documentation>Tagalog</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tha">
+				<xs:annotation>
+					<xs:documentation>Thai</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tib">
+				<xs:annotation>
+					<xs:documentation>Tibetan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tig">
+				<xs:annotation>
+					<xs:documentation>Tigré</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tir">
+				<xs:annotation>
+					<xs:documentation>Tigrinya</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tiv">
+				<xs:annotation>
+					<xs:documentation>Tiv</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tkl">
+				<xs:annotation>
+					<xs:documentation>Tokelauan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tlh">
+				<xs:annotation>
+					<xs:documentation>Klingon; tlhIngan-Hol</xs:documentation>
+					<xs:documentation>Artificial language.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tli">
+				<xs:annotation>
+					<xs:documentation>Tlingit</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tmh">
+				<xs:annotation>
+					<xs:documentation>Tamashek</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tog">
+				<xs:annotation>
+					<xs:documentation>Tonga (Nyasa)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ton">
+				<xs:annotation>
+					<xs:documentation>Tongan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tpi">
+				<xs:annotation>
+					<xs:documentation>Tok Pisin</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tsi">
+				<xs:annotation>
+					<xs:documentation>Tsimshian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tsn">
+				<xs:annotation>
+					<xs:documentation>Tswana</xs:documentation>
+					<xs:documentation>AKA Setswana.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tso">
+				<xs:annotation>
+					<xs:documentation>Tsonga</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tuk">
+				<xs:annotation>
+					<xs:documentation>Turkmen</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tum">
+				<xs:annotation>
+					<xs:documentation>Tumbuka</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tup">
+				<xs:annotation>
+					<xs:documentation>Tupi languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tur">
+				<xs:annotation>
+					<xs:documentation>Turkish</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tut">
+				<xs:annotation>
+					<xs:documentation>Altaic languages</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tvl">
+				<xs:annotation>
+					<xs:documentation>Tuvaluan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="twi">
+				<xs:annotation>
+					<xs:documentation>Twi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tyv">
+				<xs:annotation>
+					<xs:documentation>Tuvinian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="udm">
+				<xs:annotation>
+					<xs:documentation>Udmurt</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="uga">
+				<xs:annotation>
+					<xs:documentation>Ugaritic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="uig">
+				<xs:annotation>
+					<xs:documentation>Uighur; Uyghur</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ukr">
+				<xs:annotation>
+					<xs:documentation>Ukrainian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="umb">
+				<xs:annotation>
+					<xs:documentation>Umbundu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="und">
+				<xs:annotation>
+					<xs:documentation>Undetermined language</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="urd">
+				<xs:annotation>
+					<xs:documentation>Urdu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="uzb">
+				<xs:annotation>
+					<xs:documentation>Uzbek</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="vai">
+				<xs:annotation>
+					<xs:documentation>Vai</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ven">
+				<xs:annotation>
+					<xs:documentation>Venda</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="vie">
+				<xs:annotation>
+					<xs:documentation>Vietnamese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="vol">
+				<xs:annotation>
+					<xs:documentation>Volapük</xs:documentation>
+					<xs:documentation>Artificial language.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="vot">
+				<xs:annotation>
+					<xs:documentation>Votic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="wak">
+				<xs:annotation>
+					<xs:documentation>Wakashan languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="wal">
+				<xs:annotation>
+					<xs:documentation>Wolaitta; Wolaytta</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="war">
+				<xs:annotation>
+					<xs:documentation>Waray</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="was">
+				<xs:annotation>
+					<xs:documentation>Washo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="wel">
+				<xs:annotation>
+					<xs:documentation>Welsh</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="wen">
+				<xs:annotation>
+					<xs:documentation>Sorbian languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="wln">
+				<xs:annotation>
+					<xs:documentation>Walloon</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="wol">
+				<xs:annotation>
+					<xs:documentation>Wolof</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="xal">
+				<xs:annotation>
+					<xs:documentation>Kalmyk</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="xho">
+				<xs:annotation>
+					<xs:documentation>Xhosa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="yao">
+				<xs:annotation>
+					<xs:documentation>Yao</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="yap">
+				<xs:annotation>
+					<xs:documentation>Yapese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="yid">
+				<xs:annotation>
+					<xs:documentation>Yiddish</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="yor">
+				<xs:annotation>
+					<xs:documentation>Yoruba</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ypk">
+				<xs:annotation>
+					<xs:documentation>Yupik languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="zap">
+				<xs:annotation>
+					<xs:documentation>Zapotec</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="zbl">
+				<xs:annotation>
+					<xs:documentation>Blissymbols; Blissymbolics; Bliss</xs:documentation>
+					<xs:documentation>Artificial language.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="zen">
+				<xs:annotation>
+					<xs:documentation>Zenaga</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="zha">
+				<xs:annotation>
+					<xs:documentation>Zhuang; Chuang</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="znd">
+				<xs:annotation>
+					<xs:documentation>Zande languages</xs:documentation>
+					<xs:documentation>Collective name.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="zul">
+				<xs:annotation>
+					<xs:documentation>Zulu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="zun">
+				<xs:annotation>
+					<xs:documentation>Zuni</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="zxx">
+				<xs:annotation>
+					<xs:documentation>No linguistic content</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="zza">
+				<xs:annotation>
+					<xs:documentation>Zaza; Dimili; Dimli; Kirdki; Kirmanjki; Zazaki</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List75">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 75">Person date role</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="007">
+				<xs:annotation>
+					<xs:documentation>Date of birth</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="008">
+				<xs:annotation>
+					<xs:documentation>Date of death</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List76">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 76">Product form feature value - DVD region codes</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="0">
+				<xs:annotation>
+					<xs:documentation>All regions</xs:documentation>
+					<xs:documentation>DVD or Blu-Ray.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="1">
+				<xs:annotation>
+					<xs:documentation>DVD region 1</xs:documentation>
+					<xs:documentation>US, US Territories, Canada.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="2">
+				<xs:annotation>
+					<xs:documentation>DVD region 2</xs:documentation>
+					<xs:documentation>Japan, Europe, South Africa and Middle East (including Egypt).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="3">
+				<xs:annotation>
+					<xs:documentation>DVD region 3</xs:documentation>
+					<xs:documentation>Southeast Asia, Hong Kong, Macau, South Korea, and Taiwan.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="4">
+				<xs:annotation>
+					<xs:documentation>DVD region 4</xs:documentation>
+					<xs:documentation>Australia, New Zealand, Pacific Islands, Central America, Mexico, South America and the Caribbean.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="5">
+				<xs:annotation>
+					<xs:documentation>DVD region 5</xs:documentation>
+					<xs:documentation>Eastern Europe (former Soviet Union), Indian subcontinent, Africa, North Korea and Mongolia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="6">
+				<xs:annotation>
+					<xs:documentation>DVD region 6</xs:documentation>
+					<xs:documentation>People&apos;s Republic of China (except Macau and Hong Kong).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="7">
+				<xs:annotation>
+					<xs:documentation>DVD region 7</xs:documentation>
+					<xs:documentation>Reserved for future use.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="8">
+				<xs:annotation>
+					<xs:documentation>DVD region 8</xs:documentation>
+					<xs:documentation>International venues: aircraft, cruise ships etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A">
+				<xs:annotation>
+					<xs:documentation>Blu-Ray region A</xs:documentation>
+					<xs:documentation>North America, Central America, South America, Japan, Taiwan, North Korea, South Korea, Hong Kong, and Southeast Asia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B">
+				<xs:annotation>
+					<xs:documentation>Blu-Ray region B</xs:documentation>
+					<xs:documentation>Most of Europe, Greenland, French territories, Middle East, Africa, Australia, and New Zealand, plus all of Oceania.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="C">
+				<xs:annotation>
+					<xs:documentation>Blu-Ray region C</xs:documentation>
+					<xs:documentation>India, Bangladesh, Nepal, Mainland China, Pakistan, Russia, Ukraine, Belarus, Central, and South Asia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List77">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 77">North American school or college grade</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="P">
+				<xs:annotation>
+					<xs:documentation>Preschool</xs:documentation>
+					<xs:documentation>Age typically 0-4 years.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="K">
+				<xs:annotation>
+					<xs:documentation>Kindergarten</xs:documentation>
+					<xs:documentation>Age typically 5 years.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="1">
+				<xs:annotation>
+					<xs:documentation>First Grade</xs:documentation>
+					<xs:documentation>Age typically 6 years.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="2">
+				<xs:annotation>
+					<xs:documentation>Second Grade</xs:documentation>
+					<xs:documentation>Age typically 7 years.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="3">
+				<xs:annotation>
+					<xs:documentation>Third Grade</xs:documentation>
+					<xs:documentation>Age typically 8 years.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="4">
+				<xs:annotation>
+					<xs:documentation>Fourth Grade</xs:documentation>
+					<xs:documentation>Age typically 9 years.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="5">
+				<xs:annotation>
+					<xs:documentation>Fifth Grade</xs:documentation>
+					<xs:documentation>Age typically 10 years.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="6">
+				<xs:annotation>
+					<xs:documentation>Sixth Grade</xs:documentation>
+					<xs:documentation>Age typically 11 years.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="7">
+				<xs:annotation>
+					<xs:documentation>Seventh Grade</xs:documentation>
+					<xs:documentation>Age typically 12 years.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="8">
+				<xs:annotation>
+					<xs:documentation>Eighth Grade</xs:documentation>
+					<xs:documentation>Age typically 13 years.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="9">
+				<xs:annotation>
+					<xs:documentation>Ninth Grade</xs:documentation>
+					<xs:documentation>High School Freshman - age typically 14 years.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Tenth Grade</xs:documentation>
+					<xs:documentation>High School Sophomore - age typically 15 years.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Eleventh Grade</xs:documentation>
+					<xs:documentation>High School Junior - age typically 16 years.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Twelfth Grade</xs:documentation>
+					<xs:documentation>High School Senior - age typically 17 years.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>College Freshman</xs:documentation>
+					<xs:documentation>Age typically 18 years.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>College Sophomore</xs:documentation>
+					<xs:documentation>Age typically 19 years.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>College Junior</xs:documentation>
+					<xs:documentation>Age typically 20 years.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>College Senior</xs:documentation>
+					<xs:documentation>Age typically 21 years.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>College Graduate Student</xs:documentation>
+					<xs:documentation>Age typically 22+ years.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List78">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 78">Product form detail</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="A101">
+				<xs:annotation>
+					<xs:documentation>CD standard audio format</xs:documentation>
+					<xs:documentation>CD &apos;red book&apos; format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A102">
+				<xs:annotation>
+					<xs:documentation>SACD super audio format</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A103">
+				<xs:annotation>
+					<xs:documentation>MP3 format</xs:documentation>
+					<xs:documentation>MPEG-1/2 Audio Layer III file.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A104">
+				<xs:annotation>
+					<xs:documentation>WAV format</xs:documentation>
+					<xs:documentation>Waveform audio file.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A105">
+				<xs:annotation>
+					<xs:documentation>Real Audio format</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A106">
+				<xs:annotation>
+					<xs:documentation>WMA</xs:documentation>
+					<xs:documentation>Windows Media Audio format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A107">
+				<xs:annotation>
+					<xs:documentation>AAC</xs:documentation>
+					<xs:documentation>Advanced Audio Coding format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A108">
+				<xs:annotation>
+					<xs:documentation>Ogg/Vorbis</xs:documentation>
+					<xs:documentation>Vorbis audio format in the Ogg container.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A109">
+				<xs:annotation>
+					<xs:documentation>Audible</xs:documentation>
+					<xs:documentation>Audio format proprietary to Audible.com.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A110">
+				<xs:annotation>
+					<xs:documentation>FLAC</xs:documentation>
+					<xs:documentation>Free lossless audio codec.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A111">
+				<xs:annotation>
+					<xs:documentation>AIFF</xs:documentation>
+					<xs:documentation>Audio Interchangeable File Format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A112">
+				<xs:annotation>
+					<xs:documentation>ALAC</xs:documentation>
+					<xs:documentation>Apple Lossless Audio Codec.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A201">
+				<xs:annotation>
+					<xs:documentation>DAISY 2: full audio with title only (no navigation)</xs:documentation>
+					<xs:documentation>Deprecated, as does not meet DAISY 2 standard. Use conventional audiobook codes instead.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A202">
+				<xs:annotation>
+					<xs:documentation>DAISY 2: full audio with navigation (no text)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A203">
+				<xs:annotation>
+					<xs:documentation>DAISY 2: full audio with navigation and partial text</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A204">
+				<xs:annotation>
+					<xs:documentation>DAISY 2: full audio with navigation and full text</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A205">
+				<xs:annotation>
+					<xs:documentation>DAISY 2: full text with navigation and partial audio</xs:documentation>
+					<xs:documentation>Reading systems may provide full audio via text-to-speech.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A206">
+				<xs:annotation>
+					<xs:documentation>DAISY 2: full text with navigation and no audio</xs:documentation>
+					<xs:documentation>Reading systems may provide full audio via text-to-speech.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A207">
+				<xs:annotation>
+					<xs:documentation>DAISY 3: full audio with title only (no navigation)</xs:documentation>
+					<xs:documentation>Deprecated, as does not meet DAISY 3 standard. Use conventional audiobook codes instead.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A208">
+				<xs:annotation>
+					<xs:documentation>DAISY 3: full audio with navigation (no text)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A209">
+				<xs:annotation>
+					<xs:documentation>DAISY 3: full audio with navigation and partial text</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A210">
+				<xs:annotation>
+					<xs:documentation>DAISY 3: full audio with navigation and full text</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A211">
+				<xs:annotation>
+					<xs:documentation>DAISY 3: full text with navigation and some audio</xs:documentation>
+					<xs:documentation>Reading systems may provide full audio via text-to-speech.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A212">
+				<xs:annotation>
+					<xs:documentation>DAISY 3: full text with navigation (no audio)</xs:documentation>
+					<xs:documentation>Reading systems may provide full audio via text-to-speech.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A301">
+				<xs:annotation>
+					<xs:documentation>Standalone audio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A302">
+				<xs:annotation>
+					<xs:documentation>Readalong audio</xs:documentation>
+					<xs:documentation>Audio intended exclusively for use alongside a printed copy of the book. Most often a children&apos;s product. Normally contains instructions such as &apos;turn the page now&apos; and other references to the printed item, and is usually sold packaged together with a printed copy.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A303">
+				<xs:annotation>
+					<xs:documentation>Playalong audio</xs:documentation>
+					<xs:documentation>Audio intended for musical accompaniment, eg &apos;Music minus one&apos;, etc, often used for music learning. Includes singalong backing audio for musical learning or for Karaoke-style entertainment.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A304">
+				<xs:annotation>
+					<xs:documentation>Speakalong audio</xs:documentation>
+					<xs:documentation>Audio intended for language learning, which includes speech plus gaps intended to be filled by the listener.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B101">
+				<xs:annotation>
+					<xs:documentation>Mass market (rack) paperback</xs:documentation>
+					<xs:documentation>In North America, a category of paperback characterized partly by page size (typically 4¼ x 7 1/8 inches) and partly by target market and terms of trade. Use with Product Form code BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B102">
+				<xs:annotation>
+					<xs:documentation>Trade paperback (US)</xs:documentation>
+					<xs:documentation>In North America, a category of paperback characterized partly by page size and partly by target market and terms of trade. AKA &apos;quality paperback&apos;, and including textbooks. Most paperback books sold in North America except &apos;mass-market&apos; (B101) and &apos;tall rack&apos; (B107) are correctly described with this code. Use with Product Form code BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B103">
+				<xs:annotation>
+					<xs:documentation>Digest format paperback</xs:documentation>
+					<xs:documentation>In North America, a category of paperback characterized by page size and generally used for children&apos;s books; use with Product Form code BC. Note: was wrongly shown as B102 (duplicate entry) in Issue 3.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B104">
+				<xs:annotation>
+					<xs:documentation>A-format paperback</xs:documentation>
+					<xs:documentation>In UK, a category of paperback characterized by page size (normally 178 x 111 mm approx); use with Product Form code BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B105">
+				<xs:annotation>
+					<xs:documentation>B-format paperback</xs:documentation>
+					<xs:documentation>In UK, a category of paperback characterized by page size (normally 198 x 129 mm approx); use with Product Form code BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B106">
+				<xs:annotation>
+					<xs:documentation>Trade paperback (UK)</xs:documentation>
+					<xs:documentation>In UK, a category of paperback characterized partly by size (usually in traditional hardback dimensions), and often used for paperback originals; use with Product Form code BC (replaces &apos;C-format&apos; from former List 8).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B107">
+				<xs:annotation>
+					<xs:documentation>Tall rack paperback (US)</xs:documentation>
+					<xs:documentation>In North America, a category of paperback characterised partly by page size and partly by target market and terms of trade; use with Product Form code BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B108">
+				<xs:annotation>
+					<xs:documentation>A5 size Tankobon</xs:documentation>
+					<xs:documentation>210x148mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B109">
+				<xs:annotation>
+					<xs:documentation>JIS B5 size Tankobon</xs:documentation>
+					<xs:documentation>Japanese B-series size, 257x182mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B110">
+				<xs:annotation>
+					<xs:documentation>JIS B6 size Tankobon</xs:documentation>
+					<xs:documentation>Japanese B-series size, 182x128mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B111">
+				<xs:annotation>
+					<xs:documentation>A6 size Bunko</xs:documentation>
+					<xs:documentation>148x105mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B112">
+				<xs:annotation>
+					<xs:documentation>B40-dori Shinsho</xs:documentation>
+					<xs:documentation>Japanese format, 182x103mm or 173x105mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B113">
+				<xs:annotation>
+					<xs:documentation>Pocket (Sweden)</xs:documentation>
+					<xs:documentation>A Swedish paperback format, use with Product Form Code BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B114">
+				<xs:annotation>
+					<xs:documentation>Storpocket (Sweden)</xs:documentation>
+					<xs:documentation>A Swedish paperback format, use with Product Form Code BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B115">
+				<xs:annotation>
+					<xs:documentation>Kartonnage (Sweden)</xs:documentation>
+					<xs:documentation>A Swedish hardback format, use with Product Form Code BB.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B116">
+				<xs:annotation>
+					<xs:documentation>Flexband (Sweden)</xs:documentation>
+					<xs:documentation>A Swedish softback format, use with Product Form Code BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B117">
+				<xs:annotation>
+					<xs:documentation>Mook</xs:documentation>
+					<xs:documentation>In Japan, a softback book in the format of a magazine but sold like a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B118">
+				<xs:annotation>
+					<xs:documentation>Dwarsligger</xs:documentation>
+					<xs:documentation>Also called &apos;Flipback&apos;. A softback book in a specially compact proprietary format with pages printed in landscape on very thin paper and bound along the long (top) edge - see www.dwarsligger.com.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B119">
+				<xs:annotation>
+					<xs:documentation>46 size</xs:documentation>
+					<xs:documentation>Japanese format: 188x127mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B120">
+				<xs:annotation>
+					<xs:documentation>46-Henkei size</xs:documentation>
+					<xs:documentation>Japanese format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B121">
+				<xs:annotation>
+					<xs:documentation>A4</xs:documentation>
+					<xs:documentation>297x210mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B122">
+				<xs:annotation>
+					<xs:documentation>A4-Henkei size</xs:documentation>
+					<xs:documentation>Japanese format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B123">
+				<xs:annotation>
+					<xs:documentation>A5-Henkei size</xs:documentation>
+					<xs:documentation>Japanese format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B124">
+				<xs:annotation>
+					<xs:documentation>B5-Henkei size</xs:documentation>
+					<xs:documentation>Japanese format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B125">
+				<xs:annotation>
+					<xs:documentation>B6-Henkei size</xs:documentation>
+					<xs:documentation>Japanese format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B126">
+				<xs:annotation>
+					<xs:documentation>AB size</xs:documentation>
+					<xs:documentation>257x210mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B127">
+				<xs:annotation>
+					<xs:documentation>JIS B7 size</xs:documentation>
+					<xs:documentation>Japanese B-series size, 128x91mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B128">
+				<xs:annotation>
+					<xs:documentation>Kiku size</xs:documentation>
+					<xs:documentation>Japanese format, 218x152mm or 227x152mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B129">
+				<xs:annotation>
+					<xs:documentation>Kiku-Henkei size</xs:documentation>
+					<xs:documentation>Japanese format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B130">
+				<xs:annotation>
+					<xs:documentation>JIS B4 size</xs:documentation>
+					<xs:documentation>Japanese B-series size, 364x257mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B201">
+				<xs:annotation>
+					<xs:documentation>Coloring / join-the-dot book</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B202">
+				<xs:annotation>
+					<xs:documentation>Lift-the-flap book</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B203">
+				<xs:annotation>
+					<xs:documentation>Fuzzy book</xs:documentation>
+					<xs:documentation>DEPRECATED because of ambiguity - use B210, B214 or B215 as appropriate.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B204">
+				<xs:annotation>
+					<xs:documentation>Miniature book</xs:documentation>
+					<xs:documentation>Note: was wrongly shown as B203 (duplicate entry) in Issue 3.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B205">
+				<xs:annotation>
+					<xs:documentation>Moving picture / flicker book</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B206">
+				<xs:annotation>
+					<xs:documentation>Pop-up book</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B207">
+				<xs:annotation>
+					<xs:documentation>Scented / &apos;smelly&apos; book</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B208">
+				<xs:annotation>
+					<xs:documentation>Sound story / &apos;noisy&apos; book</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B209">
+				<xs:annotation>
+					<xs:documentation>Sticker book</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B210">
+				<xs:annotation>
+					<xs:documentation>Touch-and-feel book</xs:documentation>
+					<xs:documentation>A book whose pages have a variety of textured inserts designed to stimulate tactile exploration: see also B214 and B215.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B211">
+				<xs:annotation>
+					<xs:documentation>Toy / die-cut book</xs:documentation>
+					<xs:documentation>DEPRECATED - use B212 or B213 as appropriate.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B212">
+				<xs:annotation>
+					<xs:documentation>Die-cut book</xs:documentation>
+					<xs:documentation>A book which is cut into a distinctive non-rectilinear shape and/or in which holes or shapes have been cut internally. (&apos;Die-cut&apos; is used here as a convenient shorthand, and does not imply strict limitation to a particular production process.).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B213">
+				<xs:annotation>
+					<xs:documentation>Book-as-toy</xs:documentation>
+					<xs:documentation>A book which is also a toy, or which incorporates a toy as an integral part. (Do not, however, use B213 for a multiple-item product which includes a book and a toy as separate items.).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B214">
+				<xs:annotation>
+					<xs:documentation>Soft-to-touch book</xs:documentation>
+					<xs:documentation>A book whose cover has a soft textured finish, typically over board.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B215">
+				<xs:annotation>
+					<xs:documentation>Fuzzy-felt book</xs:documentation>
+					<xs:documentation>A book with detachable felt pieces and textured pages on which they can be arranged.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B221">
+				<xs:annotation>
+					<xs:documentation>Picture book</xs:documentation>
+					<xs:documentation>Children&apos;s picture book: use with applicable Product Form code.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B222">
+				<xs:annotation>
+					<xs:documentation>&apos;Carousel&apos; book</xs:documentation>
+					<xs:documentation>(aka &apos;Star&apos; book). Tax treatment of products may differ from that of products with similar codes such as Book as toy or Pop-up book).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B301">
+				<xs:annotation>
+					<xs:documentation>Loose leaf - sheets and binder</xs:documentation>
+					<xs:documentation>Use with Product Form code BD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B302">
+				<xs:annotation>
+					<xs:documentation>Loose leaf - binder only</xs:documentation>
+					<xs:documentation>Use with Product Form code BD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B303">
+				<xs:annotation>
+					<xs:documentation>Loose leaf - sheets only</xs:documentation>
+					<xs:documentation>Use with Product Form code BD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B304">
+				<xs:annotation>
+					<xs:documentation>Sewn</xs:documentation>
+					<xs:documentation>AKA stitched; for &apos;saddle-sewn&apos;, see code B310.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B305">
+				<xs:annotation>
+					<xs:documentation>Unsewn / adhesive bound</xs:documentation>
+					<xs:documentation>Including &apos;perfect bound&apos;, &apos;glued&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B306">
+				<xs:annotation>
+					<xs:documentation>Library binding</xs:documentation>
+					<xs:documentation>Strengthened binding intended for libraries.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B307">
+				<xs:annotation>
+					<xs:documentation>Reinforced binding</xs:documentation>
+					<xs:documentation>Strengthened binding, not specifically intended for libraries.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B308">
+				<xs:annotation>
+					<xs:documentation>Half bound</xs:documentation>
+					<xs:documentation>Must be accompanied by a code specifiying a material, eg &apos;half-bound real leather&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B309">
+				<xs:annotation>
+					<xs:documentation>Quarter bound</xs:documentation>
+					<xs:documentation>Must be accompanied by a code specifiying a material, eg &apos;quarter bound real leather&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B310">
+				<xs:annotation>
+					<xs:documentation>Saddle-sewn</xs:documentation>
+					<xs:documentation>AKA &apos;saddle-stitched&apos; or &apos;wire-stitched&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B311">
+				<xs:annotation>
+					<xs:documentation>Comb bound</xs:documentation>
+					<xs:documentation>Round or oval plastic forms in a clamp-like configuration: use with Product Form code BE.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B312">
+				<xs:annotation>
+					<xs:documentation>Wire-O</xs:documentation>
+					<xs:documentation>Twin loop metal or plastic spine: use with Product Form code BE.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B313">
+				<xs:annotation>
+					<xs:documentation>Concealed wire</xs:documentation>
+					<xs:documentation>Cased over Wire-O binding: use with Product Form code BE.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B401">
+				<xs:annotation>
+					<xs:documentation>Cloth over boards</xs:documentation>
+					<xs:documentation>AKA fabric, linen over boards.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B402">
+				<xs:annotation>
+					<xs:documentation>Paper over boards</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B403">
+				<xs:annotation>
+					<xs:documentation>Leather, real</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B404">
+				<xs:annotation>
+					<xs:documentation>Leather, imitation</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B405">
+				<xs:annotation>
+					<xs:documentation>Leather, bonded</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B406">
+				<xs:annotation>
+					<xs:documentation>Vellum</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B407">
+				<xs:annotation>
+					<xs:documentation>Plastic</xs:documentation>
+					<xs:documentation>DEPRECATED - use new B412 or B413 as appropriate.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B408">
+				<xs:annotation>
+					<xs:documentation>Vinyl</xs:documentation>
+					<xs:documentation>DEPRECATED - use new B412 or B414 as appropriate.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B409">
+				<xs:annotation>
+					<xs:documentation>Cloth</xs:documentation>
+					<xs:documentation>Cloth, not necessarily over boards - cf B401.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B410">
+				<xs:annotation>
+					<xs:documentation>Imitation cloth</xs:documentation>
+					<xs:documentation>Spanish &apos;simil-tela&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B411">
+				<xs:annotation>
+					<xs:documentation>Velvet</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B412">
+				<xs:annotation>
+					<xs:documentation>Flexible plastic/vinyl cover</xs:documentation>
+					<xs:documentation>AKA &apos;flexibound&apos;: use with Product Form code BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B413">
+				<xs:annotation>
+					<xs:documentation>Plastic-covered</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B414">
+				<xs:annotation>
+					<xs:documentation>Vinyl-covered</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B415">
+				<xs:annotation>
+					<xs:documentation>Laminated cover</xs:documentation>
+					<xs:documentation>Book, laminating material unspecified: use L101 for &apos;whole product laminated&apos;, eg a laminated sheet map or wallchart.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B501">
+				<xs:annotation>
+					<xs:documentation>With dust jacket</xs:documentation>
+					<xs:documentation>Type unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B502">
+				<xs:annotation>
+					<xs:documentation>With printed dust jacket</xs:documentation>
+					<xs:documentation>Used to distinguish from B503.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B503">
+				<xs:annotation>
+					<xs:documentation>With translucent dust cover</xs:documentation>
+					<xs:documentation>With translucent paper or plastic protective cover.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B504">
+				<xs:annotation>
+					<xs:documentation>With flaps</xs:documentation>
+					<xs:documentation>For paperback with flaps.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B505">
+				<xs:annotation>
+					<xs:documentation>With thumb index</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B506">
+				<xs:annotation>
+					<xs:documentation>With ribbon marker(s)</xs:documentation>
+					<xs:documentation>If the number of markers is significant, it can be stated as free text in &lt;ProductFormDescription>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B507">
+				<xs:annotation>
+					<xs:documentation>With zip fastener</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B508">
+				<xs:annotation>
+					<xs:documentation>With button snap fastener</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B509">
+				<xs:annotation>
+					<xs:documentation>With leather edge lining</xs:documentation>
+					<xs:documentation>AKA yapp edge?.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B510">
+				<xs:annotation>
+					<xs:documentation>Rough front</xs:documentation>
+					<xs:documentation>With edge trimming such that the front edge is ragged, not neatly and squarely trimmed: AKA deckle edge, feather edge, uncut edge, rough cut.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B601">
+				<xs:annotation>
+					<xs:documentation>Turn-around book</xs:documentation>
+					<xs:documentation>A book in which half the content is printed upside-down, to be read the other way round.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B602">
+				<xs:annotation>
+					<xs:documentation>Unflipped manga format</xs:documentation>
+					<xs:documentation>Manga with pages and panels in the sequence of the original Japanese, but with Western text.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B701">
+				<xs:annotation>
+					<xs:documentation>UK Uncontracted Braille</xs:documentation>
+					<xs:documentation>Single letters only. Was formerly identified as UK Braille Grade 1.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B702">
+				<xs:annotation>
+					<xs:documentation>UK Contracted Braille</xs:documentation>
+					<xs:documentation>With some letter combinations. Was formerly identified as UK Braille Grade 2.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B703">
+				<xs:annotation>
+					<xs:documentation>US Braille</xs:documentation>
+					<xs:documentation>DEPRECATED- use B704/B705 as appropriate instead.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B704">
+				<xs:annotation>
+					<xs:documentation>US Uncontracted Braille</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B705">
+				<xs:annotation>
+					<xs:documentation>US Contracted Braille</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B706">
+				<xs:annotation>
+					<xs:documentation>Unified English Braille</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B707">
+				<xs:annotation>
+					<xs:documentation>Moon</xs:documentation>
+					<xs:documentation>Moon embossed alphabet, used by some print-impaired readers who have difficulties with Braille.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D101">
+				<xs:annotation>
+					<xs:documentation>Real Video format</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D102">
+				<xs:annotation>
+					<xs:documentation>Quicktime format</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D103">
+				<xs:annotation>
+					<xs:documentation>AVI format</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D104">
+				<xs:annotation>
+					<xs:documentation>Windows Media Video format</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D105">
+				<xs:annotation>
+					<xs:documentation>MPEG-4</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D201">
+				<xs:annotation>
+					<xs:documentation>MS-DOS</xs:documentation>
+					<xs:documentation>Use with an applicable Product Form code D*; note that more detail of operating system requirements can be given in a Product Form Feature composite.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D202">
+				<xs:annotation>
+					<xs:documentation>Windows</xs:documentation>
+					<xs:documentation>Use with an applicable Product Form code D*; see note on D201.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D203">
+				<xs:annotation>
+					<xs:documentation>Macintosh</xs:documentation>
+					<xs:documentation>Use with an applicable Product Form code D*; see note on D201.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D204">
+				<xs:annotation>
+					<xs:documentation>UNIX / LINUX</xs:documentation>
+					<xs:documentation>Use with an applicable Product Form code D*; see note on D201.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D205">
+				<xs:annotation>
+					<xs:documentation>Other operating system(s)</xs:documentation>
+					<xs:documentation>Use with an applicable Product Form code D*; see note on D201.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D206">
+				<xs:annotation>
+					<xs:documentation>Palm OS</xs:documentation>
+					<xs:documentation>Use with an applicable Product Form code D*; see note on D201.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D207">
+				<xs:annotation>
+					<xs:documentation>Windows Mobile</xs:documentation>
+					<xs:documentation>Use with an applicable Product Form code D*; see note on D201.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D301">
+				<xs:annotation>
+					<xs:documentation>Microsoft XBox</xs:documentation>
+					<xs:documentation>Use with Product Form code DE or DB as applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D302">
+				<xs:annotation>
+					<xs:documentation>Nintendo Gameboy Color</xs:documentation>
+					<xs:documentation>Use with Product Form code DE or DB as applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D303">
+				<xs:annotation>
+					<xs:documentation>Nintendo Gameboy Advanced</xs:documentation>
+					<xs:documentation>Use with Product Form code DE or DB as applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D304">
+				<xs:annotation>
+					<xs:documentation>Nintendo Gameboy</xs:documentation>
+					<xs:documentation>Use with Product Form code DE or DB as applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D305">
+				<xs:annotation>
+					<xs:documentation>Nintendo Gamecube</xs:documentation>
+					<xs:documentation>Use with Product Form code DE or DB as applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D306">
+				<xs:annotation>
+					<xs:documentation>Nintendo 64</xs:documentation>
+					<xs:documentation>Use with Product Form code DE or DB as applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D307">
+				<xs:annotation>
+					<xs:documentation>Sega Dreamcast</xs:documentation>
+					<xs:documentation>Use with Product Form code DE or DB as applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D308">
+				<xs:annotation>
+					<xs:documentation>Sega Genesis/Megadrive</xs:documentation>
+					<xs:documentation>Use with Product Form code DE or DB as applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D309">
+				<xs:annotation>
+					<xs:documentation>Sega Saturn</xs:documentation>
+					<xs:documentation>Use with Product Form code DE or DB as applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D310">
+				<xs:annotation>
+					<xs:documentation>Sony PlayStation 1</xs:documentation>
+					<xs:documentation>Use with Product Form code DE or DB as applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D311">
+				<xs:annotation>
+					<xs:documentation>Sony PlayStation 2</xs:documentation>
+					<xs:documentation>Use with Product Form code DE or DB as applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D312">
+				<xs:annotation>
+					<xs:documentation>Nintendo Dual Screen</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D313">
+				<xs:annotation>
+					<xs:documentation>Sony PlayStation 3</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D314">
+				<xs:annotation>
+					<xs:documentation>Xbox 360</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D315">
+				<xs:annotation>
+					<xs:documentation>Nintendo Wii</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D316">
+				<xs:annotation>
+					<xs:documentation>Sony PlayStation Portable (PSP)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E200">
+				<xs:annotation>
+					<xs:documentation>Reflowable</xs:documentation>
+					<xs:documentation>Use where a particular e-publication type (specified in &lt;EpubType>) has both reflowable and fixed-format variants.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E201">
+				<xs:annotation>
+					<xs:documentation>Fixed format</xs:documentation>
+					<xs:documentation>Use where a particular e-publication type (specified in &lt;EpubType>) has both reflowable and fixed-format variants.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E202">
+				<xs:annotation>
+					<xs:documentation>Readable offline</xs:documentation>
+					<xs:documentation>All e-publication resources are included within the e-publication package.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E203">
+				<xs:annotation>
+					<xs:documentation>Requires network connection</xs:documentation>
+					<xs:documentation>E-publication requires a network connection to access some resources (eg an enhanced e-book where video clips are not stored within the e-publication &apos;package&apos; itself, but are delivered via an internet connection).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="L101">
+				<xs:annotation>
+					<xs:documentation>Laminated</xs:documentation>
+					<xs:documentation>Whole product laminated (eg laminated map, fold-out chart, wallchart, etc): use B415 for book with laminated cover.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P101">
+				<xs:annotation>
+					<xs:documentation>Desk calendar</xs:documentation>
+					<xs:documentation>Use with Product Form code PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P102">
+				<xs:annotation>
+					<xs:documentation>Mini calendar</xs:documentation>
+					<xs:documentation>Use with Product Form code PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P103">
+				<xs:annotation>
+					<xs:documentation>Engagement calendar</xs:documentation>
+					<xs:documentation>Use with Product Form code PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P104">
+				<xs:annotation>
+					<xs:documentation>Day by day calendar</xs:documentation>
+					<xs:documentation>Use with Product Form code PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P105">
+				<xs:annotation>
+					<xs:documentation>Poster calendar</xs:documentation>
+					<xs:documentation>Use with Product Form code PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P106">
+				<xs:annotation>
+					<xs:documentation>Wall calendar</xs:documentation>
+					<xs:documentation>Use with Product Form code PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P107">
+				<xs:annotation>
+					<xs:documentation>Perpetual calendar</xs:documentation>
+					<xs:documentation>Use with Product Form code PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P108">
+				<xs:annotation>
+					<xs:documentation>Advent calendar</xs:documentation>
+					<xs:documentation>Use with Product Form code PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P109">
+				<xs:annotation>
+					<xs:documentation>Bookmark calendar</xs:documentation>
+					<xs:documentation>Use with Product Form code PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P110">
+				<xs:annotation>
+					<xs:documentation>Student calendar</xs:documentation>
+					<xs:documentation>Use with Product Form code PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P111">
+				<xs:annotation>
+					<xs:documentation>Project calendar</xs:documentation>
+					<xs:documentation>Use with Product Form code PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P112">
+				<xs:annotation>
+					<xs:documentation>Almanac calendar</xs:documentation>
+					<xs:documentation>Use with Product Form code PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P113">
+				<xs:annotation>
+					<xs:documentation>Other calendar</xs:documentation>
+					<xs:documentation>A calendar that is not one of the types specified elsewhere: use with Product Form code PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P114">
+				<xs:annotation>
+					<xs:documentation>Other calendar or organiser product</xs:documentation>
+					<xs:documentation>A product that is associated with or ancillary to a calendar or organiser, eg a deskstand for a calendar, or an insert for an organiser: use with Product Form code PC or PS.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P201">
+				<xs:annotation>
+					<xs:documentation>Hardback (stationery)</xs:documentation>
+					<xs:documentation>Stationery item in hardback book format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P202">
+				<xs:annotation>
+					<xs:documentation>Paperback / softback (stationery)</xs:documentation>
+					<xs:documentation>Stationery item in paperback/softback book format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P203">
+				<xs:annotation>
+					<xs:documentation>Spiral bound (stationery)</xs:documentation>
+					<xs:documentation>Stationery item in spiral-bound book format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P204">
+				<xs:annotation>
+					<xs:documentation>Leather / fine binding (stationery)</xs:documentation>
+					<xs:documentation>Stationery item in leather-bound book format, or other fine binding.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="V201">
+				<xs:annotation>
+					<xs:documentation>PAL</xs:documentation>
+					<xs:documentation>TV standard for video or DVD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="V202">
+				<xs:annotation>
+					<xs:documentation>NTSC</xs:documentation>
+					<xs:documentation>TV standard for video or DVD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="V203">
+				<xs:annotation>
+					<xs:documentation>SECAM</xs:documentation>
+					<xs:documentation>TV standard for video or DVD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List79">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 79">Product form feature type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Color of cover</xs:documentation>
+					<xs:documentation>For Product Form Feature values see code list 98.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Color of page edge</xs:documentation>
+					<xs:documentation>For Product Form Feature values see code list 98.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Text font</xs:documentation>
+					<xs:documentation>The principal font used for body text, when this is a significant aspect of product description, eg for some Bibles, and for large print product. The accompanying Product Form Feature Description is text specifying font size and, if desired, typeface.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Special cover material</xs:documentation>
+					<xs:documentation>For Product Form Feature values see code list 99.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>DVD region</xs:documentation>
+					<xs:documentation>For Product Form Feature values see code list 76.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Operating system requirements</xs:documentation>
+					<xs:documentation>A computer or handheld device operating system required to use a digital product, with version detail if applicable. The accompanying Product Form Feature Value is a code from List 176. Version detail, when applicable, is carried in Product Form Feature Description.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Other system requirements</xs:documentation>
+					<xs:documentation>Other system requirements for a digital product, described by free text in Product Form Feature Description.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>&apos;Point and listen&apos; device compatibility</xs:documentation>
+					<xs:documentation>Indicates compatibility with proprietary &apos;point and listen&apos; devices such as Ting Pen (http://www.ting.eu) or the iSmart Touch and Read Pen. These devices scan invisible codes specially printed on the page to identify the book and position of the word, and the word is then read aloud by the device. The name of the compatible device (or range of devices) should be given in &lt;ProductFormFeatureDescription>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>E-publication accessibility detail</xs:documentation>
+					<xs:documentation>For &lt;ProductFormFeatureValue> codes, see Codelist 196.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>E-publication format version</xs:documentation>
+					<xs:documentation>For versioned e-book file format (or in some cases, device) - for example EPUB 2 and EPUB 3. &lt;ProductFormFeatureValue> should contain the version number. Use only with ONIX 3.0 - in ONIX 2.1, use &lt;EpubTypeVersion> instead.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>CPSIA choking hazard warning</xs:documentation>
+					<xs:documentation>DEPRECATED - use code 12 and List 143.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>CPSIA choking hazard warning</xs:documentation>
+					<xs:documentation>Choking hazard warning required by US Consumer Product Safety Improvement Act (CPSIA) of 2008. Required, when applicable, for products sold in the US. The Product Form Feature Value is a code from List 143. Further explanation may be given in Product Form Feature Description.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>EU Toy Safety Hazard Warning</xs:documentation>
+					<xs:documentation>Product carries hazard warning required by EU Toy Safety Directive. The Product Form Feature value is a code from List 184, and (for some codes) the exact wording of the warning may be given in Product Form Feature Description.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>Not FSC or PEFC certified</xs:documentation>
+					<xs:documentation>Product does not carry FSC or PEFC logo. The Product Form Feature Value and Description elements are not used. The product may, however, still carry a claimed Pre- and Post-Consumer Waste (PCW) content (type code 37) in a separate repeat of the Product Form Feature composite.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>FSC certified - pure</xs:documentation>
+					<xs:documentation>Product carries FSC logo (Pure, 100%). &lt;ProductFormFeatureValue> is the Certification number (ie either a Chain Of Custody (COC) number or a Trademark License number) printed on the book. Format: Chain of Custody number is two to five letters-COC-six digits (the digits should include leading zeros if necessary), eg &apos;AB-COC-001234&apos; or &apos;ABCDE-COC-123456&apos;; Trademark License number is C followed by six digits, eg &apos;C005678&apos; (this would normally be prefixed by &apos;FSC®&apos; when displayed). By definition, a product certified Pure does not contain Pre- and Post-Consumer-Waste (PCW), so type code 31 can only occur on its own. Certification numbers may be checked at &apos;http://info.fsc.org/&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>FSC certified - mixed sources</xs:documentation>
+					<xs:documentation>Product carries FSC logo (Mixed sources, Mix). &lt;ProductFormFeatureValue> is the Certification number (ie either a Chain Of Custody (COC) number or a Trademark License number) printed on the book. Format: Chain of Custody number is two to five letters-COC-six digits (the digits should include leading zeros if necessary), eg &apos;AB-COC-001234&apos; or &apos;ABCDE-COC-123456&apos;; Trademark License number is C followed by six digits, eg &apos;C005678&apos; (this would normally be prefixed by &apos;FSC®&apos; when displayed). May be accompanied by a Pre- and Post-Consumer-Waste (PCW) percentage value, to be reported in another instance of &lt;ProductFormFeature> with type code 36. Certification numbers may be checked at http://info.fsc.org/</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>FSC certified - recycled</xs:documentation>
+					<xs:documentation>Product carries FSC logo (Recycled). &lt;ProductFormFeatureValue> is the Certification number (ie either a Chain Of Custody (COC) number or a Trademark License number) printed on the book. Format: Chain of Custody number is two to five letters-COC-six digits (the digits should include leading zeroes if necessary), eg &apos;AB-COC-001234&apos; or &apos;ABCDE-COC-123456&apos;; Trademark License number is C followed by six digits, eg &apos;C005678&apos; (this would normally be prefixed by &apos;FSC®&apos; when displayed). Should be accompanied by a Pre- and Post-Consumer-Waste (PCW) percentage value, to be reported in another instance of &lt;ProductFormFeature> with type code 36. Certification numbers may be checked at&apos; http://info.fsc.org/&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>PEFC certified</xs:documentation>
+					<xs:documentation>Product carries PEFC logo (certified). &lt;ProductFormFeatureValue> is the Chain Of Custody (COC) number printed on the book. May be accompanied by a Post-Consumer Waste (PCW) percentage value, to be reported in another instance of &lt;ProductFormFeature> with type code 36.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="35">
+				<xs:annotation>
+					<xs:documentation>PEFC recycled</xs:documentation>
+					<xs:documentation>Product carries PEFC logo (recycled). &lt;ProductFormFeatureValue> is the Chain Of Custody (COC) number printed on the book. Should be accompanied by a Post-Consumer-Waste (PCW) percentage value, to be reported in another instance of &lt;ProductFormFeature> with type code 36.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="36">
+				<xs:annotation>
+					<xs:documentation>FSC or PEFC certified Pre- and Post-Consumer Waste (PCW) percentage</xs:documentation>
+					<xs:documentation>The percentage of recycled Pre- and Post-Consumer-Waste (PCW) used in a product where the composition is certified by FSC or PEFC. &lt;ProductFormFeatureValue> is an integer. May occur together with type code 32, 33, 34 or 35.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="37">
+				<xs:annotation>
+					<xs:documentation>Claimed Pre- and Post-Consumer Waste (PCW) percentage</xs:documentation>
+					<xs:documentation>The percentage of recycled Pre- and Post-Consumer Waste (PCW) claimed to be used in a product where the composition is not certified by FSC or PEFC. &lt;Product FormFeatureValue> is an integer. &lt;ProductFormFeatureDescription> may carry free text supporting the claim. Must be accompanied by type code 30.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="40">
+				<xs:annotation>
+					<xs:documentation>Paper produced by &apos;green&apos; technology</xs:documentation>
+					<xs:documentation>Product made from paper produced using environmentally-conscious technology. &lt;ProductFormFeatureDescription> may carry free text with a more detailed statement.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List80">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 80">Product packaging type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>No outer packaging</xs:documentation>
+					<xs:documentation>No packaging, or all smaller items enclosed inside largest item.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Slip-sleeve</xs:documentation>
+					<xs:documentation>Thin card sleeve, much less rigid than a slip case.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Clamshell</xs:documentation>
+					<xs:documentation>Packaging consisting of formed plastic sealed around each side of the product. Not to be confused with single-sided Blister pack.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Keep case</xs:documentation>
+					<xs:documentation>Typical DVD-style packaging, sometimes known as an &apos;Amaray&apos; case.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Jewel case</xs:documentation>
+					<xs:documentation>Typical CD-style packaging.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>In box</xs:documentation>
+					<xs:documentation>Individual item, items or set in card box with separate or hinged lid: not to be confused with the commonly-used &apos;boxed set&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Slip-cased</xs:documentation>
+					<xs:documentation>Slip-case for single item only: German &apos;Schuber&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Slip-cased set</xs:documentation>
+					<xs:documentation>Slip-case for multi-volume set: German &apos;Kassette&apos;; also commonly referred to as &apos;boxed set&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Tube</xs:documentation>
+					<xs:documentation>Rolled in tube or cylinder: eg sheet map or poster.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Binder</xs:documentation>
+					<xs:documentation>Use for miscellaneous items such as slides, microfiche, when presented in a binder.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>In wallet or folder</xs:documentation>
+					<xs:documentation>Use for miscellaneous items such as slides, microfiche, when presented in a wallet or folder.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Long triangular package</xs:documentation>
+					<xs:documentation>Long package with triangular cross-section used for rolled sheet maps, posters etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Long square package</xs:documentation>
+					<xs:documentation>Long package with square cross-section used for rolled sheet maps, posters, etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Softbox (for DVD)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Pouch</xs:documentation>
+					<xs:documentation>In pouch, eg teaching materials in a plastic bag or pouch.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Rigid plastic case</xs:documentation>
+					<xs:documentation>In duroplastic or other rigid plastic case, eg for a class set.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Cardboard case</xs:documentation>
+					<xs:documentation>In cardboard case, eg for a class set.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>Shrink-wrapped</xs:documentation>
+					<xs:documentation>Use for products or product bundles supplied for retail sale in shrink-wrapped packaging. For shrink-wrapped packs of multiple products for trade supply only, see code XL in List 7.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Blister pack</xs:documentation>
+					<xs:documentation>A pack comprising a pre-formed plastic blister and a printed card with a heat-seal coating.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Carry case</xs:documentation>
+					<xs:documentation>A case with carrying handle, typically for a set of educational books and/or learning materials.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List81">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 81">Product content type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Text (eye-readable)</xs:documentation>
+					<xs:documentation>Readable text of the main work: this value is required, together with applicable &lt;ProductForm> and &lt;ProductFormDetail> values, to designate an e-book or other digital product whose primary content is eye-readable text.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Extensive links between internal content</xs:documentation>
+					<xs:documentation>E-publication is enhanced with a significant number of actionable cross-references, hyperlinked notes and annotations, or with other links between largely textual elements (eg quiz/test questions, &apos;choose your own ending&apos; etc).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Extensive links to external content</xs:documentation>
+					<xs:documentation>E-publication is enhanced with a significant number of actionable (clickable) web links.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Additional eye-readable text not part of main work</xs:documentation>
+					<xs:documentation>E-publication is enhanced with additional textual content such as interview, feature article, essay, bibliography, quiz/test, other background material or text that is not included in a primary or &apos;unenhanced&apos; version.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Promotional text for other book product</xs:documentation>
+					<xs:documentation>eg Teaser chapter.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Musical notation</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Still images / graphics</xs:documentation>
+					<xs:documentation>Use only when no more detailed specification is provided.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Photographs</xs:documentation>
+					<xs:documentation>Whether in a plate section / insert, or not.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Figures, diagrams, charts, graphs</xs:documentation>
+					<xs:documentation>Including other &apos;mechanical&apos; (ie non-photographic) illustrations.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Additional images / graphics not part of main work</xs:documentation>
+					<xs:documentation>E-publication is enhanced with additional images or graphical content such as supplementary photographs that are not included in a primary or &apos;unenhanced&apos; version.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Maps and/or other cartographic content</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Audiobook</xs:documentation>
+					<xs:documentation>Audio recording of a reading of a book or other text.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Performance - spoken word</xs:documentation>
+					<xs:documentation>Audio recording of a drama or other spoken word performance.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Other speech content</xs:documentation>
+					<xs:documentation>eg an interview, not a &apos;reading&apos; or &apos;performance&apos;).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Music recording</xs:documentation>
+					<xs:documentation>Audio recording of a music performance, including musical drama and opera.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Other audio</xs:documentation>
+					<xs:documentation>Audio recording of other sound, eg birdsong.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>Partial performance - spoken word</xs:documentation>
+					<xs:documentation>Audio recording of a reading, performance or dramatization of part of the work.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Additional audio content not part of main work</xs:documentation>
+					<xs:documentation>Product is enhanced with audio recording of full or partial reading, performance, dramatization, interview, background documentary or other audio content not included in the primary or &apos;unenhanced&apos; version.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Promotional audio for other book product</xs:documentation>
+					<xs:documentation>eg Reading of teaser chapter.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Video</xs:documentation>
+					<xs:documentation>Includes Film, video, animation etc. Use only when no more detailed specification is provided. Formerly &apos;Moving images&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Video recording of a reading</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>Performance - visual</xs:documentation>
+					<xs:documentation>Video recording of a drama or other performance, including musical performance.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Animated / interactive illustrations</xs:documentation>
+					<xs:documentation>eg animated diagrams, charts, graphs or other illustrations.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Narrative animation</xs:documentation>
+					<xs:documentation>eg cartoon, animatic or CGI animation.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>Other video</xs:documentation>
+					<xs:documentation>Other video content eg interview, not a reading or performance.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="29">
+				<xs:annotation>
+					<xs:documentation>Partial performance - video</xs:documentation>
+					<xs:documentation>Video recording of a reading, performance or dramatization of part of the work.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>Additional video content not part of main work</xs:documentation>
+					<xs:documentation>E-publication is enhanced with video recording of full or partial reading, performance, dramatization, interview, background documentary or other content not included in the primary or &apos;unenhanced&apos; version.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>Promotional video for other book product</xs:documentation>
+					<xs:documentation>eg Book trailer.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Game / Puzzle</xs:documentation>
+					<xs:documentation>No multi-user functionality. Formerly just &apos;Game&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>Contest</xs:documentation>
+					<xs:documentation>Includes some degree of multi-user functionality.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Software</xs:documentation>
+					<xs:documentation>Largely &apos;content free&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Dades</xs:documentation>
+					<xs:documentation>Data files.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>Data set plus software</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>Blank pages</xs:documentation>
+					<xs:documentation>Intended to be filled in by the reader.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="35">
+				<xs:annotation>
+					<xs:documentation>Advertising content</xs:documentation>
+					<xs:documentation>Use only where type of advertising content is not stated.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="37">
+				<xs:annotation>
+					<xs:documentation>Advertising - first party</xs:documentation>
+					<xs:documentation>&apos;Back ads&apos; - promotional pages for other books (that do not include sample content, cf codes 17, 23).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="36">
+				<xs:annotation>
+					<xs:documentation>Advertising - coupons</xs:documentation>
+					<xs:documentation>Eg to obtain discounts on other products.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="38">
+				<xs:annotation>
+					<xs:documentation>Advertising - third party display</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="39">
+				<xs:annotation>
+					<xs:documentation>Advertising - third party textual</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List82">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 82">Bible contents</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AP">
+				<xs:annotation>
+					<xs:documentation>Apocrypha (Catholic canon)</xs:documentation>
+					<xs:documentation>The seven portions of the Apocrypha added to the Catholic canon at the Council of Trent in 1546: Tobit; Judith; Wisdom of Solomon; Sirach (Ecclesiasticus); Baruch, including the Letter of Jeremiah; I and II Maccabees; Extra portions of Esther and Daniel (Additions to Esther; the Prayer of Azariah; Song of the Three Jews; Susannah; Bel and the Dragon). These are not generally included in the Protestant canon.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AQ">
+				<xs:annotation>
+					<xs:documentation>Apocrypha (canon unspecified)</xs:documentation>
+					<xs:documentation>A collection of Apocryphal texts, canon not specified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AX">
+				<xs:annotation>
+					<xs:documentation>Additional Apocryphal texts: Greek Orthodox canon</xs:documentation>
+					<xs:documentation>I Esdras; Prayer of Manasseh; Psalm 151; III Maccabees.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AY">
+				<xs:annotation>
+					<xs:documentation>Additional Apocryphal texts: Slavonic Orthodox canon</xs:documentation>
+					<xs:documentation>I and II Esdras; Prayer of Manasseh; Psalm 151; III and IV Maccabees.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AZ">
+				<xs:annotation>
+					<xs:documentation>Additional Apocryphal texts</xs:documentation>
+					<xs:documentation>Additional Apocryphal texts included in some Bible versions: I and II Esdras; Prayer of Manasseh.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GA">
+				<xs:annotation>
+					<xs:documentation>General canon with Apocrypha (Catholic canon)</xs:documentation>
+					<xs:documentation>The 66 books included in the Protestant, Catholic and Orthodox canons, together with the seven portions of the Apocrypha included in the Catholic canon.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GC">
+				<xs:annotation>
+					<xs:documentation>General canon with Apocryphal texts (canon unspecified)</xs:documentation>
+					<xs:documentation>The 66 books included in the Protestant, Catholic and Orthodox canons, together with Apocryphal texts, canon not specified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GE">
+				<xs:annotation>
+					<xs:documentation>General canon</xs:documentation>
+					<xs:documentation>The 66 books included in the Protestant, Catholic and Orthodox canons, 39 from the Old Testament and 27 from the New Testament. The sequence of books may differ in different canons.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GS">
+				<xs:annotation>
+					<xs:documentation>Gospels</xs:documentation>
+					<xs:documentation>The books of Matthew, Mark, Luke and John.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="OT">
+				<xs:annotation>
+					<xs:documentation>Old Testament</xs:documentation>
+					<xs:documentation>Those 39 books which were included in the Jewish canon by the rabbinical academy established at Jamma in 90 CE. Also known as the Jewish or Hebrew scriptures.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NT">
+				<xs:annotation>
+					<xs:documentation>New Testament</xs:documentation>
+					<xs:documentation>The 27 books included in the Christian canon through the Easter Letter of Athanasius, Bishop of Alexandria and also by a general council of the Christian church held near the end of the 4th century CE.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NP">
+				<xs:annotation>
+					<xs:documentation>New Testament with Psalms and Proverbs</xs:documentation>
+					<xs:documentation>Includes the 27 books of the New Testament plus Psalms and Proverbs from the Old Testament.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PE">
+				<xs:annotation>
+					<xs:documentation>Paul&apos;s Epistles</xs:documentation>
+					<xs:documentation>The books containing the letters of Paul to the various early Christian churches.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PP">
+				<xs:annotation>
+					<xs:documentation>Psalms and Proverbs</xs:documentation>
+					<xs:documentation>The book of Psalms and the book of Proverbs combined.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PS">
+				<xs:annotation>
+					<xs:documentation>Psalms</xs:documentation>
+					<xs:documentation>The book of Psalms.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PT">
+				<xs:annotation>
+					<xs:documentation>Pentateuch</xs:documentation>
+					<xs:documentation>The first five books of the Bible: Genesis, Exodus, Numbers, Leviticus, Deuteronomy. Also applied to the Torah.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZZ">
+				<xs:annotation>
+					<xs:documentation>Other portions</xs:documentation>
+					<xs:documentation>Selected books of either the OT or NT not otherwise noted.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List83">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 83">Bible version</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ALV">
+				<xs:annotation>
+					<xs:documentation>Alberto Vaccari</xs:documentation>
+					<xs:documentation>Alberto Vaccari - Pontificio Istituto Biblico.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AMP">
+				<xs:annotation>
+					<xs:documentation>Amplified</xs:documentation>
+					<xs:documentation>A translation based on the American Standard Version and showing multiple options for the translation of ancient text. Published in full in 1965. Sponsored by the Lockman Foundation.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ANM">
+				<xs:annotation>
+					<xs:documentation>Antonio Martini</xs:documentation>
+					<xs:documentation>Most popular Catholic Bible translation in Italian prior to the CEI translation in 1971.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ASV">
+				<xs:annotation>
+					<xs:documentation>American Standard</xs:documentation>
+					<xs:documentation>A 1901 translation using verbal equivalence techniques with the purpose of Americanizing the REV.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CEI">
+				<xs:annotation>
+					<xs:documentation>Conferenza Episcopale Italiana</xs:documentation>
+					<xs:documentation>Italian Episcopal Conference 1971 translation suitable for Italian Catholic liturgy. (Includes minor 1974 revision).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CEN">
+				<xs:annotation>
+					<xs:documentation>Conferenza Episcopale Italiana 2008</xs:documentation>
+					<xs:documentation>New translation of the C.E.I. first published in 2008 - the version most widely used by the Italian Catholic Church.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CEV">
+				<xs:annotation>
+					<xs:documentation>Contemporary English</xs:documentation>
+					<xs:documentation>A translation completed in 1995 and sponsored by the American Bible Society under the leadership of Barclay Newman.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CNC">
+				<xs:annotation>
+					<xs:documentation>Concordata</xs:documentation>
+					<xs:documentation>1968 Interfaith version promoted by the Italian Bible Society. Has a Catholic &apos;imprimateur&apos;, but its ecumenical approach has Jewish, Protestant and Christian Orthodox approval.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DDI">
+				<xs:annotation>
+					<xs:documentation>Diodati</xs:documentation>
+					<xs:documentation>Version based on original documents, edited by Giovanni Diodati in 1607, revised by Diodati in 1641 and again in 1894. It is the reference version for many Italian Protestants.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DDN">
+				<xs:annotation>
+					<xs:documentation>Nuova Diodati</xs:documentation>
+					<xs:documentation>Revision of the Diodati Bible dating to the 1990s, aiming at highest fidelity to original ancient Greek (New Testament) and Hebrew (Old Testament) texts.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DOU">
+				<xs:annotation>
+					<xs:documentation>Douay-Rheims</xs:documentation>
+					<xs:documentation>An early (1580-1609) English translation from the Latin Vulgate designed for Catholics and performed by George Martin.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EIN">
+				<xs:annotation>
+					<xs:documentation>Einheitsübersetzung</xs:documentation>
+					<xs:documentation>A German translation of the Bible for use in Roman Catholic churches.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ESV">
+				<xs:annotation>
+					<xs:documentation>English Standard</xs:documentation>
+					<xs:documentation>An update of the Revised Standard Version that makes &apos;modest&apos; use of gender-free terminology.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FBB">
+				<xs:annotation>
+					<xs:documentation>Biblia (1776)</xs:documentation>
+					<xs:documentation>Finnish Bible translation.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FRA">
+				<xs:annotation>
+					<xs:documentation>Raamattu (1933/1938)</xs:documentation>
+					<xs:documentation>Finnish Bible translation.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FRK">
+				<xs:annotation>
+					<xs:documentation>Raamattu kansalle</xs:documentation>
+					<xs:documentation>Finnish Bible translation.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FRM">
+				<xs:annotation>
+					<xs:documentation>Raamattu (1992)</xs:documentation>
+					<xs:documentation>Finnish Bible translation.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GDW">
+				<xs:annotation>
+					<xs:documentation>God&apos;s Word</xs:documentation>
+					<xs:documentation>A 1995 translation by the World Bible Publishing Company using the English language in a manner to communicate to the late 20th century American.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GEN">
+				<xs:annotation>
+					<xs:documentation>Geneva</xs:documentation>
+					<xs:documentation>An early (1560) English version of the Bible translated by William Whittingham with strong Protestant leanings.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GNB">
+				<xs:annotation>
+					<xs:documentation>Good News</xs:documentation>
+					<xs:documentation>A translation sponsored by the American Bible Society. The New Testament was first published (as &apos;Today&apos;s English Version&apos; TEV) in 1966. The Old Testament was completed in 1976, and the whole was published as the &apos;Good News Bible&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GPR">
+				<xs:annotation>
+					<xs:documentation>Galbiati, Penna, Rossano - UTET</xs:documentation>
+					<xs:documentation>Version edited by E. Galbiati, A. Penna and P. Rossano, and published by UTET. This version, based on original texts, is rich in notes and has been used as the basis for CEI translation.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GRK">
+				<xs:annotation>
+					<xs:documentation>Original Greek</xs:documentation>
+					<xs:documentation>New Testament text in an original Greek version.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GRM">
+				<xs:annotation>
+					<xs:documentation>Garofano, Rinaldi - Marietti</xs:documentation>
+					<xs:documentation>Richly annotated 1963 Version edited by S. Garofano and S. Rinaldi, and published by Marietti.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HBR">
+				<xs:annotation>
+					<xs:documentation>Original Hebrew</xs:documentation>
+					<xs:documentation>Old Testament text in an original Hebrew version.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HCS">
+				<xs:annotation>
+					<xs:documentation>Holman Christian Standard</xs:documentation>
+					<xs:documentation>Published by Broadman and Holman this translation rejects all forms of gender-neutral wording and is written with strong influences from the Southern Baptist perspective of biblical scholarship.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ICB">
+				<xs:annotation>
+					<xs:documentation>International Children&apos;s</xs:documentation>
+					<xs:documentation>A translation completed in 1986 targeting readability at the US third grade level.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ILC">
+				<xs:annotation>
+					<xs:documentation>Traduzione Interconfessionale in Lingua Corrente</xs:documentation>
+					<xs:documentation>Interconfessional translation resulting from 1985 effort by Catholic and Protestant scholars, aimed at delivering an easy-to-understand message.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="JER">
+				<xs:annotation>
+					<xs:documentation>Jerusalem</xs:documentation>
+					<xs:documentation>A translation designed for English speaking Catholics based on the original languages. It is based on French as well as ancient texts and was first published in 1966.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KJV">
+				<xs:annotation>
+					<xs:documentation>King James</xs:documentation>
+					<xs:documentation>A translation commissioned by King James I of England and first published in 1611.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KJT">
+				<xs:annotation>
+					<xs:documentation>21st Century King James</xs:documentation>
+					<xs:documentation>A verbal translation led by William Prindele. Published in 1994, it was designed to modernize the language of the King James Version based on Webster&apos;s New International Dictionary, 2nd edition, unabridged.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LVB">
+				<xs:annotation>
+					<xs:documentation>Living Bible</xs:documentation>
+					<xs:documentation>A paraphrase translation led by Kenneth N Taylor and first published in 1972.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LZZ">
+				<xs:annotation>
+					<xs:documentation>Luzzi</xs:documentation>
+					<xs:documentation>1924 translation by Giovanni Luzzi, Professor at the Waldensian Faculty of Theology in Rome, who revised the 17th Century Diodati version.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MSG">
+				<xs:annotation>
+					<xs:documentation>Message Bible</xs:documentation>
+					<xs:documentation>A paraphrase translation of the New Testament by Eugene Peterson first published in 1993.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NAB">
+				<xs:annotation>
+					<xs:documentation>New American</xs:documentation>
+					<xs:documentation>A translation aimed at Catholic readers first published in its entirety in 1970. A revised New Testament was issued in 1986 as the 2nd Edition. The 3rd Edtion was published in 1991 with a revision to Psalms. The 4th Edition (also known as the New American Bible Revised Edition) was published in 2011, incorporating revisions to the Old Testament.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NAS">
+				<xs:annotation>
+					<xs:documentation>New American Standard</xs:documentation>
+					<xs:documentation>A translation commissioned by the Lockman Foundation. The New Testament was published in 1960 followed by the entire Bible in 1971.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NAU">
+				<xs:annotation>
+					<xs:documentation>New American Standard, Updated</xs:documentation>
+					<xs:documentation>A 1995 translation using more modern language than the NASB.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NBA">
+				<xs:annotation>
+					<xs:documentation>Bibelen 1895</xs:documentation>
+					<xs:documentation>Norwegian Bible translation.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NBB">
+				<xs:annotation>
+					<xs:documentation>Bibelen 1930</xs:documentation>
+					<xs:documentation>Norwegian Bible translation.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NBC">
+				<xs:annotation>
+					<xs:documentation>Bibelen 1938</xs:documentation>
+					<xs:documentation>Norwegian Bible translation.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NBD">
+				<xs:annotation>
+					<xs:documentation>Bibelen 1978-85</xs:documentation>
+					<xs:documentation>Norwegian Bible translation.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NBE">
+				<xs:annotation>
+					<xs:documentation>Bibelen 1978</xs:documentation>
+					<xs:documentation>Norwegian Bible translation.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NBF">
+				<xs:annotation>
+					<xs:documentation>Bibelen 1985</xs:documentation>
+					<xs:documentation>Norwegian Bible translation.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NBG">
+				<xs:annotation>
+					<xs:documentation>Bibelen 1988</xs:documentation>
+					<xs:documentation>Norwegian Bible translation.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NBH">
+				<xs:annotation>
+					<xs:documentation>Bibelen 1978-85/rev. 2005</xs:documentation>
+					<xs:documentation>Norwegian Bible translation.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NBI">
+				<xs:annotation>
+					<xs:documentation>Bibelen 2011</xs:documentation>
+					<xs:documentation>Norwegian Bible translation.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NCV">
+				<xs:annotation>
+					<xs:documentation>New Century</xs:documentation>
+					<xs:documentation>A translation inspired by the International Children&apos;s version. First published by World Publishing in 1991.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NEB">
+				<xs:annotation>
+					<xs:documentation>New English</xs:documentation>
+					<xs:documentation>A translation first issued in 1961 (New Testament) and 1970 (complete Bible) as a result of a proposal at the 1946 General Assembly of the Church of Scotland.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NGO">
+				<xs:annotation>
+					<xs:documentation>Bibelen Guds ord</xs:documentation>
+					<xs:documentation>Norwegian Bible translation.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NIV">
+				<xs:annotation>
+					<xs:documentation>New International</xs:documentation>
+					<xs:documentation>A translation underwritten by Biblica (formerly the International Bible Society, and previously the New York Bible Society). The New Testament was published in 1973 followed by the entire Bible in 1978. The NIV text was revised in 1984 and again in 2011.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NIR">
+				<xs:annotation>
+					<xs:documentation>New International Reader&apos;s</xs:documentation>
+					<xs:documentation>A 1996 translation designed for people with limited literacy in English and based on the NIV.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NJB">
+				<xs:annotation>
+					<xs:documentation>New Jerusalem</xs:documentation>
+					<xs:documentation>A revision of the Jerusalem Bible. First published in 1986.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NKJ">
+				<xs:annotation>
+					<xs:documentation>New King James</xs:documentation>
+					<xs:documentation>A version issued by Thomas Nelson Publishers in 1982-83 designed to update the language of the King James Version while maintaining the phrasing and rhythm and using the same sources as its predecessor.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NNK">
+				<xs:annotation>
+					<xs:documentation>Bibelen, nynorsk</xs:documentation>
+					<xs:documentation>Norwegian &apos;nynorsk&apos; Bible translation.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NLV">
+				<xs:annotation>
+					<xs:documentation>New Living</xs:documentation>
+					<xs:documentation>A translation sponsored by Tyndale House and first released in 1996. It is considered a revision and updating of the Living Bible.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NRS">
+				<xs:annotation>
+					<xs:documentation>New Revised Standard</xs:documentation>
+					<xs:documentation>A revision of the Revised Standard based on ancient texts but updating language to American usage of the 1980s.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NTV">
+				<xs:annotation>
+					<xs:documentation>Nueva Traduccion Vivienta</xs:documentation>
+					<xs:documentation>A Spanish translation from the original Greek and Hebrew, sponsored by Tyndale House.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NVB">
+				<xs:annotation>
+					<xs:documentation>Novissima Versione della Bibbia</xs:documentation>
+					<xs:documentation>Nuovissima version - a Catholic-oriented translation in modern Italian, edited by a group including Carlo Martini, Gianfranco Ravasi and Ugo Vanni and first published (in 48 volumes, 1967-1980) by Edizioni San Paolo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NVD">
+				<xs:annotation>
+					<xs:documentation>Nueva Biblia al Dia</xs:documentation>
+					<xs:documentation>A Spanish translation from the original Greek and Hebrew, sponsored by the International Bible Society/Sociedad Bíblica Internacional.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NVI">
+				<xs:annotation>
+					<xs:documentation>Nueva Version Internacional</xs:documentation>
+					<xs:documentation>A Spanish translation underwritten by the International Bible Society.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PHP">
+				<xs:annotation>
+					<xs:documentation>New Testament in Modern English (Phillips)</xs:documentation>
+					<xs:documentation>An idiomatic translation by J B Phillips, first completed in 1966.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="REB">
+				<xs:annotation>
+					<xs:documentation>Revised English</xs:documentation>
+					<xs:documentation>A 1989 revision of the NEB. A significant effort was made to reduce the British flavor present in the NEB.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="REV">
+				<xs:annotation>
+					<xs:documentation>Revised Version</xs:documentation>
+					<xs:documentation>The first major revision of the King James Version, the Revised Version incorporates insights from early manuscripts discovered between 1611 and 1870, and corrects readings in the KJV which nineteenth-century scholarship deemed mistaken. The New Testament was published in 1881, the Old Testament in 1885, and the Apocrypha in 1895.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RSV">
+				<xs:annotation>
+					<xs:documentation>Revised Standard</xs:documentation>
+					<xs:documentation>A translation authorized by the National Council of Churches of Christ in the USA. The New Testament was published in 1946 followed by a complete Protestant canon in 1951.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RVL">
+				<xs:annotation>
+					<xs:documentation>Reina Valera</xs:documentation>
+					<xs:documentation>A Spanish translation based on the original texts.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SBB">
+				<xs:annotation>
+					<xs:documentation>Bibel 2000</xs:documentation>
+					<xs:documentation>Swedish Bible translation.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SMK">
+				<xs:annotation>
+					<xs:documentation>Bibelen, samisk</xs:documentation>
+					<xs:documentation>Norwegian &apos;samisk&apos; Bible translation.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TEV">
+				<xs:annotation>
+					<xs:documentation>Today&apos;s English</xs:documentation>
+					<xs:documentation>A translation of the New Testament sponsored by the American Bible Society and first published in 1966. It was incorporated into the &apos;Good News Bible&apos; GNB in 1976.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TNI">
+				<xs:annotation>
+					<xs:documentation>Today&apos;s New International</xs:documentation>
+					<xs:documentation>An updating of the New International Version. The New Testament was published in 2002, and the entire Bible in 2005. Superseded by the 2011 NIV update.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZZZ">
+				<xs:annotation>
+					<xs:documentation>Altres</xs:documentation>
+					<xs:documentation>Other translations not otherwise noted.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List84">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 84">Study Bible type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CAM">
+				<xs:annotation>
+					<xs:documentation>Cambridge Annotated</xs:documentation>
+					<xs:documentation>Contains the work of Howard Clark Kee including a summary of the development of the canon, introductions to the books, notes and cross references. Originally published in 1993, NRSV.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LIF">
+				<xs:annotation>
+					<xs:documentation>Life Application</xs:documentation>
+					<xs:documentation>A project of Tyndale House Publishers and Zondervan intended to help readers apply the Bible to daily living. Living Bible, King James, New International, NASB.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MAC">
+				<xs:annotation>
+					<xs:documentation>Macarthur</xs:documentation>
+					<xs:documentation>A King James version study Bible with notes by James Macarthur first published in 1997.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="OXF">
+				<xs:annotation>
+					<xs:documentation>Oxford Annotated</xs:documentation>
+					<xs:documentation>A study Bible originally published in the 1960s and based on the RSV / NRSV.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NNT">
+				<xs:annotation>
+					<xs:documentation>Studiebibel, Det Nye testamentet</xs:documentation>
+					<xs:documentation>Norwegian study Bible, New Testament.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NOX">
+				<xs:annotation>
+					<xs:documentation>New Oxford Annotated</xs:documentation>
+					<xs:documentation>Published in 1991 and based on the New Revised Standard version.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NSB">
+				<xs:annotation>
+					<xs:documentation>Norsk studiebibel</xs:documentation>
+					<xs:documentation>Norwegian study Bible.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RYR">
+				<xs:annotation>
+					<xs:documentation>Ryrie</xs:documentation>
+					<xs:documentation>Based on the work of Charles C. Ryrie. King James, NI, NASB.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SCO">
+				<xs:annotation>
+					<xs:documentation>Scofield</xs:documentation>
+					<xs:documentation>A study Bible based on the early 20th century work of C.I. Scofield. Based on the King James version.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SPR">
+				<xs:annotation>
+					<xs:documentation>Spirit Filled</xs:documentation>
+					<xs:documentation>A transdenominational study Bible for persons from the Pentecostal/Charismatic traditions.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List85">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 85">Bible purpose</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AW">
+				<xs:annotation>
+					<xs:documentation>Award</xs:documentation>
+					<xs:documentation>A Bible (or selected Biblical text) designed for presentation from a religious organization.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BB">
+				<xs:annotation>
+					<xs:documentation>Baby</xs:documentation>
+					<xs:documentation>A Bible (or selected Biblical text) designed to be a gift to commemorate a child&apos;s birth.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BR">
+				<xs:annotation>
+					<xs:documentation>Bride</xs:documentation>
+					<xs:documentation>A special gift Bible (or selected Biblical text) designed for the bride on her wedding day. Usually white.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CF">
+				<xs:annotation>
+					<xs:documentation>Confirmació</xs:documentation>
+					<xs:documentation>A Bible (or selected Biblical text) designed to be used in the confirmation reading or as a gift to a confirmand.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CH">
+				<xs:annotation>
+					<xs:documentation>Children&apos;s</xs:documentation>
+					<xs:documentation>A text Bible (or selected Biblical text) designed in presentation and readability for a child.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CM">
+				<xs:annotation>
+					<xs:documentation>Compact</xs:documentation>
+					<xs:documentation>A small Bible (or selected Biblical text) with a trim height of five inches or less.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CR">
+				<xs:annotation>
+					<xs:documentation>Cross-reference</xs:documentation>
+					<xs:documentation>A Bible (or selected Biblical text) which includes text conveying cross-references to related scripture passages.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DR">
+				<xs:annotation>
+					<xs:documentation>Daily readings</xs:documentation>
+					<xs:documentation>A Bible (or selected Biblical text) laid out to provide readings for each day of the year.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DV">
+				<xs:annotation>
+					<xs:documentation>Devotional</xs:documentation>
+					<xs:documentation>A Bible (or selected Biblical text) containing devotional content together with the scripture.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FM">
+				<xs:annotation>
+					<xs:documentation>Family</xs:documentation>
+					<xs:documentation>A Bible (or selected Biblical text) containing family record pages and/or additional study material for family devotion.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GT">
+				<xs:annotation>
+					<xs:documentation>General/Text</xs:documentation>
+					<xs:documentation>A standard Bible (or selected Biblical text) of any version with no distinguishing characteristics beyond the canonical text.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GF">
+				<xs:annotation>
+					<xs:documentation>Regal</xs:documentation>
+					<xs:documentation>A Bible (or selected Biblical text) designed for gift or presentation, often including a presentation page.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LP">
+				<xs:annotation>
+					<xs:documentation>Lectern/Pulpit</xs:documentation>
+					<xs:documentation>A large Bible (or selected Biblical text) with large print designed for use in reading scriptures in public worship from either the pulpit or lectern.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MN">
+				<xs:annotation>
+					<xs:documentation>Men&apos;s</xs:documentation>
+					<xs:documentation>A Bible (or selected Biblical text) especially designed with helps and study guides oriented to the adult male.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PS">
+				<xs:annotation>
+					<xs:documentation>Primary school</xs:documentation>
+					<xs:documentation>A Bible (or selected Biblical text) designed for use in primary school.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PW">
+				<xs:annotation>
+					<xs:documentation>Pew</xs:documentation>
+					<xs:documentation>Usually inexpensive but sturdy, a Bible (or selected Biblical text) designed for use in church pews.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SC">
+				<xs:annotation>
+					<xs:documentation>Scholarly</xs:documentation>
+					<xs:documentation>A Bible (or selected Biblical text) including texts in Greek and/or Hebrew and designed for scholarly study.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SL">
+				<xs:annotation>
+					<xs:documentation>Slimline</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ST">
+				<xs:annotation>
+					<xs:documentation>Student</xs:documentation>
+					<xs:documentation>A Bible (or selected Biblical text) with study articles and helps especially for use in the classroom.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SU">
+				<xs:annotation>
+					<xs:documentation>Study</xs:documentation>
+					<xs:documentation>A Bible (or selected Biblical text) with many extra features, e.g. book introductions, dictionary, concordance, references, maps, etc., to help readers better understand the scripture.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WG">
+				<xs:annotation>
+					<xs:documentation>Wedding gift</xs:documentation>
+					<xs:documentation>A special gift Bible (or selected Biblical text) designed as a gift to the couple on their wedding day.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WM">
+				<xs:annotation>
+					<xs:documentation>Women&apos;s</xs:documentation>
+					<xs:documentation>A devotional or study Bible (or selected Biblical text) with helps targeted at the adult woman.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="YT">
+				<xs:annotation>
+					<xs:documentation>Youth</xs:documentation>
+					<xs:documentation>A Bible (or selected Biblical text) containing special study and devotional helps designed specifically for the needs of teenagers.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List86">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 86">Bible text organization</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CHR">
+				<xs:annotation>
+					<xs:documentation>Chronological</xs:documentation>
+					<xs:documentation>A Bible with the text organized in the order in which events are believed to have happened.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CHA">
+				<xs:annotation>
+					<xs:documentation>Chain reference</xs:documentation>
+					<xs:documentation>A Bible which explores keywords or themes by referring text to preceding or following text.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="INT">
+				<xs:annotation>
+					<xs:documentation>Interlinear</xs:documentation>
+					<xs:documentation>A Bible or other text in which different versions are printed one line above the other, so that the variations can easily be detected.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PAR">
+				<xs:annotation>
+					<xs:documentation>Parallel</xs:documentation>
+					<xs:documentation>A Bible with two or more versions printed side by side.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="STN">
+				<xs:annotation>
+					<xs:documentation>Standard</xs:documentation>
+					<xs:documentation>A Bible in which the text is presented in the traditional order.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List87">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 87">Bible reference location</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CCL">
+				<xs:annotation>
+					<xs:documentation>Center column</xs:documentation>
+					<xs:documentation>References are printed in a narrow column in the center of the page between two columns of text.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PGE">
+				<xs:annotation>
+					<xs:documentation>Page end</xs:documentation>
+					<xs:documentation>References are printed at the foot of the page.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SID">
+				<xs:annotation>
+					<xs:documentation>Side column</xs:documentation>
+					<xs:documentation>References are printed in a column to the side of the scripture.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VER">
+				<xs:annotation>
+					<xs:documentation>Verse end</xs:documentation>
+					<xs:documentation>References are printed at the end of the applicable verse.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="UNK">
+				<xs:annotation>
+					<xs:documentation>Desconegut/da</xs:documentation>
+					<xs:documentation>The person creating the ONIX record does not know where the references are located.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZZZ">
+				<xs:annotation>
+					<xs:documentation>Altres</xs:documentation>
+					<xs:documentation>Other locations not otherwise identified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List88">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 88">Religious text identifier</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="List89">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 89">Religious text feature type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Church season or activity</xs:documentation>
+					<xs:documentation>A church season or activity for which a religious text is intended.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List90">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 90">Religious text feature code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Academic year</xs:documentation>
+					<xs:documentation>Use with code 01 in &lt;ReligiousTextFeatureType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Catechistic year</xs:documentation>
+					<xs:documentation>Use with code 01 in &lt;ReligiousTextFeatureType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Liturgical year</xs:documentation>
+					<xs:documentation>Use with code 01 in &lt;ReligiousTextFeatureType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Advent and Christmas</xs:documentation>
+					<xs:documentation>Use with code 01 in &lt;ReligiousTextFeatureType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Blessings</xs:documentation>
+					<xs:documentation>Use with code 01 in &lt;ReligiousTextFeatureType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Scholastic cycles</xs:documentation>
+					<xs:documentation>Use with code 01 in &lt;ReligiousTextFeatureType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Confirmation and Holy Communion</xs:documentation>
+					<xs:documentation>Use with code 01 in &lt;ReligiousTextFeatureType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Summer activites</xs:documentation>
+					<xs:documentation>For example, summer camps and other youth recreational activities: use with code 01 in &lt;ReligiousTextFeatureType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Easter</xs:documentation>
+					<xs:documentation>Use with code 01 in &lt;ReligiousTextFeatureType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Lent</xs:documentation>
+					<xs:documentation>Use with code 01 in &lt;ReligiousTextFeatureType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Marian themes</xs:documentation>
+					<xs:documentation>Use with code 01 in &lt;ReligiousTextFeatureType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List91">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 91">Country code - ISO 3166-1</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AD">
+				<xs:annotation>
+					<xs:documentation>Andorra</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AE">
+				<xs:annotation>
+					<xs:documentation>United Arab Emirates</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AF">
+				<xs:annotation>
+					<xs:documentation>Afghanistan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AG">
+				<xs:annotation>
+					<xs:documentation>Antigua and Barbuda</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AI">
+				<xs:annotation>
+					<xs:documentation>Anguilla</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AL">
+				<xs:annotation>
+					<xs:documentation>Albania</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AM">
+				<xs:annotation>
+					<xs:documentation>Armenia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AN">
+				<xs:annotation>
+					<xs:documentation>Netherlands Antilles</xs:documentation>
+					<xs:documentation>Deprecated - use BQ, CW or SX as appropriate.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AO">
+				<xs:annotation>
+					<xs:documentation>Angola</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AQ">
+				<xs:annotation>
+					<xs:documentation>Antarctica</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AR">
+				<xs:annotation>
+					<xs:documentation>Argentina</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AS">
+				<xs:annotation>
+					<xs:documentation>American Samoa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AT">
+				<xs:annotation>
+					<xs:documentation>Austria</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AU">
+				<xs:annotation>
+					<xs:documentation>Australia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AW">
+				<xs:annotation>
+					<xs:documentation>Aruba</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AX">
+				<xs:annotation>
+					<xs:documentation>Åland Islands</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AZ">
+				<xs:annotation>
+					<xs:documentation>Azerbaijan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BA">
+				<xs:annotation>
+					<xs:documentation>Bosnia and Herzegovina</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BB">
+				<xs:annotation>
+					<xs:documentation>Barbados</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BD">
+				<xs:annotation>
+					<xs:documentation>Bangladesh</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BE">
+				<xs:annotation>
+					<xs:documentation>Belgium</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BF">
+				<xs:annotation>
+					<xs:documentation>Burkina Faso</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BG">
+				<xs:annotation>
+					<xs:documentation>Bulgaria</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BH">
+				<xs:annotation>
+					<xs:documentation>Bahrain</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BI">
+				<xs:annotation>
+					<xs:documentation>Burundi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BJ">
+				<xs:annotation>
+					<xs:documentation>Benin</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BL">
+				<xs:annotation>
+					<xs:documentation>Saint Barthélemy</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BM">
+				<xs:annotation>
+					<xs:documentation>Bermuda</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BN">
+				<xs:annotation>
+					<xs:documentation>Brunei Darussalam</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BO">
+				<xs:annotation>
+					<xs:documentation>Bolivia, Plurinational State of</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BQ">
+				<xs:annotation>
+					<xs:documentation>Bonaire, Sint Eustatius, Saba</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BR">
+				<xs:annotation>
+					<xs:documentation>Brazil</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BS">
+				<xs:annotation>
+					<xs:documentation>Bahamas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BT">
+				<xs:annotation>
+					<xs:documentation>Bhutan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BV">
+				<xs:annotation>
+					<xs:documentation>Bouvet Island</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BW">
+				<xs:annotation>
+					<xs:documentation>Botswana</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BY">
+				<xs:annotation>
+					<xs:documentation>Belarus</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BZ">
+				<xs:annotation>
+					<xs:documentation>Belize</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA">
+				<xs:annotation>
+					<xs:documentation>Canada</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CC">
+				<xs:annotation>
+					<xs:documentation>Cocos (Keeling) Islands</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CD">
+				<xs:annotation>
+					<xs:documentation>Congo, Democratic Republic of the</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CF">
+				<xs:annotation>
+					<xs:documentation>Central African Republic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CG">
+				<xs:annotation>
+					<xs:documentation>Congo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CH">
+				<xs:annotation>
+					<xs:documentation>Switzerland</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CI">
+				<xs:annotation>
+					<xs:documentation>Cote D&apos;Ivoire</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CK">
+				<xs:annotation>
+					<xs:documentation>Cook Islands</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CL">
+				<xs:annotation>
+					<xs:documentation>Chile</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CM">
+				<xs:annotation>
+					<xs:documentation>Cameroon</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN">
+				<xs:annotation>
+					<xs:documentation>China</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CO">
+				<xs:annotation>
+					<xs:documentation>Colombia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CR">
+				<xs:annotation>
+					<xs:documentation>Costa Rica</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CS">
+				<xs:annotation>
+					<xs:documentation>Serbia and Montenegro</xs:documentation>
+					<xs:documentation>DEPRECATED, replaced by ME - Montenegro and RS - Serbia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CU">
+				<xs:annotation>
+					<xs:documentation>Cuba</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CV">
+				<xs:annotation>
+					<xs:documentation>Cape Verde</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CW">
+				<xs:annotation>
+					<xs:documentation>Curaçao</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CX">
+				<xs:annotation>
+					<xs:documentation>Christmas Island</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CY">
+				<xs:annotation>
+					<xs:documentation>Cyprus</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CZ">
+				<xs:annotation>
+					<xs:documentation>Czech Republic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DE">
+				<xs:annotation>
+					<xs:documentation>Germany</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DJ">
+				<xs:annotation>
+					<xs:documentation>Djibouti</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DK">
+				<xs:annotation>
+					<xs:documentation>Denmark</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DM">
+				<xs:annotation>
+					<xs:documentation>Dominica</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DO">
+				<xs:annotation>
+					<xs:documentation>Dominican Republic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DZ">
+				<xs:annotation>
+					<xs:documentation>Algeria</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EC">
+				<xs:annotation>
+					<xs:documentation>Ecuador</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EE">
+				<xs:annotation>
+					<xs:documentation>Estonia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EG">
+				<xs:annotation>
+					<xs:documentation>Egypt</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EH">
+				<xs:annotation>
+					<xs:documentation>Western Sahara</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ER">
+				<xs:annotation>
+					<xs:documentation>Eritrea</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ES">
+				<xs:annotation>
+					<xs:documentation>Spain</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ET">
+				<xs:annotation>
+					<xs:documentation>Ethiopia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FI">
+				<xs:annotation>
+					<xs:documentation>Finland</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FJ">
+				<xs:annotation>
+					<xs:documentation>Fiji</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FK">
+				<xs:annotation>
+					<xs:documentation>Falkland Islands (Malvinas)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FM">
+				<xs:annotation>
+					<xs:documentation>Micronesia, Federated States of</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FO">
+				<xs:annotation>
+					<xs:documentation>Faroe Islands</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FR">
+				<xs:annotation>
+					<xs:documentation>France</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GA">
+				<xs:annotation>
+					<xs:documentation>Gabon</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GB">
+				<xs:annotation>
+					<xs:documentation>United Kingdom</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GD">
+				<xs:annotation>
+					<xs:documentation>Grenada</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GE">
+				<xs:annotation>
+					<xs:documentation>Georgia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GF">
+				<xs:annotation>
+					<xs:documentation>French Guiana</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GG">
+				<xs:annotation>
+					<xs:documentation>Guernsey</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GH">
+				<xs:annotation>
+					<xs:documentation>Ghana</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GI">
+				<xs:annotation>
+					<xs:documentation>Gibraltar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GL">
+				<xs:annotation>
+					<xs:documentation>Greenland</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GM">
+				<xs:annotation>
+					<xs:documentation>Gambia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GN">
+				<xs:annotation>
+					<xs:documentation>Guinea</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GP">
+				<xs:annotation>
+					<xs:documentation>Guadeloupe</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GQ">
+				<xs:annotation>
+					<xs:documentation>Equatorial Guinea</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GR">
+				<xs:annotation>
+					<xs:documentation>Greece</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GS">
+				<xs:annotation>
+					<xs:documentation>South Georgia and the South Sandwich Islands</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GT">
+				<xs:annotation>
+					<xs:documentation>Guatemala</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GU">
+				<xs:annotation>
+					<xs:documentation>Guam</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GW">
+				<xs:annotation>
+					<xs:documentation>Guinea-Bissau</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GY">
+				<xs:annotation>
+					<xs:documentation>Guyana</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HK">
+				<xs:annotation>
+					<xs:documentation>Hong Kong</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HM">
+				<xs:annotation>
+					<xs:documentation>Heard Island and McDonald Islands</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HN">
+				<xs:annotation>
+					<xs:documentation>Honduras</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HR">
+				<xs:annotation>
+					<xs:documentation>Croatia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HT">
+				<xs:annotation>
+					<xs:documentation>Haiti</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HU">
+				<xs:annotation>
+					<xs:documentation>Hungary</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ID">
+				<xs:annotation>
+					<xs:documentation>Indonesia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IE">
+				<xs:annotation>
+					<xs:documentation>Ireland</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IL">
+				<xs:annotation>
+					<xs:documentation>Israel</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IM">
+				<xs:annotation>
+					<xs:documentation>Isle of Man</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IN">
+				<xs:annotation>
+					<xs:documentation>India</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IO">
+				<xs:annotation>
+					<xs:documentation>British Indian Ocean Territory</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IQ">
+				<xs:annotation>
+					<xs:documentation>Iraq</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IR">
+				<xs:annotation>
+					<xs:documentation>Iran, Islamic Republic of</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IS">
+				<xs:annotation>
+					<xs:documentation>Iceland</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IT">
+				<xs:annotation>
+					<xs:documentation>Italy</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="JE">
+				<xs:annotation>
+					<xs:documentation>Jersey</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="JM">
+				<xs:annotation>
+					<xs:documentation>Jamaica</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="JO">
+				<xs:annotation>
+					<xs:documentation>Jordan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="JP">
+				<xs:annotation>
+					<xs:documentation>Japan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KE">
+				<xs:annotation>
+					<xs:documentation>Kenya</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KG">
+				<xs:annotation>
+					<xs:documentation>Kyrgyzstan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KH">
+				<xs:annotation>
+					<xs:documentation>Cambodia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KI">
+				<xs:annotation>
+					<xs:documentation>Kiribati</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KM">
+				<xs:annotation>
+					<xs:documentation>Comoros</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KN">
+				<xs:annotation>
+					<xs:documentation>Saint Kitts and Nevis</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KP">
+				<xs:annotation>
+					<xs:documentation>Korea, Democratic People&apos;s Republic of</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KR">
+				<xs:annotation>
+					<xs:documentation>Korea, Republic of</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KW">
+				<xs:annotation>
+					<xs:documentation>Kuwait</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KY">
+				<xs:annotation>
+					<xs:documentation>Cayman Islands</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KZ">
+				<xs:annotation>
+					<xs:documentation>Kazakhstan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LA">
+				<xs:annotation>
+					<xs:documentation>Lao People&apos;s Democratic Republic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LB">
+				<xs:annotation>
+					<xs:documentation>Lebanon</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LC">
+				<xs:annotation>
+					<xs:documentation>Saint Lucia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LI">
+				<xs:annotation>
+					<xs:documentation>Liechtenstein</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LK">
+				<xs:annotation>
+					<xs:documentation>Sri Lanka</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LR">
+				<xs:annotation>
+					<xs:documentation>Liberia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LS">
+				<xs:annotation>
+					<xs:documentation>Lesotho</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LT">
+				<xs:annotation>
+					<xs:documentation>Lithuania</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LU">
+				<xs:annotation>
+					<xs:documentation>Luxembourg</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LV">
+				<xs:annotation>
+					<xs:documentation>Latvia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LY">
+				<xs:annotation>
+					<xs:documentation>Libyan Arab Jamahiriya</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MA">
+				<xs:annotation>
+					<xs:documentation>Morocco</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MC">
+				<xs:annotation>
+					<xs:documentation>Monaco</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MD">
+				<xs:annotation>
+					<xs:documentation>Moldova</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ME">
+				<xs:annotation>
+					<xs:documentation>Montenegro</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MF">
+				<xs:annotation>
+					<xs:documentation>Saint Martin, French part</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MG">
+				<xs:annotation>
+					<xs:documentation>Madagascar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MH">
+				<xs:annotation>
+					<xs:documentation>Marshall Islands</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MK">
+				<xs:annotation>
+					<xs:documentation>Macedonia, the former Yugoslav Republic of</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ML">
+				<xs:annotation>
+					<xs:documentation>Mali</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MM">
+				<xs:annotation>
+					<xs:documentation>Myanmar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MN">
+				<xs:annotation>
+					<xs:documentation>Mongolia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MO">
+				<xs:annotation>
+					<xs:documentation>Macao</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MP">
+				<xs:annotation>
+					<xs:documentation>Northern Mariana Islands</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MQ">
+				<xs:annotation>
+					<xs:documentation>Martinique</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MR">
+				<xs:annotation>
+					<xs:documentation>Mauritania</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MS">
+				<xs:annotation>
+					<xs:documentation>Montserrat</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MT">
+				<xs:annotation>
+					<xs:documentation>Malta</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MU">
+				<xs:annotation>
+					<xs:documentation>Mauritius</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MV">
+				<xs:annotation>
+					<xs:documentation>Maldives</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MW">
+				<xs:annotation>
+					<xs:documentation>Malawi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MX">
+				<xs:annotation>
+					<xs:documentation>Mexico</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MY">
+				<xs:annotation>
+					<xs:documentation>Malaysia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MZ">
+				<xs:annotation>
+					<xs:documentation>Mozambique</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NA">
+				<xs:annotation>
+					<xs:documentation>Namibia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NC">
+				<xs:annotation>
+					<xs:documentation>New Caledonia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NE">
+				<xs:annotation>
+					<xs:documentation>Niger</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NF">
+				<xs:annotation>
+					<xs:documentation>Norfolk Island</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NG">
+				<xs:annotation>
+					<xs:documentation>Nigeria</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NI">
+				<xs:annotation>
+					<xs:documentation>Nicaragua</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NL">
+				<xs:annotation>
+					<xs:documentation>Netherlands</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NO">
+				<xs:annotation>
+					<xs:documentation>Norway</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NP">
+				<xs:annotation>
+					<xs:documentation>Nepal</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NR">
+				<xs:annotation>
+					<xs:documentation>Nauru</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NU">
+				<xs:annotation>
+					<xs:documentation>Niue</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NZ">
+				<xs:annotation>
+					<xs:documentation>New Zealand</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="OM">
+				<xs:annotation>
+					<xs:documentation>Oman</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PA">
+				<xs:annotation>
+					<xs:documentation>Panama</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PE">
+				<xs:annotation>
+					<xs:documentation>Peru</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PF">
+				<xs:annotation>
+					<xs:documentation>French Polynesia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PG">
+				<xs:annotation>
+					<xs:documentation>Papua New Guinea</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PH">
+				<xs:annotation>
+					<xs:documentation>Philippines</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PK">
+				<xs:annotation>
+					<xs:documentation>Pakistan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PL">
+				<xs:annotation>
+					<xs:documentation>Poland</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PM">
+				<xs:annotation>
+					<xs:documentation>Saint Pierre and Miquelon</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PN">
+				<xs:annotation>
+					<xs:documentation>Pitcairn</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PR">
+				<xs:annotation>
+					<xs:documentation>Puerto Rico</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PS">
+				<xs:annotation>
+					<xs:documentation>Palestinian Territory, Occupied</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PT">
+				<xs:annotation>
+					<xs:documentation>Portugal</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PW">
+				<xs:annotation>
+					<xs:documentation>Palau</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PY">
+				<xs:annotation>
+					<xs:documentation>Paraguay</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="QA">
+				<xs:annotation>
+					<xs:documentation>Qatar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RE">
+				<xs:annotation>
+					<xs:documentation>Réunion</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RO">
+				<xs:annotation>
+					<xs:documentation>Romania</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RS">
+				<xs:annotation>
+					<xs:documentation>Serbia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RU">
+				<xs:annotation>
+					<xs:documentation>Russian Federation</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RW">
+				<xs:annotation>
+					<xs:documentation>Rwanda</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SA">
+				<xs:annotation>
+					<xs:documentation>Saudi Arabia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SB">
+				<xs:annotation>
+					<xs:documentation>Solomon Islands</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SC">
+				<xs:annotation>
+					<xs:documentation>Seychelles</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SD">
+				<xs:annotation>
+					<xs:documentation>Sudan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SE">
+				<xs:annotation>
+					<xs:documentation>Sweden</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SG">
+				<xs:annotation>
+					<xs:documentation>Singapore</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SH">
+				<xs:annotation>
+					<xs:documentation>Saint Helena, Ascension, Tristan da Cunha</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SI">
+				<xs:annotation>
+					<xs:documentation>Slovenia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SJ">
+				<xs:annotation>
+					<xs:documentation>Svalbard and Jan Mayen</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SK">
+				<xs:annotation>
+					<xs:documentation>Slovakia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SL">
+				<xs:annotation>
+					<xs:documentation>Sierra Leone</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SM">
+				<xs:annotation>
+					<xs:documentation>San Marino</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SN">
+				<xs:annotation>
+					<xs:documentation>Senegal</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SO">
+				<xs:annotation>
+					<xs:documentation>Somalia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SR">
+				<xs:annotation>
+					<xs:documentation>Suriname</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SS">
+				<xs:annotation>
+					<xs:documentation>South Sudan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ST">
+				<xs:annotation>
+					<xs:documentation>Sao Tome and Principe</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SV">
+				<xs:annotation>
+					<xs:documentation>El Salvador</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SX">
+				<xs:annotation>
+					<xs:documentation>Sint Maarten (Dutch part)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SY">
+				<xs:annotation>
+					<xs:documentation>Syrian Arab Republic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SZ">
+				<xs:annotation>
+					<xs:documentation>Swaziland</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TC">
+				<xs:annotation>
+					<xs:documentation>Turks and Caicos Islands</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TD">
+				<xs:annotation>
+					<xs:documentation>Chad</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TF">
+				<xs:annotation>
+					<xs:documentation>French Southern Territories</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TG">
+				<xs:annotation>
+					<xs:documentation>Togo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TH">
+				<xs:annotation>
+					<xs:documentation>Thailand</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TJ">
+				<xs:annotation>
+					<xs:documentation>Tajikistan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TK">
+				<xs:annotation>
+					<xs:documentation>Tokelau</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TL">
+				<xs:annotation>
+					<xs:documentation>Timor-Leste</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TM">
+				<xs:annotation>
+					<xs:documentation>Turkmenistan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TN">
+				<xs:annotation>
+					<xs:documentation>Tunisia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TO">
+				<xs:annotation>
+					<xs:documentation>Tonga</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TR">
+				<xs:annotation>
+					<xs:documentation>Turkey</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TT">
+				<xs:annotation>
+					<xs:documentation>Trinidad and Tobago</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TV">
+				<xs:annotation>
+					<xs:documentation>Tuvalu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TW">
+				<xs:annotation>
+					<xs:documentation>Taiwan, Province of China</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TZ">
+				<xs:annotation>
+					<xs:documentation>Tanzania, United Republic of</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="UA">
+				<xs:annotation>
+					<xs:documentation>Ukraine</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="UG">
+				<xs:annotation>
+					<xs:documentation>Uganda</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="UM">
+				<xs:annotation>
+					<xs:documentation>United States Minor Outlying Islands</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US">
+				<xs:annotation>
+					<xs:documentation>United States</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="UY">
+				<xs:annotation>
+					<xs:documentation>Uruguay</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="UZ">
+				<xs:annotation>
+					<xs:documentation>Uzbekistan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VA">
+				<xs:annotation>
+					<xs:documentation>Holy See (Vatican City State)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VC">
+				<xs:annotation>
+					<xs:documentation>Saint Vincent and the Grenadines</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VE">
+				<xs:annotation>
+					<xs:documentation>Venezuela, Bolivarian Republic of</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VG">
+				<xs:annotation>
+					<xs:documentation>Virgin Islands, British</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VI">
+				<xs:annotation>
+					<xs:documentation>Virgin Islands, US</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VN">
+				<xs:annotation>
+					<xs:documentation>Viet Nam</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VU">
+				<xs:annotation>
+					<xs:documentation>Vanuatu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WF">
+				<xs:annotation>
+					<xs:documentation>Wallis and Futuna</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WS">
+				<xs:annotation>
+					<xs:documentation>Samoa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="YE">
+				<xs:annotation>
+					<xs:documentation>Yemen</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="YT">
+				<xs:annotation>
+					<xs:documentation>Mayotte</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="YU">
+				<xs:annotation>
+					<xs:documentation>Yugoslavia</xs:documentation>
+					<xs:documentation>DEPRECATED, replaced by ME - Montenegro and RS - Serbia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZA">
+				<xs:annotation>
+					<xs:documentation>South Africa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZM">
+				<xs:annotation>
+					<xs:documentation>Zambia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZW">
+				<xs:annotation>
+					<xs:documentation>Zimbabwe</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List92">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 92">Supplier identifier type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Propietari</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Propietari</xs:documentation>
+					<xs:documentation>DEPRECATED - use 01.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Börsenverein Verkehrsnummer</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>German ISBN Agency publisher identifier</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>GLN</xs:documentation>
+					<xs:documentation>GS1 global location number (formerly EAN location number).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>SAN</xs:documentation>
+					<xs:documentation>Book trade Standard Address Number - US, UK etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Distributeurscode Boekenbank</xs:documentation>
+					<xs:documentation>Flemish supplier code.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Fondscode Boekenbank</xs:documentation>
+					<xs:documentation>Flemish publisher code.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>VAT Identity Number</xs:documentation>
+					<xs:documentation>Identifier for a business organization for VAT purposes, eg within the EU&apos;s VIES system. See http://ec.europa.eu/taxation_customs/vies/faqvies.do for EU VAT ID formats, which vary from country to country. Generally these consist of a two-letter country code followed by the 8-12 digits of the national VAT ID. Some countries include one or two letters within their VAT ID. See http://en.wikipedia.org/wiki/VAT_identification_number for non-EU countries that maintain similar identifiers. Spaces, dashes etc should be omitted.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List93">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 93">Supplier role</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>No especificat</xs:documentation>
+					<xs:documentation>Per defecte.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Publisher to retailers</xs:documentation>
+					<xs:documentation>Publisher as supplier to retail trade outlets.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Publisher&apos;s exclusive distributor to retailers</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Publisher&apos;s non-exclusive distributor to retailers</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Wholesaler</xs:documentation>
+					<xs:documentation>Wholesaler supplying retail trade outlets.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Sales agent</xs:documentation>
+					<xs:documentation>DEPRECATED - use &lt;MarketRepresentation> (ONIX 2.1) or &lt;MarketPublishingDetail> (ONIX 3.0) to specify a sales agent.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Publisher&apos;s distributor to retailers</xs:documentation>
+					<xs:documentation>In a specified supply territory. Use only where exclusive/non-exclusive status is not known. Prefer 02 or 03 as appropriate, where possible.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>POD supplier</xs:documentation>
+					<xs:documentation>Where a POD product is supplied to retailers and/or consumers direct from a POD source.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Retailer</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Publisher to end-customers</xs:documentation>
+					<xs:documentation>Publisher as supplier direct to consumers and/or institutional customers.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Exclusive distributor to end-customers</xs:documentation>
+					<xs:documentation>Intermediary as exclusive distributor direct to consumers and/or institutional customers.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Non-exclusive distributor to end-customers</xs:documentation>
+					<xs:documentation>Intermediary as non-exclusive distributor direct to consumers and/or institutional customers.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Distributor to end-customers</xs:documentation>
+					<xs:documentation>Use only where exclusive/non-exclusive status is not known. Prefer 10 or 11 as appropriate, where possible.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List94">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 94">Default linear unit</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="cm">
+				<xs:annotation>
+					<xs:documentation>Centimeters</xs:documentation>
+					<xs:documentation>Millimeters are the preferred metric unit of length.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="in">
+				<xs:annotation>
+					<xs:documentation>Inches (US)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mm">
+				<xs:annotation>
+					<xs:documentation>Millimeters</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List95">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 95">Default unit of weight</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="lb">
+				<xs:annotation>
+					<xs:documentation>Pounds (US)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gr">
+				<xs:annotation>
+					<xs:documentation>Grams</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="oz">
+				<xs:annotation>
+					<xs:documentation>Ounces (US)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List96">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 96">Currency code - ISO 4217</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AED">
+				<xs:annotation>
+					<xs:documentation>UAE Dirham</xs:documentation>
+					<xs:documentation>United Arab Emirates.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AFA">
+				<xs:annotation>
+					<xs:documentation>Afghani</xs:documentation>
+					<xs:documentation>DEPRECATED, replaced by AFN.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AFN">
+				<xs:annotation>
+					<xs:documentation>Afghani</xs:documentation>
+					<xs:documentation>Afghanistan.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ALL">
+				<xs:annotation>
+					<xs:documentation>Lek</xs:documentation>
+					<xs:documentation>Albania.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AMD">
+				<xs:annotation>
+					<xs:documentation>Armenian Dram</xs:documentation>
+					<xs:documentation>Armenia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ANG">
+				<xs:annotation>
+					<xs:documentation>Netherlands Antillian Guilder</xs:documentation>
+					<xs:documentation>Curaçao, Sint Maarten.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AOA">
+				<xs:annotation>
+					<xs:documentation>Angolan Kwanza</xs:documentation>
+					<xs:documentation>Angola.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ARS">
+				<xs:annotation>
+					<xs:documentation>Argentine Peso</xs:documentation>
+					<xs:documentation>Argentina.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ATS">
+				<xs:annotation>
+					<xs:documentation>Austria, Schilling</xs:documentation>
+					<xs:documentation>Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AUD">
+				<xs:annotation>
+					<xs:documentation>Australian Dollar</xs:documentation>
+					<xs:documentation>Australia, Christmas Island, Cocos (Keeling) Islands, Heard Island and McDonald Islands, Kiribati, Nauru, Norfolk Island, Tuvalu.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AWG">
+				<xs:annotation>
+					<xs:documentation>Aruban Florin</xs:documentation>
+					<xs:documentation>Aruba.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AZN">
+				<xs:annotation>
+					<xs:documentation>Azerbaijanian Manat</xs:documentation>
+					<xs:documentation>Azerbaijan.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BAM">
+				<xs:annotation>
+					<xs:documentation>Convertible Marks</xs:documentation>
+					<xs:documentation>Bosnia and Herzegovina.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BBD">
+				<xs:annotation>
+					<xs:documentation>Barbados Dollar</xs:documentation>
+					<xs:documentation>Barbados.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BDT">
+				<xs:annotation>
+					<xs:documentation>Taka</xs:documentation>
+					<xs:documentation>Bangladesh.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BEF">
+				<xs:annotation>
+					<xs:documentation>Belgium, Franc</xs:documentation>
+					<xs:documentation>Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BGL">
+				<xs:annotation>
+					<xs:documentation>Lev</xs:documentation>
+					<xs:documentation>DEPRECATED, replaced by BGN.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BGN">
+				<xs:annotation>
+					<xs:documentation>Lev</xs:documentation>
+					<xs:documentation>Bulgaria.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BHD">
+				<xs:annotation>
+					<xs:documentation>Bahraini Dinar</xs:documentation>
+					<xs:documentation>Bahrain.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BIF">
+				<xs:annotation>
+					<xs:documentation>Burundi Franc</xs:documentation>
+					<xs:documentation>Burundi.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BMD">
+				<xs:annotation>
+					<xs:documentation>Bermuda Dollar</xs:documentation>
+					<xs:documentation>Bermuda.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BND">
+				<xs:annotation>
+					<xs:documentation>Brunei Dollar</xs:documentation>
+					<xs:documentation>Brunei Darussalam.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BOB">
+				<xs:annotation>
+					<xs:documentation>Boliviano</xs:documentation>
+					<xs:documentation>Bolivia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BRL">
+				<xs:annotation>
+					<xs:documentation>Brazilian Real</xs:documentation>
+					<xs:documentation>Brazil.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BSD">
+				<xs:annotation>
+					<xs:documentation>Bahamian Dollar</xs:documentation>
+					<xs:documentation>Bahamas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BTN">
+				<xs:annotation>
+					<xs:documentation>Ngultrun</xs:documentation>
+					<xs:documentation>Bhutan.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BWP">
+				<xs:annotation>
+					<xs:documentation>Pula</xs:documentation>
+					<xs:documentation>Botswana.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BYR">
+				<xs:annotation>
+					<xs:documentation>Belarussian Ruble</xs:documentation>
+					<xs:documentation>Belarus.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BZD">
+				<xs:annotation>
+					<xs:documentation>Belize Dollar</xs:documentation>
+					<xs:documentation>Belize.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CAD">
+				<xs:annotation>
+					<xs:documentation>Canadian Dollar</xs:documentation>
+					<xs:documentation>Canada.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CDF">
+				<xs:annotation>
+					<xs:documentation>Franc Congolais</xs:documentation>
+					<xs:documentation>Congo (Democratic Republic of the).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CHF">
+				<xs:annotation>
+					<xs:documentation>Swiss Franc</xs:documentation>
+					<xs:documentation>Switzerland, Liechtenstein.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CLP">
+				<xs:annotation>
+					<xs:documentation>Chilean Peso</xs:documentation>
+					<xs:documentation>Chile.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CNY">
+				<xs:annotation>
+					<xs:documentation>Yuan Renminbi</xs:documentation>
+					<xs:documentation>China.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="COP">
+				<xs:annotation>
+					<xs:documentation>Colombian Peso</xs:documentation>
+					<xs:documentation>Colombia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CRC">
+				<xs:annotation>
+					<xs:documentation>Costa Rican Colon</xs:documentation>
+					<xs:documentation>Costa Rica.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CSD">
+				<xs:annotation>
+					<xs:documentation>Serbian Dinar</xs:documentation>
+					<xs:documentation>Deprecated, replaced by RSD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CUC">
+				<xs:annotation>
+					<xs:documentation>Cuban Convertible Peso</xs:documentation>
+					<xs:documentation>Cuba (alternative currency).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CUP">
+				<xs:annotation>
+					<xs:documentation>Cuban Peso</xs:documentation>
+					<xs:documentation>Cuba.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CVE">
+				<xs:annotation>
+					<xs:documentation>Cape Verde Escudo</xs:documentation>
+					<xs:documentation>Cape Verde.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CYP">
+				<xs:annotation>
+					<xs:documentation>Cyprus Pound</xs:documentation>
+					<xs:documentation>Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CZK">
+				<xs:annotation>
+					<xs:documentation>Czech Koruna</xs:documentation>
+					<xs:documentation>Czech Republic.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DEM">
+				<xs:annotation>
+					<xs:documentation>Germany, Mark</xs:documentation>
+					<xs:documentation>Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DJF">
+				<xs:annotation>
+					<xs:documentation>Djibouti Franc</xs:documentation>
+					<xs:documentation>Djibouti.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DKK">
+				<xs:annotation>
+					<xs:documentation>Danish Krone</xs:documentation>
+					<xs:documentation>Denmark, Faroe Islands, Greenland.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DOP">
+				<xs:annotation>
+					<xs:documentation>Dominican Peso</xs:documentation>
+					<xs:documentation>Dominican Republic.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DZD">
+				<xs:annotation>
+					<xs:documentation>Algerian Dinar</xs:documentation>
+					<xs:documentation>Algeria.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EEK">
+				<xs:annotation>
+					<xs:documentation>Kroon</xs:documentation>
+					<xs:documentation>Estonia - now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EGP">
+				<xs:annotation>
+					<xs:documentation>Egyptian Pound</xs:documentation>
+					<xs:documentation>Egypt.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ERN">
+				<xs:annotation>
+					<xs:documentation>Nakfa</xs:documentation>
+					<xs:documentation>Eritrea.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ESP">
+				<xs:annotation>
+					<xs:documentation>Spain, Peseta</xs:documentation>
+					<xs:documentation>Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ETB">
+				<xs:annotation>
+					<xs:documentation>Ethiopian Birr</xs:documentation>
+					<xs:documentation>Ethiopia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EUR">
+				<xs:annotation>
+					<xs:documentation>Euro</xs:documentation>
+					<xs:documentation>Andorra, Austria, Belgium, Cyprus, Estonia, Finland, France, Fr Guiana, Fr S Territories, Germany, Greece, Guadeloupe, Holy See (Vatican City), Ireland, Italy, Luxembourg, Martinique, Malta, Mayotte, Monaco, Montenegro, Netherlands, Portugal, Réunion, St Pierre and Miquelon, San Marino, Spain.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FIM">
+				<xs:annotation>
+					<xs:documentation>Finland, Markka</xs:documentation>
+					<xs:documentation>Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FJD">
+				<xs:annotation>
+					<xs:documentation>Fiji Dollar</xs:documentation>
+					<xs:documentation>Fiji.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FKP">
+				<xs:annotation>
+					<xs:documentation>Falkland Islands Pound</xs:documentation>
+					<xs:documentation>Falkland Islands (Malvinas).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FRF">
+				<xs:annotation>
+					<xs:documentation>France, Franc</xs:documentation>
+					<xs:documentation>Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GBP">
+				<xs:annotation>
+					<xs:documentation>Pound Sterling</xs:documentation>
+					<xs:documentation>United Kingdom, Isle of Man, Channel Islands, South Georgia, South Sandwich Islands, Brisish Indian Ocean Territory.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GEL">
+				<xs:annotation>
+					<xs:documentation>Lari</xs:documentation>
+					<xs:documentation>Georgia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GHC">
+				<xs:annotation>
+					<xs:documentation>Cedi</xs:documentation>
+					<xs:documentation>Deprecated, replaced by GHS.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GHS">
+				<xs:annotation>
+					<xs:documentation>Cedi</xs:documentation>
+					<xs:documentation>Ghana.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GIP">
+				<xs:annotation>
+					<xs:documentation>Gibraltar Pound</xs:documentation>
+					<xs:documentation>Gibraltar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GMD">
+				<xs:annotation>
+					<xs:documentation>Dalasi</xs:documentation>
+					<xs:documentation>Gambia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GNF">
+				<xs:annotation>
+					<xs:documentation>Guinea Franc</xs:documentation>
+					<xs:documentation>Guinea.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GRD">
+				<xs:annotation>
+					<xs:documentation>Greece, Drachma</xs:documentation>
+					<xs:documentation>Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GTQ">
+				<xs:annotation>
+					<xs:documentation>Quetzal</xs:documentation>
+					<xs:documentation>Guatemala.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GWP">
+				<xs:annotation>
+					<xs:documentation>Guinea-Bissau Peso</xs:documentation>
+					<xs:documentation>Now replaced by the CFA Franc BCEAO XOF use only for historical prices that pre-date use of the CFA Franc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GYD">
+				<xs:annotation>
+					<xs:documentation>Guyana Dollar</xs:documentation>
+					<xs:documentation>Guyana.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HKD">
+				<xs:annotation>
+					<xs:documentation>Hong Kong Dollar</xs:documentation>
+					<xs:documentation>Hong Kong, Macao.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HNL">
+				<xs:annotation>
+					<xs:documentation>Lempira</xs:documentation>
+					<xs:documentation>Honduras.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HRK">
+				<xs:annotation>
+					<xs:documentation>Croatian Kuna</xs:documentation>
+					<xs:documentation>Croatia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HTG">
+				<xs:annotation>
+					<xs:documentation>Gourde</xs:documentation>
+					<xs:documentation>Haiti.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HUF">
+				<xs:annotation>
+					<xs:documentation>Forint</xs:documentation>
+					<xs:documentation>Hungary.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IDR">
+				<xs:annotation>
+					<xs:documentation>Rupiah</xs:documentation>
+					<xs:documentation>Indonesia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IEP">
+				<xs:annotation>
+					<xs:documentation>Ireland, Punt</xs:documentation>
+					<xs:documentation>Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ILS">
+				<xs:annotation>
+					<xs:documentation>Israeli Sheqel</xs:documentation>
+					<xs:documentation>Israel.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="INR">
+				<xs:annotation>
+					<xs:documentation>Indian Rupee</xs:documentation>
+					<xs:documentation>India.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IQD">
+				<xs:annotation>
+					<xs:documentation>Iraqi Dinar</xs:documentation>
+					<xs:documentation>Iraq.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IRR">
+				<xs:annotation>
+					<xs:documentation>Iranian Rial</xs:documentation>
+					<xs:documentation>Iran (Islamic Republic of).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ISK">
+				<xs:annotation>
+					<xs:documentation>Iceland Krona</xs:documentation>
+					<xs:documentation>Iceland.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ITL">
+				<xs:annotation>
+					<xs:documentation>Italy, Lira</xs:documentation>
+					<xs:documentation>Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="JMD">
+				<xs:annotation>
+					<xs:documentation>Jamaican Dollar</xs:documentation>
+					<xs:documentation>Jamaica.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="JOD">
+				<xs:annotation>
+					<xs:documentation>Jordanian Dinar</xs:documentation>
+					<xs:documentation>Jordan.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="JPY">
+				<xs:annotation>
+					<xs:documentation>Yen</xs:documentation>
+					<xs:documentation>Japan.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KES">
+				<xs:annotation>
+					<xs:documentation>Kenyan Shilling</xs:documentation>
+					<xs:documentation>Kenya.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KGS">
+				<xs:annotation>
+					<xs:documentation>Som</xs:documentation>
+					<xs:documentation>Kyrgyzstan.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KHR">
+				<xs:annotation>
+					<xs:documentation>Riel</xs:documentation>
+					<xs:documentation>Cambodia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KMF">
+				<xs:annotation>
+					<xs:documentation>Comoro Franc</xs:documentation>
+					<xs:documentation>Comoros.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KPW">
+				<xs:annotation>
+					<xs:documentation>North Korean Won</xs:documentation>
+					<xs:documentation>Korea (Democratic People&apos;s Republic of).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KRW">
+				<xs:annotation>
+					<xs:documentation>Won</xs:documentation>
+					<xs:documentation>Korea (Republic of).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KWD">
+				<xs:annotation>
+					<xs:documentation>Kuwaiti Dinar</xs:documentation>
+					<xs:documentation>Kuwait.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KYD">
+				<xs:annotation>
+					<xs:documentation>Cayman Islands Dollar</xs:documentation>
+					<xs:documentation>Cayman Islands.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KZT">
+				<xs:annotation>
+					<xs:documentation>Tenge</xs:documentation>
+					<xs:documentation>Kazakstan.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LAK">
+				<xs:annotation>
+					<xs:documentation>Kip</xs:documentation>
+					<xs:documentation>Lao People&apos;s Democratic Republic.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LBP">
+				<xs:annotation>
+					<xs:documentation>Lebanese Pound</xs:documentation>
+					<xs:documentation>Lebanon.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LKR">
+				<xs:annotation>
+					<xs:documentation>Sri Lanka Rupee</xs:documentation>
+					<xs:documentation>Sri Lanka.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LRD">
+				<xs:annotation>
+					<xs:documentation>Liberian Dollar</xs:documentation>
+					<xs:documentation>Liberia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LSL">
+				<xs:annotation>
+					<xs:documentation>Loti</xs:documentation>
+					<xs:documentation>Lesotho.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LTL">
+				<xs:annotation>
+					<xs:documentation>Lithuanian Litus</xs:documentation>
+					<xs:documentation>Lithuania.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LUF">
+				<xs:annotation>
+					<xs:documentation>Luxembourg, Franc</xs:documentation>
+					<xs:documentation>Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LVL">
+				<xs:annotation>
+					<xs:documentation>Latvian Lats</xs:documentation>
+					<xs:documentation>Latvia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LYD">
+				<xs:annotation>
+					<xs:documentation>Libyan Dinar</xs:documentation>
+					<xs:documentation>Libyan Arab Jamahiriya.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MAD">
+				<xs:annotation>
+					<xs:documentation>Moroccan Dirham</xs:documentation>
+					<xs:documentation>Morocco, Western Sahara.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MDL">
+				<xs:annotation>
+					<xs:documentation>Moldovan Leu</xs:documentation>
+					<xs:documentation>Moldova, Republic of.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MGA">
+				<xs:annotation>
+					<xs:documentation>Ariary</xs:documentation>
+					<xs:documentation>Madagascar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MGF">
+				<xs:annotation>
+					<xs:documentation>Malagasy Franc</xs:documentation>
+					<xs:documentation>Now replaced by the Ariary (MGA).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MKD">
+				<xs:annotation>
+					<xs:documentation>Denar</xs:documentation>
+					<xs:documentation>Macedonia (former Yugoslav Republic of).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MMK">
+				<xs:annotation>
+					<xs:documentation>Kyat</xs:documentation>
+					<xs:documentation>Myanmar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MNT">
+				<xs:annotation>
+					<xs:documentation>Tugrik</xs:documentation>
+					<xs:documentation>Mongolia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MOP">
+				<xs:annotation>
+					<xs:documentation>Pataca</xs:documentation>
+					<xs:documentation>Macau.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MRO">
+				<xs:annotation>
+					<xs:documentation>Ouguiya</xs:documentation>
+					<xs:documentation>Mauritania.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MTL">
+				<xs:annotation>
+					<xs:documentation>Maltese Lira</xs:documentation>
+					<xs:documentation>Malta - now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MUR">
+				<xs:annotation>
+					<xs:documentation>Mauritius Rupee</xs:documentation>
+					<xs:documentation>Mauritius.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MVR">
+				<xs:annotation>
+					<xs:documentation>Rufiyaa</xs:documentation>
+					<xs:documentation>Maldives.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MWK">
+				<xs:annotation>
+					<xs:documentation>Kwacha</xs:documentation>
+					<xs:documentation>Malawi.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MXN">
+				<xs:annotation>
+					<xs:documentation>Mexican Peso</xs:documentation>
+					<xs:documentation>Mexico.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MYR">
+				<xs:annotation>
+					<xs:documentation>Malaysian Ringgit</xs:documentation>
+					<xs:documentation>Malaysia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MZN">
+				<xs:annotation>
+					<xs:documentation>Metical</xs:documentation>
+					<xs:documentation>Mozambique.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NAD">
+				<xs:annotation>
+					<xs:documentation>Namibia Dollar</xs:documentation>
+					<xs:documentation>Namibia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NGN">
+				<xs:annotation>
+					<xs:documentation>Naira</xs:documentation>
+					<xs:documentation>Nigeria.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NIO">
+				<xs:annotation>
+					<xs:documentation>Cordoba Oro</xs:documentation>
+					<xs:documentation>Nicaragua.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NLG">
+				<xs:annotation>
+					<xs:documentation>Netherlands, Guilder</xs:documentation>
+					<xs:documentation>Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NOK">
+				<xs:annotation>
+					<xs:documentation>Norwegian Krone</xs:documentation>
+					<xs:documentation>Norway, Bouvet Island, Svalbard and Jan Mayen.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NPR">
+				<xs:annotation>
+					<xs:documentation>Nepalese Rupee</xs:documentation>
+					<xs:documentation>Nepal.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NZD">
+				<xs:annotation>
+					<xs:documentation>New Zealand Dollar</xs:documentation>
+					<xs:documentation>New Zealand, Cook Islands, Niue, Pitcairn, Tokelau.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="OMR">
+				<xs:annotation>
+					<xs:documentation>Rial Omani</xs:documentation>
+					<xs:documentation>Oman.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PAB">
+				<xs:annotation>
+					<xs:documentation>Balboa</xs:documentation>
+					<xs:documentation>Panama.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PEN">
+				<xs:annotation>
+					<xs:documentation>Nuevo Sol</xs:documentation>
+					<xs:documentation>Peru.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PGK">
+				<xs:annotation>
+					<xs:documentation>Kina</xs:documentation>
+					<xs:documentation>Papua New Guinea.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PHP">
+				<xs:annotation>
+					<xs:documentation>Philippine Peso</xs:documentation>
+					<xs:documentation>Philippines.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PKR">
+				<xs:annotation>
+					<xs:documentation>Pakistan Rupee</xs:documentation>
+					<xs:documentation>Pakistan.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PLN">
+				<xs:annotation>
+					<xs:documentation>Zloty</xs:documentation>
+					<xs:documentation>Poland.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PTE">
+				<xs:annotation>
+					<xs:documentation>Portugal, Escudo</xs:documentation>
+					<xs:documentation>Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PYG">
+				<xs:annotation>
+					<xs:documentation>Guarani</xs:documentation>
+					<xs:documentation>Paraguay.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="QAR">
+				<xs:annotation>
+					<xs:documentation>Qatari Rial</xs:documentation>
+					<xs:documentation>Qatar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ROL">
+				<xs:annotation>
+					<xs:documentation>Old Leu</xs:documentation>
+					<xs:documentation>Deprecated, replaced by RON.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RON">
+				<xs:annotation>
+					<xs:documentation>New Leu</xs:documentation>
+					<xs:documentation>Romania.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RSD">
+				<xs:annotation>
+					<xs:documentation>Serbian Dinar</xs:documentation>
+					<xs:documentation>Serbia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RUB">
+				<xs:annotation>
+					<xs:documentation>Russian Ruble</xs:documentation>
+					<xs:documentation>Russian Federation.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RUR">
+				<xs:annotation>
+					<xs:documentation>Russian Ruble</xs:documentation>
+					<xs:documentation>DEPRECATED, replaced by RUB.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RWF">
+				<xs:annotation>
+					<xs:documentation>Rwanda Franc</xs:documentation>
+					<xs:documentation>Rwanda.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SAR">
+				<xs:annotation>
+					<xs:documentation>Saudi Riyal</xs:documentation>
+					<xs:documentation>Saudi Arabia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SBD">
+				<xs:annotation>
+					<xs:documentation>Solomon Islands Dollar</xs:documentation>
+					<xs:documentation>Solomon Islands.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SCR">
+				<xs:annotation>
+					<xs:documentation>Seychelles Rupee</xs:documentation>
+					<xs:documentation>Seychelles.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SDD">
+				<xs:annotation>
+					<xs:documentation>Sudanese Dinar</xs:documentation>
+					<xs:documentation>Now replaced by the Sudanese Pound (SDG).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SDG">
+				<xs:annotation>
+					<xs:documentation>Sudanese Pound</xs:documentation>
+					<xs:documentation>Sudan.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SEK">
+				<xs:annotation>
+					<xs:documentation>Swedish Krona</xs:documentation>
+					<xs:documentation>Sweden.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SGD">
+				<xs:annotation>
+					<xs:documentation>Singapore Dollar</xs:documentation>
+					<xs:documentation>Singapore.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SHP">
+				<xs:annotation>
+					<xs:documentation>Saint Helena Pound</xs:documentation>
+					<xs:documentation>Saint Helena.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SIT">
+				<xs:annotation>
+					<xs:documentation>Tolar</xs:documentation>
+					<xs:documentation>Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SKK">
+				<xs:annotation>
+					<xs:documentation>Slovak Koruna</xs:documentation>
+					<xs:documentation>Now replaced by the Euro (EUR): use only for historical prices that pre-date the introduction of the Euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SLL">
+				<xs:annotation>
+					<xs:documentation>Leone</xs:documentation>
+					<xs:documentation>Sierra Leone.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SOS">
+				<xs:annotation>
+					<xs:documentation>Somali Shilling</xs:documentation>
+					<xs:documentation>Somalia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SRD">
+				<xs:annotation>
+					<xs:documentation>Suriname Guilder</xs:documentation>
+					<xs:documentation>Suriname.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SRG">
+				<xs:annotation>
+					<xs:documentation>Suriname Guilder</xs:documentation>
+					<xs:documentation>DEPRECATED, replaced by SRD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="STD">
+				<xs:annotation>
+					<xs:documentation>Dobra</xs:documentation>
+					<xs:documentation>São Tome and Principe.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SVC">
+				<xs:annotation>
+					<xs:documentation>El Salvador Colon</xs:documentation>
+					<xs:documentation>El Salvador.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SYP">
+				<xs:annotation>
+					<xs:documentation>Syrian Pound</xs:documentation>
+					<xs:documentation>Syrian Arab Republic.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SZL">
+				<xs:annotation>
+					<xs:documentation>Lilangeni</xs:documentation>
+					<xs:documentation>Swaziland.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="THB">
+				<xs:annotation>
+					<xs:documentation>Baht</xs:documentation>
+					<xs:documentation>Thailand.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TJS">
+				<xs:annotation>
+					<xs:documentation>Somoni</xs:documentation>
+					<xs:documentation>Tajikistan.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TMM">
+				<xs:annotation>
+					<xs:documentation>Manat</xs:documentation>
+					<xs:documentation>Deprecated, replaced by TMT.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TMT">
+				<xs:annotation>
+					<xs:documentation>Manat</xs:documentation>
+					<xs:documentation>Turkmenistan.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TND">
+				<xs:annotation>
+					<xs:documentation>Tunisian Dinar</xs:documentation>
+					<xs:documentation>Tunisia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TOP">
+				<xs:annotation>
+					<xs:documentation>Pa&apos;anga</xs:documentation>
+					<xs:documentation>Tonga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TPE">
+				<xs:annotation>
+					<xs:documentation>Timor Escudo</xs:documentation>
+					<xs:documentation>NO LONGER VALID, Timor-Leste now uses the US Dollar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TRL">
+				<xs:annotation>
+					<xs:documentation>Turkish Lira (old)</xs:documentation>
+					<xs:documentation>Deprecated, replaced by TRY.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TRY">
+				<xs:annotation>
+					<xs:documentation>Turkish Lira (new)</xs:documentation>
+					<xs:documentation>Turkey, from 1 January 2005.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TTD">
+				<xs:annotation>
+					<xs:documentation>Trinidad and Tobago Dollar</xs:documentation>
+					<xs:documentation>Trinidad and Tobago.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TWD">
+				<xs:annotation>
+					<xs:documentation>New Taiwan Dollar</xs:documentation>
+					<xs:documentation>Taiwan (Province of China).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TZS">
+				<xs:annotation>
+					<xs:documentation>Tanzanian Shilling</xs:documentation>
+					<xs:documentation>Tanzania (United Republic of).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="UAH">
+				<xs:annotation>
+					<xs:documentation>Hryvnia</xs:documentation>
+					<xs:documentation>Ukraine.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="UGX">
+				<xs:annotation>
+					<xs:documentation>Uganda Shilling</xs:documentation>
+					<xs:documentation>Uganda.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="USD">
+				<xs:annotation>
+					<xs:documentation>US Dollar</xs:documentation>
+					<xs:documentation>United States, American Samoa, British Indian Ocean Territory, Ecuador, Guam, Marshall Is, Micronesia (Federated States of), Northern Mariana Is, Palau, Puerto Rico, Timor-Leste, Turks and Caicos Is, US Minor Outlying Is, Virgin Is (British), Virgin Is (US).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="UYU">
+				<xs:annotation>
+					<xs:documentation>Peso Uruguayo</xs:documentation>
+					<xs:documentation>Uruguay.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="UZS">
+				<xs:annotation>
+					<xs:documentation>Uzbekistan Sum</xs:documentation>
+					<xs:documentation>Uzbekistan.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VEB">
+				<xs:annotation>
+					<xs:documentation>Bolivar</xs:documentation>
+					<xs:documentation>Deprecated, replaced by VEF.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VEF">
+				<xs:annotation>
+					<xs:documentation>Bolivar fuerte</xs:documentation>
+					<xs:documentation>Venezuela.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VND">
+				<xs:annotation>
+					<xs:documentation>Dong</xs:documentation>
+					<xs:documentation>Viet Nam.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VUV">
+				<xs:annotation>
+					<xs:documentation>Vatu</xs:documentation>
+					<xs:documentation>Vanuatu.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WST">
+				<xs:annotation>
+					<xs:documentation>Tala</xs:documentation>
+					<xs:documentation>Samoa.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XAF">
+				<xs:annotation>
+					<xs:documentation>CFA Franc BEAC</xs:documentation>
+					<xs:documentation>Cameroon, Central African Republic, Chad, Congo, Equatorial Guinea, Gabon.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XCD">
+				<xs:annotation>
+					<xs:documentation>East Caribbean Dollar</xs:documentation>
+					<xs:documentation>Anguilla, Antigua and Barbuda, Dominica, Grenada, Montserrat, Saint Kitts and Nevis, Saint Lucia, Saint Vincent and the Grenadines.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XOF">
+				<xs:annotation>
+					<xs:documentation>CFA Franc BCEAO</xs:documentation>
+					<xs:documentation>Benin, Burkina Faso, Côte D&apos;Ivoire, Guinea-Bissau, Mali, Niger, Senegal, Togo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XPF">
+				<xs:annotation>
+					<xs:documentation>CFP Franc</xs:documentation>
+					<xs:documentation>French Polynesia, New Caledonia, Wallis and Futuna.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="YER">
+				<xs:annotation>
+					<xs:documentation>Yemeni Rial</xs:documentation>
+					<xs:documentation>Yemen.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="YUM">
+				<xs:annotation>
+					<xs:documentation>Yugoslavian Dinar</xs:documentation>
+					<xs:documentation>DEPRECATED, replaced by CSD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZAR">
+				<xs:annotation>
+					<xs:documentation>Rand</xs:documentation>
+					<xs:documentation>South Africa.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZMK">
+				<xs:annotation>
+					<xs:documentation>Kwacha</xs:documentation>
+					<xs:documentation>Zambia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZWD">
+				<xs:annotation>
+					<xs:documentation>Zimbabwe Dollar</xs:documentation>
+					<xs:documentation>Deprecated, replaced with ZWL.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZWL">
+				<xs:annotation>
+					<xs:documentation>Zimbabwe Dollar</xs:documentation>
+					<xs:documentation>Zimbabwe.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List97">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 97">Bible text feature</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="RL">
+				<xs:annotation>
+					<xs:documentation>Red letter</xs:documentation>
+					<xs:documentation>Words spoken by Christ are printed in red.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List98">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 98">Product form feature value - binding or page edge color</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="BLK">
+				<xs:annotation>
+					<xs:documentation>Black</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BLU">
+				<xs:annotation>
+					<xs:documentation>Blue</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BRN">
+				<xs:annotation>
+					<xs:documentation>Brown</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BUR">
+				<xs:annotation>
+					<xs:documentation>Burgundy/maroon</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CRE">
+				<xs:annotation>
+					<xs:documentation>Cream</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FCO">
+				<xs:annotation>
+					<xs:documentation>Four-color</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FCS">
+				<xs:annotation>
+					<xs:documentation>Four-color and spot-color</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GLD">
+				<xs:annotation>
+					<xs:documentation>Gold</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GRN">
+				<xs:annotation>
+					<xs:documentation>Green</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GRY">
+				<xs:annotation>
+					<xs:documentation>Grey</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MUL">
+				<xs:annotation>
+					<xs:documentation>Multicolor</xs:documentation>
+					<xs:documentation>Use &lt;ProductFormFeatureDescription> to add brief details if required.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NAV">
+				<xs:annotation>
+					<xs:documentation>Navy/Dark blue</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ORG">
+				<xs:annotation>
+					<xs:documentation>Orange</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PNK">
+				<xs:annotation>
+					<xs:documentation>Pink</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PUR">
+				<xs:annotation>
+					<xs:documentation>Purple</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RED">
+				<xs:annotation>
+					<xs:documentation>Red</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SLV">
+				<xs:annotation>
+					<xs:documentation>Silver</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TAN">
+				<xs:annotation>
+					<xs:documentation>Tan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WHI">
+				<xs:annotation>
+					<xs:documentation>White</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="YEL">
+				<xs:annotation>
+					<xs:documentation>Yellow</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZZZ">
+				<xs:annotation>
+					<xs:documentation>Altres</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List99">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 99">Product form feature value - special cover material</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Berkshire leather</xs:documentation>
+					<xs:documentation>Pigskin.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Calfskin</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>French Morocco</xs:documentation>
+					<xs:documentation>Calf split or sheep split.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Morocco</xs:documentation>
+					<xs:documentation>Goatskin.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Bonded buffalo grain</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Bonded calf grain</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Bonded Cordova</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Bonded eelskin</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Bonded Ostraleg</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Bonded ostrich</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Bonded reptile grain</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Bonded leather</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Cowhide</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Eelskin</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Kivar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Leatherflex</xs:documentation>
+					<xs:documentation>An imitation leather binding material.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Moleskin</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Softhide leather</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Metal</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Velvet</xs:documentation>
+					<xs:documentation>German &apos;Samt&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>Mother-of-pearl</xs:documentation>
+					<xs:documentation>Spanish &apos;nácar&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Papyrus</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Géltex</xs:documentation>
+					<xs:documentation>An imitation cloth binding material.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Guaflex</xs:documentation>
+					<xs:documentation>An imitation leather binding material.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List100">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 100">Discount code type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>BIC discount group code</xs:documentation>
+					<xs:documentation>UK publisher&apos;s or distributor&apos;s discount group code in a format specified by BIC to ensure uniqueness.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Proprietary discount code</xs:documentation>
+					<xs:documentation>A publisher&apos;s or supplier&apos;s own code which identifies a trade discount category, the actual discount being set by trading partner agreement (applies to goods supplied on standard trade discounting terms).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Boeksoort</xs:documentation>
+					<xs:documentation>Terms code used in the Netherlands book trade.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>German terms code</xs:documentation>
+					<xs:documentation>Terms code used in German ONIX applications.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Proprietary commission code</xs:documentation>
+					<xs:documentation>A publisher&apos;s or supplier&apos;s own code which identifies a commission rate category, the actual commission rate being set by trading partner agreement (applies to goods supplied on agency terms).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>BIC commission group code</xs:documentation>
+					<xs:documentation>UK publisher&apos;s or distributor&apos;s commission group code in format specified by BIC to ensure uniqueness. Format is identical to BIC discount group code, but indicates a commission rather than a discount (applies to goods supplied on agency terms).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List101">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 101">Person name identifier type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Propietari</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>PND</xs:documentation>
+					<xs:documentation>Personennamendatei - person name authority file used by Deutsche Nationalbibliothek and in other German-speaking countries. See http://www.d-nb.de/standardisierung/normdateien/pnd.htm (German) or http://www.d-nb.de/eng/standardisierung/normdateien/pnd.htm (English).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>ISNI</xs:documentation>
+					<xs:documentation>International Standard Name Identifier. See &apos;http://www.isni.org/&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List102">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 102">Sales outlet identifier type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Propietari</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>BIC sales outlet ID code</xs:documentation>
+					<xs:documentation>DEPRECATED - use code 03.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>ONIX sales outlet ID code</xs:documentation>
+					<xs:documentation>From List 139.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List121">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 121">Text script code - ISO 15924</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Afak">
+				<xs:annotation>
+					<xs:documentation>Afaka</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Arab">
+				<xs:annotation>
+					<xs:documentation>Arabic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Armi">
+				<xs:annotation>
+					<xs:documentation>Imperial Aramaic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Armn">
+				<xs:annotation>
+					<xs:documentation>Armenian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Avst">
+				<xs:annotation>
+					<xs:documentation>Avestan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Bali">
+				<xs:annotation>
+					<xs:documentation>Balinese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Bamu">
+				<xs:annotation>
+					<xs:documentation>Bamun</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Bass">
+				<xs:annotation>
+					<xs:documentation>Bassa Vah</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Batk">
+				<xs:annotation>
+					<xs:documentation>Batak</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Beng">
+				<xs:annotation>
+					<xs:documentation>Bengali</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Blis">
+				<xs:annotation>
+					<xs:documentation>Blissymbols</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Bopo">
+				<xs:annotation>
+					<xs:documentation>Bopomofo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Brah">
+				<xs:annotation>
+					<xs:documentation>Brahmi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Brai">
+				<xs:annotation>
+					<xs:documentation>Braille</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Bugi">
+				<xs:annotation>
+					<xs:documentation>Buginese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Buhd">
+				<xs:annotation>
+					<xs:documentation>Buhid</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Cakm">
+				<xs:annotation>
+					<xs:documentation>Chakma</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Cans">
+				<xs:annotation>
+					<xs:documentation>Unified Canadian Aboriginal Syllabics</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Cari">
+				<xs:annotation>
+					<xs:documentation>Carian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Cham">
+				<xs:annotation>
+					<xs:documentation>Cham</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Cher">
+				<xs:annotation>
+					<xs:documentation>Cherokee</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Cirt">
+				<xs:annotation>
+					<xs:documentation>Cirth</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Copt">
+				<xs:annotation>
+					<xs:documentation>Coptic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Cprt">
+				<xs:annotation>
+					<xs:documentation>Cypriot</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Cyrl">
+				<xs:annotation>
+					<xs:documentation>Cyrillic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Cyrs">
+				<xs:annotation>
+					<xs:documentation>Cyrillic (Old Church Slavonic variant)</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Deva">
+				<xs:annotation>
+					<xs:documentation>Devanagari (Nagari)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Dsrt">
+				<xs:annotation>
+					<xs:documentation>Deseret (Mormon)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Dupl">
+				<xs:annotation>
+					<xs:documentation>Duployan shorthand, Duployan stenography</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Egyd">
+				<xs:annotation>
+					<xs:documentation>Egyptian demotic</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Egyh">
+				<xs:annotation>
+					<xs:documentation>Egyptian hieratic</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Egyp">
+				<xs:annotation>
+					<xs:documentation>Egyptian hieroglyphs</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Elba">
+				<xs:annotation>
+					<xs:documentation>Elbasan</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Ethi">
+				<xs:annotation>
+					<xs:documentation>Ethiopic (Ge&apos;ez)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Geok">
+				<xs:annotation>
+					<xs:documentation>Khutsuri (Asomtavruli and Khutsuri)</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Geor">
+				<xs:annotation>
+					<xs:documentation>Georgian (Mkhedruli)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Glag">
+				<xs:annotation>
+					<xs:documentation>Glagolitic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Goth">
+				<xs:annotation>
+					<xs:documentation>Gothic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Gran">
+				<xs:annotation>
+					<xs:documentation>Grantha</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Grek">
+				<xs:annotation>
+					<xs:documentation>Greek</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Gujr">
+				<xs:annotation>
+					<xs:documentation>Gujarati</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Guru">
+				<xs:annotation>
+					<xs:documentation>Gurmukhi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Hang">
+				<xs:annotation>
+					<xs:documentation>Hangul (Hangŭl, Hangeul)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Hani">
+				<xs:annotation>
+					<xs:documentation>Han (Hanzi, Kanji, Hanja)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Hano">
+				<xs:annotation>
+					<xs:documentation>Hanunoo (Hanunóo)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Hans">
+				<xs:annotation>
+					<xs:documentation>Han (Simplified variant)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Hant">
+				<xs:annotation>
+					<xs:documentation>Han (Traditional variant)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Hebr">
+				<xs:annotation>
+					<xs:documentation>Hebrew</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Hira">
+				<xs:annotation>
+					<xs:documentation>Hiragana</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Hmng">
+				<xs:annotation>
+					<xs:documentation>Pahawh Hmong</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Hrkt">
+				<xs:annotation>
+					<xs:documentation>Japanese syllabaries (alias for Hiragana + Katakana)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Hung">
+				<xs:annotation>
+					<xs:documentation>Old Hungarian</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Inds">
+				<xs:annotation>
+					<xs:documentation>Indus (Harappan)</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Ital">
+				<xs:annotation>
+					<xs:documentation>Old Italic (Etruscan, Oscan, etc.)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Java">
+				<xs:annotation>
+					<xs:documentation>Javanese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Jpan">
+				<xs:annotation>
+					<xs:documentation>Japanese syllabaries (alias for Han + Hiragana + Katakana)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Jurc">
+				<xs:annotation>
+					<xs:documentation>Jurchen</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Kali">
+				<xs:annotation>
+					<xs:documentation>Kayah Li</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Kana">
+				<xs:annotation>
+					<xs:documentation>Katakana</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Khar">
+				<xs:annotation>
+					<xs:documentation>Kharoshthi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Khmr">
+				<xs:annotation>
+					<xs:documentation>Khmer</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Khoj">
+				<xs:annotation>
+					<xs:documentation>Khojki</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Knda">
+				<xs:annotation>
+					<xs:documentation>Kannada</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Kore">
+				<xs:annotation>
+					<xs:documentation>Korean (alias for Hangul + Han)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Kpel">
+				<xs:annotation>
+					<xs:documentation>Kpelle</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Kthi">
+				<xs:annotation>
+					<xs:documentation>Kaithi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Lana">
+				<xs:annotation>
+					<xs:documentation>Lanna, Tai Tham</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Laoo">
+				<xs:annotation>
+					<xs:documentation>Lao</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Latf">
+				<xs:annotation>
+					<xs:documentation>Latin (Fraktur variant)</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Latg">
+				<xs:annotation>
+					<xs:documentation>Latin (Gaelic variant)</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Latn">
+				<xs:annotation>
+					<xs:documentation>Latin</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Lepc">
+				<xs:annotation>
+					<xs:documentation>Lepcha (Róng)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Limb">
+				<xs:annotation>
+					<xs:documentation>Limbu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Lina">
+				<xs:annotation>
+					<xs:documentation>Linear A</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Linb">
+				<xs:annotation>
+					<xs:documentation>Linear B</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Lisu">
+				<xs:annotation>
+					<xs:documentation>Lisu (Fraser)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Loma">
+				<xs:annotation>
+					<xs:documentation>Loma</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Lyci">
+				<xs:annotation>
+					<xs:documentation>Lycian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Lydi">
+				<xs:annotation>
+					<xs:documentation>Lydian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Mand">
+				<xs:annotation>
+					<xs:documentation>Mandaic, Mandaean</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Mani">
+				<xs:annotation>
+					<xs:documentation>Manichaean</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Maya">
+				<xs:annotation>
+					<xs:documentation>Mayan hieroglyphs</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Mend">
+				<xs:annotation>
+					<xs:documentation>Mende</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Merc">
+				<xs:annotation>
+					<xs:documentation>Meroitic Cursive</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Mero">
+				<xs:annotation>
+					<xs:documentation>Meroitic Hieroglyphs</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Mlym">
+				<xs:annotation>
+					<xs:documentation>Malayalam</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Mong">
+				<xs:annotation>
+					<xs:documentation>Mongolian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Moon">
+				<xs:annotation>
+					<xs:documentation>Moon (Moon code, Moon script, Moon type)</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Mroo">
+				<xs:annotation>
+					<xs:documentation>Mro, Mru</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Mtei">
+				<xs:annotation>
+					<xs:documentation>Meitei Mayek (Meithei, Meetei)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Mymr">
+				<xs:annotation>
+					<xs:documentation>Myanmar (Burmese)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Narb">
+				<xs:annotation>
+					<xs:documentation>Old North Arabian (Ancient North Arabian)</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Nbat">
+				<xs:annotation>
+					<xs:documentation>Nabatean</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Nkgb">
+				<xs:annotation>
+					<xs:documentation>Nakhi Geba (&apos;Na-&apos;Khi ²Ggŏ-¹baw, Naxi Geba)</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Nkoo">
+				<xs:annotation>
+					<xs:documentation>N&apos;Ko</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Nshu">
+				<xs:annotation>
+					<xs:documentation>Nüshu</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Ogam">
+				<xs:annotation>
+					<xs:documentation>Ogham</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Olck">
+				<xs:annotation>
+					<xs:documentation>Ol Chiki (Ol Cemet&apos;, Ol, Santali)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Orkh">
+				<xs:annotation>
+					<xs:documentation>Old Turkic, Orkhon Runic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Orya">
+				<xs:annotation>
+					<xs:documentation>Oriya</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Osma">
+				<xs:annotation>
+					<xs:documentation>Osmanya</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Palm">
+				<xs:annotation>
+					<xs:documentation>Palmyrene</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Perm">
+				<xs:annotation>
+					<xs:documentation>Old Permic</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Phag">
+				<xs:annotation>
+					<xs:documentation>Phags-pa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Phli">
+				<xs:annotation>
+					<xs:documentation>Inscriptional Pahlavi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Phlp">
+				<xs:annotation>
+					<xs:documentation>Psalter Pahlavi</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Phlv">
+				<xs:annotation>
+					<xs:documentation>Book Pahlavi</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Phnx">
+				<xs:annotation>
+					<xs:documentation>Phoenician</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Plrd">
+				<xs:annotation>
+					<xs:documentation>Miao (Pollard)</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Prti">
+				<xs:annotation>
+					<xs:documentation>Inscriptional Parthian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Qaaa">
+				<xs:annotation>
+					<xs:documentation>Reserved for private use (start)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Qabx">
+				<xs:annotation>
+					<xs:documentation>Reserved for private use (end)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Rjng">
+				<xs:annotation>
+					<xs:documentation>Rejang (Redjang, Kaganga)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Roro">
+				<xs:annotation>
+					<xs:documentation>Rongorongo</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Runr">
+				<xs:annotation>
+					<xs:documentation>Runic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Samr">
+				<xs:annotation>
+					<xs:documentation>Samaritan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Sara">
+				<xs:annotation>
+					<xs:documentation>Sarati</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Sarb">
+				<xs:annotation>
+					<xs:documentation>Old South Arabian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Saur">
+				<xs:annotation>
+					<xs:documentation>Saurashtra</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Sgnw">
+				<xs:annotation>
+					<xs:documentation>SignWriting</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Shaw">
+				<xs:annotation>
+					<xs:documentation>Shavian (Shaw)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Shrd">
+				<xs:annotation>
+					<xs:documentation>Sharada, Śāradā</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Sind">
+				<xs:annotation>
+					<xs:documentation>Khudawadi, Sindhi</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Sinh">
+				<xs:annotation>
+					<xs:documentation>Sinhala</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Sora">
+				<xs:annotation>
+					<xs:documentation>Sora Sompeng</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Sund">
+				<xs:annotation>
+					<xs:documentation>Sundanese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Sylo">
+				<xs:annotation>
+					<xs:documentation>Syloti Nagri</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Syrc">
+				<xs:annotation>
+					<xs:documentation>Syriac</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Syre">
+				<xs:annotation>
+					<xs:documentation>Syriac (Estrangelo variant)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Syrj">
+				<xs:annotation>
+					<xs:documentation>Syriac (Western variant)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Syrn">
+				<xs:annotation>
+					<xs:documentation>Syriac (Eastern variant)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Tagb">
+				<xs:annotation>
+					<xs:documentation>Tagbanwa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Takr">
+				<xs:annotation>
+					<xs:documentation>Takri, Ṭākrī, Ṭāṅkrī</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Tale">
+				<xs:annotation>
+					<xs:documentation>Tai Le</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Talu">
+				<xs:annotation>
+					<xs:documentation>New Tai Lue</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Taml">
+				<xs:annotation>
+					<xs:documentation>Tamil</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Tang">
+				<xs:annotation>
+					<xs:documentation>Tangut</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Tavt">
+				<xs:annotation>
+					<xs:documentation>Tai Viet</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Telu">
+				<xs:annotation>
+					<xs:documentation>Telugu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Teng">
+				<xs:annotation>
+					<xs:documentation>Tengwar</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Tfng">
+				<xs:annotation>
+					<xs:documentation>Tifinagh (Berber)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Tglg">
+				<xs:annotation>
+					<xs:documentation>Tagalog (Baybayin, Alibata)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Thaa">
+				<xs:annotation>
+					<xs:documentation>Thaana</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Thai">
+				<xs:annotation>
+					<xs:documentation>Thai</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Tibt">
+				<xs:annotation>
+					<xs:documentation>Tibetan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Tirh">
+				<xs:annotation>
+					<xs:documentation>Tiruta</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Ugar">
+				<xs:annotation>
+					<xs:documentation>Ugaritic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Vaii">
+				<xs:annotation>
+					<xs:documentation>Vai</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Visp">
+				<xs:annotation>
+					<xs:documentation>Visible Speech</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Wara">
+				<xs:annotation>
+					<xs:documentation>Warang Citi (Varang Kshiti)</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Wole">
+				<xs:annotation>
+					<xs:documentation>Woleai</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Xpeo">
+				<xs:annotation>
+					<xs:documentation>Old Persian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Xsux">
+				<xs:annotation>
+					<xs:documentation>Cuneiform, Sumero-Akkadian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Yiii">
+				<xs:annotation>
+					<xs:documentation>Yi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Zinh">
+				<xs:annotation>
+					<xs:documentation>Code for inherited script</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Zmth">
+				<xs:annotation>
+					<xs:documentation>Mathematical notation</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Zsym">
+				<xs:annotation>
+					<xs:documentation>Symbols</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Zxxx">
+				<xs:annotation>
+					<xs:documentation>Code for unwritten documents</xs:documentation>
+					<xs:documentation>Script is not supported by Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Zyyy">
+				<xs:annotation>
+					<xs:documentation>Code for undetermined script</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Zzzz">
+				<xs:annotation>
+					<xs:documentation>Code for uncoded script</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List138">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 138">Transliteration scheme code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="SFS4900">
+				<xs:annotation>
+					<xs:documentation>Finnish standard SFS 4900</xs:documentation>
+					<xs:documentation>Transliteration of Cyrillic characters - Slavic languages.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SFS5807">
+				<xs:annotation>
+					<xs:documentation>Finnish standard SFS 5807</xs:documentation>
+					<xs:documentation>Transliteration and transcription of Greek characters.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SFS5755">
+				<xs:annotation>
+					<xs:documentation>Finnish standard SFS 5755</xs:documentation>
+					<xs:documentation>Transliteration of Arabic characters.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SFS3602">
+				<xs:annotation>
+					<xs:documentation>Finnish standard SFS 5824</xs:documentation>
+					<xs:documentation>Transliteration of Hebrew characters.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ISO3602">
+				<xs:annotation>
+					<xs:documentation>ISO 3602</xs:documentation>
+					<xs:documentation>Documentation - Romanization of Japanese (kana script).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ISO7098">
+				<xs:annotation>
+					<xs:documentation>ISO 7098</xs:documentation>
+					<xs:documentation>Information and documentation - Romanization of Chinese.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List139">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 139">ONIX sales outlet IDs</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ACM">
+				<xs:annotation>
+					<xs:documentation>A C Moore</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AAP">
+				<xs:annotation>
+					<xs:documentation>AandP</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ALB">
+				<xs:annotation>
+					<xs:documentation>Albertson&apos;s</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AMZ">
+				<xs:annotation>
+					<xs:documentation>Amazon</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ANR">
+				<xs:annotation>
+					<xs:documentation>Angus and Robertson</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ANB">
+				<xs:annotation>
+					<xs:documentation>Anobii</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="APC">
+				<xs:annotation>
+					<xs:documentation>Apple Computer stores</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ASD">
+				<xs:annotation>
+					<xs:documentation>Asda</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AUD">
+				<xs:annotation>
+					<xs:documentation>Audible</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BDL">
+				<xs:annotation>
+					<xs:documentation>B Dalton</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BNO">
+				<xs:annotation>
+					<xs:documentation>Barnes and Noble</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BBB">
+				<xs:annotation>
+					<xs:documentation>Bed Bath and Beyond</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BST">
+				<xs:annotation>
+					<xs:documentation>Best Buy</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BIL">
+				<xs:annotation>
+					<xs:documentation>Bilbary</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BJW">
+				<xs:annotation>
+					<xs:documentation>BJ&apos;s Wholesale Club</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BLK">
+				<xs:annotation>
+					<xs:documentation>Blackwell&apos;s</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BCA">
+				<xs:annotation>
+					<xs:documentation>Book Club Associates</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BSH">
+				<xs:annotation>
+					<xs:documentation>Bookish</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BKP">
+				<xs:annotation>
+					<xs:documentation>Bookpeople</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BKM">
+				<xs:annotation>
+					<xs:documentation>Books-A-Million</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BRD">
+				<xs:annotation>
+					<xs:documentation>Borders</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BRB">
+				<xs:annotation>
+					<xs:documentation>Borders/Books Etc</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BRT">
+				<xs:annotation>
+					<xs:documentation>British Bookshops</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CHD">
+				<xs:annotation>
+					<xs:documentation>Christianbook.com</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CST">
+				<xs:annotation>
+					<xs:documentation>Costco</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CRB">
+				<xs:annotation>
+					<xs:documentation>Crate and Barrel</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CVS">
+				<xs:annotation>
+					<xs:documentation>CVS Drug Stores</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DSG">
+				<xs:annotation>
+					<xs:documentation>Dick&apos;s Sporting Goods</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DYM">
+				<xs:annotation>
+					<xs:documentation>Dymocks</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ELC">
+				<xs:annotation>
+					<xs:documentation>Early Learning Centre</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ESN">
+				<xs:annotation>
+					<xs:documentation>Eason</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EBC">
+				<xs:annotation>
+					<xs:documentation>Ebooks Corp</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ECH">
+				<xs:annotation>
+					<xs:documentation>eChristian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ELB">
+				<xs:annotation>
+					<xs:documentation>Elib.se</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EMP">
+				<xs:annotation>
+					<xs:documentation>Empik</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ENH">
+				<xs:annotation>
+					<xs:documentation>English Heritage</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FNC">
+				<xs:annotation>
+					<xs:documentation>Fnac</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FRY">
+				<xs:annotation>
+					<xs:documentation>Fry&apos;s Electronics</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GMS">
+				<xs:annotation>
+					<xs:documentation>Gamestop</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GOO">
+				<xs:annotation>
+					<xs:documentation>Google Books</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GOS">
+				<xs:annotation>
+					<xs:documentation>GoSpoken</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HST">
+				<xs:annotation>
+					<xs:documentation>Hastings Entertainment</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HMV">
+				<xs:annotation>
+					<xs:documentation>HMV</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HMD">
+				<xs:annotation>
+					<xs:documentation>Home Depot</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IND">
+				<xs:annotation>
+					<xs:documentation>Indigo-Chapters</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="JSM">
+				<xs:annotation>
+					<xs:documentation>John Smith and Son</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KMT">
+				<xs:annotation>
+					<xs:documentation>K-Mart</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KNB">
+				<xs:annotation>
+					<xs:documentation>KNFB/Blio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KNO">
+				<xs:annotation>
+					<xs:documentation>Kno Inc</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KBO">
+				<xs:annotation>
+					<xs:documentation>Kobo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KOO">
+				<xs:annotation>
+					<xs:documentation>Koorong</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KRG">
+				<xs:annotation>
+					<xs:documentation>Kroger</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LWE">
+				<xs:annotation>
+					<xs:documentation>Lowe&apos;s</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MKS">
+				<xs:annotation>
+					<xs:documentation>Marks and Spencer</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MAT">
+				<xs:annotation>
+					<xs:documentation>Matras</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MMS">
+				<xs:annotation>
+					<xs:documentation>Media Markt/Saturn</xs:documentation>
+					<xs:documentation>Also known as Media World.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MCR">
+				<xs:annotation>
+					<xs:documentation>Microcenter</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MRR">
+				<xs:annotation>
+					<xs:documentation>Morrisons</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MTC">
+				<xs:annotation>
+					<xs:documentation>Mothercare</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NTR">
+				<xs:annotation>
+					<xs:documentation>National Trust</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="OFD">
+				<xs:annotation>
+					<xs:documentation>Office Depot</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="OFM">
+				<xs:annotation>
+					<xs:documentation>Office Max</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="OLF">
+				<xs:annotation>
+					<xs:documentation>OLF</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PST">
+				<xs:annotation>
+					<xs:documentation>Past Times</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PTS">
+				<xs:annotation>
+					<xs:documentation>Pet Smart</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PTC">
+				<xs:annotation>
+					<xs:documentation>Petco</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PLY">
+				<xs:annotation>
+					<xs:documentation>Play.com</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PTB">
+				<xs:annotation>
+					<xs:documentation>Pottery Barn</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RCL">
+				<xs:annotation>
+					<xs:documentation>ReadCloud</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RST">
+				<xs:annotation>
+					<xs:documentation>Restoration Hardware</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RET">
+				<xs:annotation>
+					<xs:documentation>Rethink</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RTZ">
+				<xs:annotation>
+					<xs:documentation>Ritz Camera</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SFW">
+				<xs:annotation>
+					<xs:documentation>Safeway</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SNS">
+				<xs:annotation>
+					<xs:documentation>Sainsbury&apos;s</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SLF">
+				<xs:annotation>
+					<xs:documentation>Selfridges</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SNY">
+				<xs:annotation>
+					<xs:documentation>Sony</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="STP">
+				<xs:annotation>
+					<xs:documentation>Staples</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TRG">
+				<xs:annotation>
+					<xs:documentation>Target</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TES">
+				<xs:annotation>
+					<xs:documentation>Tesco</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TSR">
+				<xs:annotation>
+					<xs:documentation>Toys &apos;R&apos; Us</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TSO">
+				<xs:annotation>
+					<xs:documentation>TSO (The Stationery Office)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VRG">
+				<xs:annotation>
+					<xs:documentation>Virgin Megastores</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WHS">
+				<xs:annotation>
+					<xs:documentation>W H Smith</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WTR">
+				<xs:annotation>
+					<xs:documentation>Waitrose</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WLM">
+				<xs:annotation>
+					<xs:documentation>Wal-Mart</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WST">
+				<xs:annotation>
+					<xs:documentation>Waterstone&apos;s</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WHT">
+				<xs:annotation>
+					<xs:documentation>Whitcoul&apos;s</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WLS">
+				<xs:annotation>
+					<xs:documentation>Williams Sonoma</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WLW">
+				<xs:annotation>
+					<xs:documentation>Woolworths</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZVV">
+				<xs:annotation>
+					<xs:documentation>Zavvi</xs:documentation>
+					<xs:documentation>Formerly Virgin Megastores (UK).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZZZ">
+				<xs:annotation>
+					<xs:documentation>Altres</xs:documentation>
+					<xs:documentation>Include retailer name in &lt;SalesOutletName>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List140">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 140">US CPSIA choking hazard warning code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>WARNING: CHOKING HAZARD - Small parts | Not for children under 3 yrs.</xs:documentation>
+					<xs:documentation>List withdrawn - use List 143.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>WARNING: CHOKING HAZARD - This toy is a small ball | Not for children under 3 yrs.</xs:documentation>
+					<xs:documentation>List withdrawn - use List 143.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>WARNING: CHOKING HAZARD - Toy contains a small ball | Not for children under 3 yrs.</xs:documentation>
+					<xs:documentation>List withdrawn - use List 143.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>WARNING: CHOKING HAZARD - Children under 8 yrs. can choke or suffocate on uninflated or broken balloons. Adult supervision required | Keep uninflated balloons from children. Discard broken balloons at once.</xs:documentation>
+					<xs:documentation>List withdrawn - use List 143.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>WARNING: CHOKING HAZARD - This toy is a marble | Not for children under 3 yrs.</xs:documentation>
+					<xs:documentation>List withdrawn - use List 143.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>WARNING: CHOKING HAZARD - Toy contains a marble | Not for children under 3 yrs.</xs:documentation>
+					<xs:documentation>List withdrawn - use List 143.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>No choking hazard warning necessary</xs:documentation>
+					<xs:documentation>List withdrawn - use List 143.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List141">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 141">Barcode indicator</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Not barcoded</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Barcoded, scheme unspecified</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>GTIN-13</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>GTIN-13+5 (US dollar price encoded)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>GTIN-13+5 (CAN dollar price encoded)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>GTIN-13+5 (no price encoded)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>UPC-12 (item-specific)</xs:documentation>
+					<xs:documentation>AKA item/price.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>UPC-12+5 (item-specific)</xs:documentation>
+					<xs:documentation>AKA item/price.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>UPC-12 (price-point)</xs:documentation>
+					<xs:documentation>AKA price/item.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>UPC-12+5 (price-point)</xs:documentation>
+					<xs:documentation>AKA price/item.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List142">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 142">Position on product</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Unknown / unspecified</xs:documentation>
+					<xs:documentation>Position unknown or unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Cover 4</xs:documentation>
+					<xs:documentation>The back cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Cover 3</xs:documentation>
+					<xs:documentation>The inside back cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Cover 2</xs:documentation>
+					<xs:documentation>The inside front cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Cover 1</xs:documentation>
+					<xs:documentation>The front cover of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>On spine</xs:documentation>
+					<xs:documentation>The spine of a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>On box</xs:documentation>
+					<xs:documentation>Used only for boxed products.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>On tag</xs:documentation>
+					<xs:documentation>Used only for products fitted with hanging tags.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>On bottom</xs:documentation>
+					<xs:documentation>Not be used for books unless they are contained within outer packaging.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>On back</xs:documentation>
+					<xs:documentation>Not be used for books unless they are contained within outer packaging.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>On outer sleeve / back</xs:documentation>
+					<xs:documentation>Used only for products packaged in outer sleeves.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>On removable wrapping</xs:documentation>
+					<xs:documentation>Used only for products packaged in shrink-wrap or other removable wrapping.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List143">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 143">US CPSIA choking hazard warning code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>WARNING: CHOKING HAZARD - Small parts | Not for children under 3 yrs.</xs:documentation>
+					<xs:documentation>Required on applicable products sold in the US.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>WARNING: CHOKING HAZARD - Children under 8 yrs. can choke or suffocate on uninflated or broken balloons. Adult supervision required | Keep uninflated balloons from children. Discard broken balloons at once.</xs:documentation>
+					<xs:documentation>Required on applicable products sold in the US.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>WARNING: CHOKING HAZARD - This toy is a small ball | Not for children under 3 yrs.</xs:documentation>
+					<xs:documentation>Required on applicable products sold in the US.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>WARNING: CHOKING HAZARD - Toy contains a small ball | Not for children under 3 yrs.</xs:documentation>
+					<xs:documentation>Required on applicable products sold in the US.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>WARNING: CHOKING HAZARD - This toy is a marble | Not for children under 3 yrs.</xs:documentation>
+					<xs:documentation>Required on applicable products sold in the US.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>WARNING: CHOKING HAZARD - Toy contains a marble | Not for children under 3 yrs.</xs:documentation>
+					<xs:documentation>Required on applicable products sold in the US.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>No choking hazard warning necessary</xs:documentation>
+					<xs:documentation>To be used when a supplier wishes to make a clear statement that no such warning is applicable to product.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List144">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 144">E-publication technical protection</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Cap</xs:documentation>
+					<xs:documentation>Has no technical protection.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>DRM</xs:documentation>
+					<xs:documentation>Has DRM protection.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Digital watermarking</xs:documentation>
+					<xs:documentation>Has digital watermarking.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Adobe DRM</xs:documentation>
+					<xs:documentation>Has DRM protection applied by the Adobe CS4 Content Server Package or by the Adobe ADEPT hosted service.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Apple DRM</xs:documentation>
+					<xs:documentation>FairPlay&apos; DRM protection applied via Apple proprietary online store.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>OMA DRM</xs:documentation>
+					<xs:documentation>Has OMA v2 DRM protection applied, as used to protect some mobile phone content.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List145">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 145">Usage type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Previsualitza</xs:documentation>
+					<xs:documentation>Preview before purchase.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>En paper</xs:documentation>
+					<xs:documentation>Print paper copy of extract.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Copy / paste</xs:documentation>
+					<xs:documentation>Make digital copy of extract.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Share</xs:documentation>
+					<xs:documentation>Share product across multiple concurrent devices.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Text to speech</xs:documentation>
+					<xs:documentation>&apos;Read aloud&apos; with text to speech functionality.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Lend</xs:documentation>
+					<xs:documentation>Lendable to other device owner or account holder, eg &apos;Lend-to-a-friend&apos;, library lending. The &apos;primary&apos; copy becomes unusable while the secondary copy is &apos;on loan&apos; unless a number of concurrent borrowers is also specified).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Time-limited license</xs:documentation>
+					<xs:documentation>E-publication license is time limited. Use with 02 from List 146 and a number of days in &lt;EpubUsageLimit>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List146">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 146">Usage status</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Permitted unlimited</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Permitted subject to limit</xs:documentation>
+					<xs:documentation>Limit should be specified in &lt;EpubUsageLimit>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Prohibited</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List147">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 147">Unit of usage</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Copies</xs:documentation>
+					<xs:documentation>Maximum number of copies that may be made of a permitted extract.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Characters</xs:documentation>
+					<xs:documentation>Maximum number of characters in a permitted extract for a specified usage.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Paraules</xs:documentation>
+					<xs:documentation>Maximum number of words in a permitted extract for a specified usage.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Pàgines</xs:documentation>
+					<xs:documentation>Maximum number of pages in a permitted extract for a specified usage.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Percentage</xs:documentation>
+					<xs:documentation>Maximum percentage of total content in a permitted extract for a specified usage.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Devices</xs:documentation>
+					<xs:documentation>Maximum number of devices in &apos;share group&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Concurrent users</xs:documentation>
+					<xs:documentation>Maximum number of concurrent users. NB where the number of concurrent users is specifically not limited, set the number of concurrent users to zero.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Percentage per time period</xs:documentation>
+					<xs:documentation>Maximum percentage of total content which may be used in a specified usage per time period; the time period being specified as another EpubUsageQuantity.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Days</xs:documentation>
+					<xs:documentation>Maximum time period in days.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Times</xs:documentation>
+					<xs:documentation>Maximum number of times a specified usage may occur.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Allowed usage start page</xs:documentation>
+					<xs:documentation>Page number where allowed usage begins. &lt;Quantity> should contain an absolute page number, counting the cover as page 1. (This type of page numbering should not be used where the e-publication has no fixed pagination). Use with (max number of) Pages, Percentage of content, or End page to specify pages allowed in Preview.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Allowed usage end page</xs:documentation>
+					<xs:documentation>Page number at which allowed usage ends. &lt;Quantity> should contain an absolute page number, counting the cover as page 1. (This type of page numbering should not be used where the e-publication has no fixed pagination). Use with Start page to specify pages allowed in a preview.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List148">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 148">Collection type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Unspecified (default)</xs:documentation>
+					<xs:documentation>Collection type is not determined.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Publisher collection</xs:documentation>
+					<xs:documentation>The collection is a bibliographic collection (eg a series) defined and identified by a publisher, either on the product itself or in product information supplied by the publisher.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Ascribed collection</xs:documentation>
+					<xs:documentation>The collection has been defined and identified by a party in the metadata supply chain other than the publisher, typically an aggregator.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List149">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 149">Title element level</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Product</xs:documentation>
+					<xs:documentation>The title element refers to an individual product.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Collection level</xs:documentation>
+					<xs:documentation>The title element refers to the top level of a bibliographic collection.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Subcollection</xs:documentation>
+					<xs:documentation>The title element refers to an intermediate level of a bibliographic collection that comprises two or more &apos;sub-collections&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Content item</xs:documentation>
+					<xs:documentation>The title element refers to a content item within a product, eg a work included in a combined or &apos;omnibus&apos; edition, or a chapter in a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List150">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 150">Product form</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>No definit</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AA">
+				<xs:annotation>
+					<xs:documentation>Audio</xs:documentation>
+					<xs:documentation>Audio recording - detail unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AB">
+				<xs:annotation>
+					<xs:documentation>Audio cassette</xs:documentation>
+					<xs:documentation>Audio cassette (analogue).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AC">
+				<xs:annotation>
+					<xs:documentation>CD-Audio</xs:documentation>
+					<xs:documentation>Audio compact disc, in any recording format: use coding in Product Form Detail to specify the format, if required.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AD">
+				<xs:annotation>
+					<xs:documentation>DAT</xs:documentation>
+					<xs:documentation>Digital audio tape cassette.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AE">
+				<xs:annotation>
+					<xs:documentation>Audio disc</xs:documentation>
+					<xs:documentation>Audio disc (excluding CD).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AF">
+				<xs:annotation>
+					<xs:documentation>Audio tape</xs:documentation>
+					<xs:documentation>Audio tape (reel tape).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AG">
+				<xs:annotation>
+					<xs:documentation>MiniDisc</xs:documentation>
+					<xs:documentation>Sony MiniDisc format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AH">
+				<xs:annotation>
+					<xs:documentation>CD-Extra</xs:documentation>
+					<xs:documentation>Audio compact disc with part CD-ROM content.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AI">
+				<xs:annotation>
+					<xs:documentation>DVD Audio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AJ">
+				<xs:annotation>
+					<xs:documentation>Downloadable audio file</xs:documentation>
+					<xs:documentation>Audio recording downloadable online.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AK">
+				<xs:annotation>
+					<xs:documentation>Pre-recorded digital audio player</xs:documentation>
+					<xs:documentation>For example, Playaway audiobook and player: use coding in Product Form Detail to specify the recording format, if required.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AL">
+				<xs:annotation>
+					<xs:documentation>Pre-recorded SD card</xs:documentation>
+					<xs:documentation>For example, Audiofy audiobook chip.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AZ">
+				<xs:annotation>
+					<xs:documentation>Other audio format</xs:documentation>
+					<xs:documentation>Other audio format not specified by AB to AK.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BA">
+				<xs:annotation>
+					<xs:documentation>Llibre</xs:documentation>
+					<xs:documentation>Book - detail unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BB">
+				<xs:annotation>
+					<xs:documentation>Hardback</xs:documentation>
+					<xs:documentation>Hardback or cased book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BC">
+				<xs:annotation>
+					<xs:documentation>Paperback / softback</xs:documentation>
+					<xs:documentation>Paperback or other softback book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BD">
+				<xs:annotation>
+					<xs:documentation>Loose-leaf</xs:documentation>
+					<xs:documentation>Loose-leaf book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BE">
+				<xs:annotation>
+					<xs:documentation>Spiral bound</xs:documentation>
+					<xs:documentation>Spiral, comb or coil bound book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BF">
+				<xs:annotation>
+					<xs:documentation>Pamphlet</xs:documentation>
+					<xs:documentation>Pamphlet or brochure, stapled; German &apos;geheftet&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BG">
+				<xs:annotation>
+					<xs:documentation>Leather / fine binding</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BH">
+				<xs:annotation>
+					<xs:documentation>Board book</xs:documentation>
+					<xs:documentation>Child&apos;s book with all pages printed on board.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BI">
+				<xs:annotation>
+					<xs:documentation>Rag book</xs:documentation>
+					<xs:documentation>Child&apos;s book with all pages printed on textile.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BJ">
+				<xs:annotation>
+					<xs:documentation>Bath book</xs:documentation>
+					<xs:documentation>Child&apos;s book printed on waterproof material.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BK">
+				<xs:annotation>
+					<xs:documentation>Novelty book</xs:documentation>
+					<xs:documentation>A book whose novelty consists wholly or partly in a format which cannot be described by any other available code - a &apos;conventional&apos; format code is always to be preferred; one or more Product Form Detail codes, eg from the B2nn group, should be used whenever possible to provide additional description.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BL">
+				<xs:annotation>
+					<xs:documentation>Slide bound</xs:documentation>
+					<xs:documentation>Slide bound book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BM">
+				<xs:annotation>
+					<xs:documentation>Big book</xs:documentation>
+					<xs:documentation>Extra-large format for teaching etc; this format and terminology may be specifically UK; required as a top-level differentiator.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BN">
+				<xs:annotation>
+					<xs:documentation>Part-work (fascículo)</xs:documentation>
+					<xs:documentation>A part-work issued with its own ISBN and intended to be collected and bound into a complete book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BO">
+				<xs:annotation>
+					<xs:documentation>Fold-out book or chart</xs:documentation>
+					<xs:documentation>Concertina-folded book or chart, designed to fold to pocket or regular page size: use for German &apos;Leporello&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BP">
+				<xs:annotation>
+					<xs:documentation>Foam book</xs:documentation>
+					<xs:documentation>A children&apos;s book whose cover and pages are made of foam.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BZ">
+				<xs:annotation>
+					<xs:documentation>Other book format</xs:documentation>
+					<xs:documentation>Other book format or binding not specified by BB to BO.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA">
+				<xs:annotation>
+					<xs:documentation>Sheet map</xs:documentation>
+					<xs:documentation>Sheet map - detail unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CB">
+				<xs:annotation>
+					<xs:documentation>Sheet map, folded</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CC">
+				<xs:annotation>
+					<xs:documentation>Sheet map, flat</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CD">
+				<xs:annotation>
+					<xs:documentation>Sheet map, rolled</xs:documentation>
+					<xs:documentation>See Code List 80 for &apos;rolled in tube&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CE">
+				<xs:annotation>
+					<xs:documentation>Globe</xs:documentation>
+					<xs:documentation>Globe or planisphere.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CZ">
+				<xs:annotation>
+					<xs:documentation>Other cartographic</xs:documentation>
+					<xs:documentation>Other cartographic format not specified by CB to CE.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DA">
+				<xs:annotation>
+					<xs:documentation>Digital (on physical carrier)</xs:documentation>
+					<xs:documentation>Digital content delivered on a physical carrier (detail unspecified).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DB">
+				<xs:annotation>
+					<xs:documentation>CD-ROM</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DC">
+				<xs:annotation>
+					<xs:documentation>CD-I</xs:documentation>
+					<xs:documentation>CD interactive.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DE">
+				<xs:annotation>
+					<xs:documentation>Game cartridge</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DF">
+				<xs:annotation>
+					<xs:documentation>Diskette</xs:documentation>
+					<xs:documentation>AKA &apos;floppy disc&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DI">
+				<xs:annotation>
+					<xs:documentation>DVD-ROM</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DJ">
+				<xs:annotation>
+					<xs:documentation>Secure Digital (SD) Memory Card</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DK">
+				<xs:annotation>
+					<xs:documentation>Compact Flash Memory Card</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DL">
+				<xs:annotation>
+					<xs:documentation>Memory Stick Memory Card</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DM">
+				<xs:annotation>
+					<xs:documentation>USB Flash Drive</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DN">
+				<xs:annotation>
+					<xs:documentation>Double-sided CD/DVD</xs:documentation>
+					<xs:documentation>Double-sided disc, one side Audio CD/CD-ROM, other side DVD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DZ">
+				<xs:annotation>
+					<xs:documentation>Other digital carrier</xs:documentation>
+					<xs:documentation>Other carrier of digital content not specified by DB to DN.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EA">
+				<xs:annotation>
+					<xs:documentation>Digital (delivered electronically)</xs:documentation>
+					<xs:documentation>Digital content delivered electronically (delivery method unspecified).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EB">
+				<xs:annotation>
+					<xs:documentation>Digital download and online</xs:documentation>
+					<xs:documentation>Digital content available both by download and by online access.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EC">
+				<xs:annotation>
+					<xs:documentation>Digital online</xs:documentation>
+					<xs:documentation>Digital content accessed online only.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ED">
+				<xs:annotation>
+					<xs:documentation>Digital download</xs:documentation>
+					<xs:documentation>Digital content delivered by download only.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FA">
+				<xs:annotation>
+					<xs:documentation>Film or transparency</xs:documentation>
+					<xs:documentation>Film or transparency - detail unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FC">
+				<xs:annotation>
+					<xs:documentation>Slides</xs:documentation>
+					<xs:documentation>Photographic transparencies mounted for projection.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FD">
+				<xs:annotation>
+					<xs:documentation>OHP transparencies</xs:documentation>
+					<xs:documentation>Transparencies for overhead projector.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FE">
+				<xs:annotation>
+					<xs:documentation>Filmstrip</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FF">
+				<xs:annotation>
+					<xs:documentation>Film</xs:documentation>
+					<xs:documentation>Continuous movie film as opposed to filmstrip.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FZ">
+				<xs:annotation>
+					<xs:documentation>Other film or transparency format</xs:documentation>
+					<xs:documentation>Other film or transparency format not specified by FB to FF.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LA">
+				<xs:annotation>
+					<xs:documentation>Digital product license</xs:documentation>
+					<xs:documentation>Digital product license (delivery method not encoded).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LB">
+				<xs:annotation>
+					<xs:documentation>Digital product license key</xs:documentation>
+					<xs:documentation>Digital product license delivered through the retail supply chain as a physical &apos;key&apos;, typically a card or booklet containing a code enabling the purchaser to download the associated product.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LC">
+				<xs:annotation>
+					<xs:documentation>Digital product license code</xs:documentation>
+					<xs:documentation>Digital product license delivered by email or other electronic distribution, typically providing a code enabling the purchaser to upgrade or extend the license supplied with the associated product.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MA">
+				<xs:annotation>
+					<xs:documentation>Microform</xs:documentation>
+					<xs:documentation>Microform - detail unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MB">
+				<xs:annotation>
+					<xs:documentation>Microfiche</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MC">
+				<xs:annotation>
+					<xs:documentation>Microfilm</xs:documentation>
+					<xs:documentation>Roll microfilm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MZ">
+				<xs:annotation>
+					<xs:documentation>Other microform</xs:documentation>
+					<xs:documentation>Other microform not specified by MB or MC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PA">
+				<xs:annotation>
+					<xs:documentation>Miscellaneous print</xs:documentation>
+					<xs:documentation>Miscellaneous printed material - detail unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PB">
+				<xs:annotation>
+					<xs:documentation>Address book</xs:documentation>
+					<xs:documentation>May use product form detail codes P201 to P204 to specify binding.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PC">
+				<xs:annotation>
+					<xs:documentation>Calendar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PD">
+				<xs:annotation>
+					<xs:documentation>Cards</xs:documentation>
+					<xs:documentation>Cards, flash cards (eg for teaching reading).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PE">
+				<xs:annotation>
+					<xs:documentation>Copymasters</xs:documentation>
+					<xs:documentation>Copymasters, photocopiable sheets.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PF">
+				<xs:annotation>
+					<xs:documentation>Diary</xs:documentation>
+					<xs:documentation>May use product form detail codes P201 to P204 to specify binding.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PG">
+				<xs:annotation>
+					<xs:documentation>Frieze</xs:documentation>
+					<xs:documentation>Narrow strip-shaped printed sheet used mostly for education or children&apos;s products (eg depicting alphabet, number line, procession of illustrated characters etc). Usually intended for horizontal display.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PH">
+				<xs:annotation>
+					<xs:documentation>Kit</xs:documentation>
+					<xs:documentation>Parts for post-purchase assembly.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PI">
+				<xs:annotation>
+					<xs:documentation>Sheet music</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PJ">
+				<xs:annotation>
+					<xs:documentation>Postcard book or pack</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PK">
+				<xs:annotation>
+					<xs:documentation>Poster</xs:documentation>
+					<xs:documentation>Poster for retail sale - see also XF.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PL">
+				<xs:annotation>
+					<xs:documentation>Record book</xs:documentation>
+					<xs:documentation>Record book (eg &apos;birthday book&apos;, &apos;baby book&apos;): binding unspecified; may use product form detail codes P201 to P204 to specify binding.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PM">
+				<xs:annotation>
+					<xs:documentation>Wallet or folder</xs:documentation>
+					<xs:documentation>Wallet or folder (containing loose sheets etc): it is preferable to code the contents and treat &apos;wallet&apos; as packaging (List 80), but if this is not possible the product as a whole may be coded as a &apos;wallet&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PN">
+				<xs:annotation>
+					<xs:documentation>Pictures or photographs</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PO">
+				<xs:annotation>
+					<xs:documentation>Wallchart</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PP">
+				<xs:annotation>
+					<xs:documentation>Stickers</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PQ">
+				<xs:annotation>
+					<xs:documentation>Plate (lámina)</xs:documentation>
+					<xs:documentation>A book-sized (as opposed to poster-sized) sheet, usually in colour or high quality print.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PR">
+				<xs:annotation>
+					<xs:documentation>Notebook / blank book</xs:documentation>
+					<xs:documentation>A book with all pages blank for the buyer&apos;s own use; may use product form detail codes P201 to P204 to specify binding.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PS">
+				<xs:annotation>
+					<xs:documentation>Organizer</xs:documentation>
+					<xs:documentation>May use product form detail codes P201 to P204 to specify binding.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PT">
+				<xs:annotation>
+					<xs:documentation>Bookmark</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PZ">
+				<xs:annotation>
+					<xs:documentation>Other printed item</xs:documentation>
+					<xs:documentation>Other printed item not specified by PB to PQ.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SA">
+				<xs:annotation>
+					<xs:documentation>Multiple-item retail product</xs:documentation>
+					<xs:documentation>Presentation unspecified: format of product items must be given in &lt;ProductPart>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SB">
+				<xs:annotation>
+					<xs:documentation>Multiple-item retail product, boxed</xs:documentation>
+					<xs:documentation>Format of product items must be given in &lt;ProductPart>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SC">
+				<xs:annotation>
+					<xs:documentation>Multiple-item retail product, slip-cased</xs:documentation>
+					<xs:documentation>Format of product items must be given in &lt;ProductPart>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SD">
+				<xs:annotation>
+					<xs:documentation>Multiple-item retail product, shrinkwrapped</xs:documentation>
+					<xs:documentation>Format of product items must be given in &lt;ProductPart>. Use code XL for a shrink-wrapped pack for trade supply, where the retail items it contains are intended for sale individually.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SE">
+				<xs:annotation>
+					<xs:documentation>Multiple-item retail product, loose</xs:documentation>
+					<xs:documentation>Format of product items must be given in &lt;ProductPart>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SF">
+				<xs:annotation>
+					<xs:documentation>Multiple-item retail product, part(s) enclosed</xs:documentation>
+					<xs:documentation>Multiple item product where subsidiary product part(s) is/are supplied as enclosures to the primary part, eg a book with a CD packaged in a sleeve glued within the back cover. Format of product items must be given in &lt;ProductPart>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VA">
+				<xs:annotation>
+					<xs:documentation>Video</xs:documentation>
+					<xs:documentation>Video - detail unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VF">
+				<xs:annotation>
+					<xs:documentation>Videodisc</xs:documentation>
+					<xs:documentation>eg Laserdisc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VI">
+				<xs:annotation>
+					<xs:documentation>DVD video</xs:documentation>
+					<xs:documentation>DVD video: specify TV standard in List 78.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VJ">
+				<xs:annotation>
+					<xs:documentation>VHS video</xs:documentation>
+					<xs:documentation>VHS videotape: specify TV standard in List 78.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VK">
+				<xs:annotation>
+					<xs:documentation>Betamax video</xs:documentation>
+					<xs:documentation>Betamax videotape: specify TV standard in List 78.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VL">
+				<xs:annotation>
+					<xs:documentation>VCD</xs:documentation>
+					<xs:documentation>VideoCD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VM">
+				<xs:annotation>
+					<xs:documentation>SVCD</xs:documentation>
+					<xs:documentation>Super VideoCD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VN">
+				<xs:annotation>
+					<xs:documentation>HD DVD</xs:documentation>
+					<xs:documentation>High definition DVD disc, Toshiba HD DVD format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VO">
+				<xs:annotation>
+					<xs:documentation>Blu-ray</xs:documentation>
+					<xs:documentation>High definition DVD disc, Sony Blu-ray format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VP">
+				<xs:annotation>
+					<xs:documentation>UMD Video</xs:documentation>
+					<xs:documentation>Sony Universal Media disc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VZ">
+				<xs:annotation>
+					<xs:documentation>Other video format</xs:documentation>
+					<xs:documentation>Other video format not specified by VB to VP.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XA">
+				<xs:annotation>
+					<xs:documentation>Trade-only material</xs:documentation>
+					<xs:documentation>Trade-only material (unspecified).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XB">
+				<xs:annotation>
+					<xs:documentation>Dumpbin - empty</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XC">
+				<xs:annotation>
+					<xs:documentation>Dumpbin - filled</xs:documentation>
+					<xs:documentation>Dumpbin with contents. ISBN (where applicable) and format of contained items must be given in Product Part.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XD">
+				<xs:annotation>
+					<xs:documentation>Counterpack - empty</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XE">
+				<xs:annotation>
+					<xs:documentation>Counterpack - filled</xs:documentation>
+					<xs:documentation>Counterpack with contents. ISBN (where applicable) and format of contained items must be given in Product Part.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XF">
+				<xs:annotation>
+					<xs:documentation>Poster, promotional</xs:documentation>
+					<xs:documentation>Promotional poster for display, not for sale - see also PK.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XG">
+				<xs:annotation>
+					<xs:documentation>Shelf strip</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XH">
+				<xs:annotation>
+					<xs:documentation>Window piece</xs:documentation>
+					<xs:documentation>Promotional piece for shop window display.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XI">
+				<xs:annotation>
+					<xs:documentation>Streamer</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XJ">
+				<xs:annotation>
+					<xs:documentation>Spinner</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XK">
+				<xs:annotation>
+					<xs:documentation>Large book display</xs:documentation>
+					<xs:documentation>Large scale facsimile of book for promotional display.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XL">
+				<xs:annotation>
+					<xs:documentation>Shrink-wrapped pack</xs:documentation>
+					<xs:documentation>A quantity pack with its own product code, for trade supply only: the retail items it contains are intended for sale individually. ISBN (where applicable) and format of contained items must be given in Product Part. For products or product bundles supplied shrink-wrapped for retail sale, use code SD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XZ">
+				<xs:annotation>
+					<xs:documentation>Other point of sale</xs:documentation>
+					<xs:documentation>Other point of sale material not specified by XB to XL.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZA">
+				<xs:annotation>
+					<xs:documentation>General merchandise</xs:documentation>
+					<xs:documentation>General merchandise - unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZB">
+				<xs:annotation>
+					<xs:documentation>Doll</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZC">
+				<xs:annotation>
+					<xs:documentation>Soft toy</xs:documentation>
+					<xs:documentation>Soft or plush toy.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZD">
+				<xs:annotation>
+					<xs:documentation>Toy</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZE">
+				<xs:annotation>
+					<xs:documentation>Game</xs:documentation>
+					<xs:documentation>Board game, or other game (except computer game: see DE).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZF">
+				<xs:annotation>
+					<xs:documentation>T-shirt</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZZ">
+				<xs:annotation>
+					<xs:documentation>Other merchandise</xs:documentation>
+					<xs:documentation>Other merchandise not specified by ZB to ZF.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List151">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 151">Contributor place relator</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Born in</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Died in</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Formerly resided in</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Currently resides in</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Educated in</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Worked in</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Flourished in</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List152">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 152">Illustrated / not illustrated</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>No</xs:documentation>
+					<xs:documentation>Not illustrated.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Sí</xs:documentation>
+					<xs:documentation>Illustrated.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List153">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 153">Text type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Sender-defined text</xs:documentation>
+					<xs:documentation>To be used only in circumstances where the parties to an exchange have agreed to include text which (a) is not for general distribution, and (b) cannot be coded elsewhere. If more than one type of text is sent, it must be identified by tagging within the text itself.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Short description/annotation</xs:documentation>
+					<xs:documentation>Limited to a maximum of 350 characters.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Descripció</xs:documentation>
+					<xs:documentation>Length unrestricted.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Table of contents</xs:documentation>
+					<xs:documentation>Used for a table of contents sent as a single text field, which may or may not carry structure expressed as XHTML.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Flap / cover copy</xs:documentation>
+					<xs:documentation>Descriptive blurb taken from the back cover and/or flaps.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Review quote</xs:documentation>
+					<xs:documentation>A quote taken from a review of the product or of the work in question where there is no need to take account of different editions.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Review quote: previous edition</xs:documentation>
+					<xs:documentation>A quote taken from a review of a previous edition of the work.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Review quote: previous work</xs:documentation>
+					<xs:documentation>A quote taken from a review of a previous work by the same author(s) or in the same series.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Endorsement</xs:documentation>
+					<xs:documentation>A quote usually provided by a celebrity to promote a new book, not from a review.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Promotional headline</xs:documentation>
+					<xs:documentation>A promotional phrase which is intended to headline a description of the product.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Funció</xs:documentation>
+					<xs:documentation>Text describing a feature of a product to which the publisher wishes to draw attention for promotional purposes.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Biographical note</xs:documentation>
+					<xs:documentation>A note referring to all contributors to a product - NOT linked to a single contributor.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Publisher&apos;s notice</xs:documentation>
+					<xs:documentation>A statement included by a publisher in fulfillment of contractual obligations, such as a disclaimer, sponsor statement, or legal notice of any sort. Note that the inclusion of such a notice cannot and does not imply that a user of the ONIX record is obliged to reproduce it.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Excerpt</xs:documentation>
+					<xs:documentation>A short excerpt from the work.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Índex</xs:documentation>
+					<xs:documentation>Used for an index sent as a single text field, which may be structured using XHTML.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Short description/annotation for collection</xs:documentation>
+					<xs:documentation>(of which the product is a part.) Limited to a maximum of 350 characters.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Description for collection</xs:documentation>
+					<xs:documentation>(of which the product is a part.) Length unrestricted.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List154">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 154">Content audience</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Unrestricted</xs:documentation>
+					<xs:documentation>Any audience.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Restringit</xs:documentation>
+					<xs:documentation>Distribution by agreement between the parties to the ONIX exchange (this value is provided to cover applications where ONIX content includes material which is not for general distribution).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Booktrade</xs:documentation>
+					<xs:documentation>Distributors, bookstores, publisher&apos;s own staff etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>End-customers</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Librarians</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Teachers</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Students</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Publicació</xs:documentation>
+					<xs:documentation>Press or other media.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Shopping comparison service</xs:documentation>
+					<xs:documentation>Where a specially formatted description is required for this audience.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List155">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 155">Content date role</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Publication date</xs:documentation>
+					<xs:documentation>Nominal date of publication.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Broadcast date</xs:documentation>
+					<xs:documentation>Date when a TV or radio program was / will be broadcast.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>From date</xs:documentation>
+					<xs:documentation>Date from which a content item or supporting resource may be referenced or used.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Until date</xs:documentation>
+					<xs:documentation>Date until which a content item or supporting resource may be referenced or used.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Last updated</xs:documentation>
+					<xs:documentation>Date when a resource was last changed or updated.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>From… until date</xs:documentation>
+					<xs:documentation>Combines From date and Until date to define a period (both dates are inclusive). Use with for example dateformat 06.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List156">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 156">Cited content type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Revisió</xs:documentation>
+					<xs:documentation>The full text of a review in a third-party publication in any medium.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Bestseller list</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Media mention</xs:documentation>
+					<xs:documentation>Other than a review.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>&apos;One locality, one book&apos; program</xs:documentation>
+					<xs:documentation>(North America) Inclusion in a program such as &apos;Chicago Reads&apos;, &apos;Seattle Reads&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List157">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 157">Content source type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Printed media</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Lloc web</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Radio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>TV</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List158">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 158">Resource content type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Front cover</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Back cover</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Cover / pack</xs:documentation>
+					<xs:documentation>Not limited to front or back.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Contributor picture</xs:documentation>
+					<xs:documentation>Photograph or portrait of contributor(s).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Series image / artwork</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Series logo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Product image / artwork</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Product logo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Publisher logo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Imprint logo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Contributor interview</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Contributor presentation</xs:documentation>
+					<xs:documentation>Contributor presentation and/or commentary.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Contributor reading</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Contributor event schedule</xs:documentation>
+					<xs:documentation>Link to a schedule in iCalendar format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Sample content</xs:documentation>
+					<xs:documentation>For example: sample chapter text, page images, screenshots.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Widget</xs:documentation>
+					<xs:documentation>A &apos;look inside&apos; feature presented as a small embeddable application.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Revisió</xs:documentation>
+					<xs:documentation>Use the &lt;TextContent> composite for review quotes carried in the ONIX record. Use the &lt;CitedContent> composite for a third-party review which is referenced from the ONIX record. Use &lt;SupportingResource> only for a review which is offered for reproduction as part of promotional material for the product.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Other commentary / discussion</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Reading group guide</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Teacher&apos;s guide</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>Feature article</xs:documentation>
+					<xs:documentation>Feature article provided by publisher.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Character &apos;interview&apos;</xs:documentation>
+					<xs:documentation>Fictional character &apos;interview&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Wallpaper / screensaver</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Press release</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Table of contents</xs:documentation>
+					<xs:documentation>A table of contents held on a webpage, not in the ONIX record.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Trailer</xs:documentation>
+					<xs:documentation>A promotional video, similar to a movie trailer (sometimes referred to as a &apos;book trailer&apos;).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>Cover thumbnail</xs:documentation>
+					<xs:documentation>Intended ONLY for transitional use, where ONIX 2.1 records referencing existing thumbnail assets of unknown pixel size are being re-expressed in ONIX 3.0. Use code 01 for all new cover assets, and where the pixel size of older assets is known.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>Full content</xs:documentation>
+					<xs:documentation>The full content of the product (or the product itself), supplied for example to support full-text search.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="29">
+				<xs:annotation>
+					<xs:documentation>Full cover</xs:documentation>
+					<xs:documentation>Includes cover, back cover, spine and - where appropriate - any flaps.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List159">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 159">Resource mode</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Application</xs:documentation>
+					<xs:documentation>An executable together with data on which it operates.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Audio</xs:documentation>
+					<xs:documentation>A sound recording.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Imatge</xs:documentation>
+					<xs:documentation>A still image.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Text</xs:documentation>
+					<xs:documentation>Readable text, with or without associated images etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Video</xs:documentation>
+					<xs:documentation>Moving images, with or without accompanying sound.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Multi-mode</xs:documentation>
+					<xs:documentation>A website or other supporting resource delivering content in a variety of modes.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List160">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 160">Resource feature type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Required credit</xs:documentation>
+					<xs:documentation>Credit that must be displayed when a resource is used (eg &apos;Photo Jerry Bauer&apos; or &apos;© Magnum Photo&apos;). Credit text should be carried in &lt;FeatureNote>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Peu</xs:documentation>
+					<xs:documentation>Explanatory caption that may accompany a resource (eg use to identify an author in a photograph). Caption text should be carried in &lt;FeatureNote>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Copyright holder</xs:documentation>
+					<xs:documentation>Copyright holder of resource (indicative only, as the resource can be used without consultation). Copyright text should be carried in &lt;FeatureNote>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Length in minutes</xs:documentation>
+					<xs:documentation>Approximate length in minutes of an audio or video resource. &lt;FeatureValue> should contain the length of time as an integer number of minutes.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List161">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 161">Resource form</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Linkable resource</xs:documentation>
+					<xs:documentation>A resource that may be accessed by a hyperlink. The current host (eg the ONIX sender, who may be the publisher) will provide ongoing hosting services for the resource for the active life of the product (or at least until the Until Date specified in &lt;ContentDate>). The ONIX recipient may embed the URL in a consumer facing-website (eg as the src attribute in an &lt;img> link), and need not host an independent copy of the resource.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Downloadable file</xs:documentation>
+					<xs:documentation>A file that may be downloaded on demand for third-party use. The ONIX sender will host a copy of the resource until the specified Until Date, but only for the ONIX recipient&apos;s direct use. The ONIX recipient should download a copy of the resource, and must host an independent copy of the resource if it is used on a consumer-facing website. Special attention should be paid to the &apos;Last Updated&apos; &lt;ContentDate> to ensure the independent copy of the resource is kept up to date.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Embeddable application</xs:documentation>
+					<xs:documentation>An application which is supplied in a form which can be embedded into a third-party webpage. As type 02, except the resource contains active content such as JavaScript, Flash, etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List162">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 162">Resource version feature type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Format del fitxer</xs:documentation>
+					<xs:documentation>Resource Version Feature Value carries a code from List 178.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Image height in pixels</xs:documentation>
+					<xs:documentation>Resource Version Feature Value carries an integer.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Image width in pixels</xs:documentation>
+					<xs:documentation>Resource Version Feature Value carries an integer.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Nom del fitxer</xs:documentation>
+					<xs:documentation>Resource Version Feature Value carries the filename of the supporting resource.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Approximate download file size in megabytes</xs:documentation>
+					<xs:documentation>Resource Version Feature Value carries a decimal number only, suggested no more than 2 significant digits (eg 1.7, not 1.7462).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>MD5 hash value</xs:documentation>
+					<xs:documentation>MD5 hash value of the resource file. &lt;ResourceVersionFeatureValue> should contain the hash value (as 32 hexadecimal digits). Can be used as a cryptographic check on the integrity of a resource after it has been retrieved.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Exact download file size in bytes</xs:documentation>
+					<xs:documentation>Resource Version Feature Value carries a integer number only (eg 1831023).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List163">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 163">Publishing date role</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Publication date</xs:documentation>
+					<xs:documentation>Nominal date of publication.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Embargo date</xs:documentation>
+					<xs:documentation>If there is an embargo on retail sales in this market before a certain date, the date from which the embargo is lifted and retail sales are permitted.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Public announcement date</xs:documentation>
+					<xs:documentation>Date when a new product may be announced to the general public.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Trade announcement date</xs:documentation>
+					<xs:documentation>Date when a new product may be announced for trade only.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Date of first publication</xs:documentation>
+					<xs:documentation>Date when the work incorporated in a product was first published.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Last reprint date</xs:documentation>
+					<xs:documentation>Date when a product was last reprinted.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Out-of-print / deletion date</xs:documentation>
+					<xs:documentation>Date when a product was declared out-of-print or deleted.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Last reissue date</xs:documentation>
+					<xs:documentation>Date when a product was last reissued.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Publication date of print counterpart</xs:documentation>
+					<xs:documentation>Date of publication of a printed book which is the print counterpart to a digital edition.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Date of first publication in original language</xs:documentation>
+					<xs:documentation>Year when the original language version of work incorporated in a product was first published (note, use only when different from code 11).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>Forthcoming reissue date</xs:documentation>
+					<xs:documentation>Date when a product will be reissued.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Expected availability date after temporary withdrawal</xs:documentation>
+					<xs:documentation>Date when a product that has been temporary withdrawn from sale or recalled for any reason is expected to become available again, eg after correction of quality or technical issues.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Review embargo date</xs:documentation>
+					<xs:documentation>Date from which reviews of a product may be published eg in newspapers and magazines or online. Provided to the book trade for information only: newspapers and magazines are not expected to be recipients of ONIX metadata.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List164">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 164">Work relation code</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Manifestation of</xs:documentation>
+					<xs:documentation>Product X is or includes a manifestation of work Y.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Derived from</xs:documentation>
+					<xs:documentation>Product X is or includes a manifestation of a work derived from related work Y in one or more of the ways specified in ISTC rules. This relation type is intended to enable products with a common &apos;parent&apos; work to be linked without specifying the precise nature of their derivation.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Related work is derived from this</xs:documentation>
+					<xs:documentation>Product X is a manifestation of a work from which related work Y is derived in one or more of the ways specified in ISTC rules (reciprocal of code 02).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Other work in same collection</xs:documentation>
+					<xs:documentation>Product X is a manifestation of a work in the same collection as related work Y.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Other work by same contributor</xs:documentation>
+					<xs:documentation>Product X is a manifestation of a work by the same contributor(s) as related work Y.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List165">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 165">Supplier own code type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Supplier&apos;s sales classification</xs:documentation>
+					<xs:documentation>A rating applied by a supplier (typically a wholesaler) to indicate its assessment of the expected or actual sales performance of a product.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Supplier&apos;s bonus eligibility</xs:documentation>
+					<xs:documentation>A supplier&apos;s coding of the eligibility of a product for a bonus scheme on overall sales.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Publisher&apos;s sales classification</xs:documentation>
+					<xs:documentation>A rating applied by the publisher to indicate a sales category (eg backlist/frontlist, core stock etc). Use only when the publisher is not the &apos;supplier&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Supplier&apos;s pricing restriction classification</xs:documentation>
+					<xs:documentation>A classification applied by a supplier to a product sold on Agency terms, to indicate that retail price restrictions are applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List166">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 166">Supply date role</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Embargo date</xs:documentation>
+					<xs:documentation>If there is an embargo on retail sales before a certain date, the date from which the embargo is lifted and retail sales are permitted.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Expected availability date</xs:documentation>
+					<xs:documentation>The date on which physical stock is expected to be available to be shipped to retailers, or a digital product is expected to be released.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Last date for returns</xs:documentation>
+					<xs:documentation>Last date when returns will be accepted, generally for a product which is being remaindered or put out of print.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Reservation order deadline</xs:documentation>
+					<xs:documentation>Latest date on which an order may be placed for guaranteed delivery prior to the publication date. May or may not be linked to a special reservation or pre-publication price.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List167">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 167">Price condition type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Includes updates</xs:documentation>
+					<xs:documentation>Purchase at this price includes specified updates.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Must also purchase updates</xs:documentation>
+					<xs:documentation>Purchase at this price requires commitment to purchase specified updates, not included in price.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Updates available</xs:documentation>
+					<xs:documentation>Updates may be purchased separately, no minimum commitment required.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List168">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 168">Price condition quantity type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Time period</xs:documentation>
+					<xs:documentation>The price condition quantity represents a time period.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Number of updates</xs:documentation>
+					<xs:documentation>The price condition quantity is a number of updates.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List169">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 169">Quantity unit</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Units</xs:documentation>
+					<xs:documentation>The quantity refers to a unit implied by the quantity type.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Setmanes</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Months</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List170">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 170">Discount type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="List171">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 171">Tax type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>VAT</xs:documentation>
+					<xs:documentation>Value added tax (TVA, IVA, MwSt etc).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>GST</xs:documentation>
+					<xs:documentation>General sales tax.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List172">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 172">Currency zone</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="EUR">
+				<xs:annotation>
+					<xs:documentation>Eurozone</xs:documentation>
+					<xs:documentation>Countries that at the time being have the Euro as their national currency. Deprecated in ONIX 3.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List173">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 173">Price date role</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>From date</xs:documentation>
+					<xs:documentation>Date on which a price becomes effective.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Until date</xs:documentation>
+					<xs:documentation>Date on which a price ceases to be effective.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>From… until date</xs:documentation>
+					<xs:documentation>Combines From date and Until date to define a period (both dates are inclusive). Use with for example dateformat 06.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List174">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 174">Printed on product</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>No</xs:documentation>
+					<xs:documentation>Price not printed on product.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Sí</xs:documentation>
+					<xs:documentation>Price printed on product.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List175">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 175">Product form detail</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="A101">
+				<xs:annotation>
+					<xs:documentation>CD standard audio format</xs:documentation>
+					<xs:documentation>CD &apos;red book&apos; format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A102">
+				<xs:annotation>
+					<xs:documentation>SACD super audio format</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A103">
+				<xs:annotation>
+					<xs:documentation>MP3 format</xs:documentation>
+					<xs:documentation>MPEG-1/2 Audio Layer III file.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A104">
+				<xs:annotation>
+					<xs:documentation>WAV format</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A105">
+				<xs:annotation>
+					<xs:documentation>Real Audio format</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A106">
+				<xs:annotation>
+					<xs:documentation>WMA</xs:documentation>
+					<xs:documentation>Windows Media Audio format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A107">
+				<xs:annotation>
+					<xs:documentation>AAC</xs:documentation>
+					<xs:documentation>Advanced Audio Coding format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A108">
+				<xs:annotation>
+					<xs:documentation>Ogg/Vorbis</xs:documentation>
+					<xs:documentation>Vorbis audio format in the Ogg container.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A109">
+				<xs:annotation>
+					<xs:documentation>Audible</xs:documentation>
+					<xs:documentation>Audio format proprietary to Audible.com.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A110">
+				<xs:annotation>
+					<xs:documentation>FLAC</xs:documentation>
+					<xs:documentation>Free lossless audio codec.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A111">
+				<xs:annotation>
+					<xs:documentation>AIFF</xs:documentation>
+					<xs:documentation>Audio Interchangeable File Format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A112">
+				<xs:annotation>
+					<xs:documentation>ALAC</xs:documentation>
+					<xs:documentation>Apple Lossless Audio Codec.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A201">
+				<xs:annotation>
+					<xs:documentation>DAISY 2: full audio with title only (no navigation)</xs:documentation>
+					<xs:documentation>Deprecated, as does not meet DAISY 2 standard. Use conventional audiobook codes instead.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A202">
+				<xs:annotation>
+					<xs:documentation>DAISY 2: full audio with navigation (no text)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A203">
+				<xs:annotation>
+					<xs:documentation>DAISY 2: full audio with navigation and partial text</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A204">
+				<xs:annotation>
+					<xs:documentation>DAISY 2: full audio with navigation and full text</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A205">
+				<xs:annotation>
+					<xs:documentation>DAISY 2: full text with navigation and partial audio</xs:documentation>
+					<xs:documentation>Reading systems may provide full audio via text-to-speech.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A206">
+				<xs:annotation>
+					<xs:documentation>DAISY 2: full text with navigation and no audio</xs:documentation>
+					<xs:documentation>Reading systems may provide full audio via text-to-speech.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A207">
+				<xs:annotation>
+					<xs:documentation>DAISY 3: full audio with title only (no navigation)</xs:documentation>
+					<xs:documentation>Deprecated, as does not meet DAISY 3 standard. Use conventional audiobook codes instead.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A208">
+				<xs:annotation>
+					<xs:documentation>DAISY 3: full audio with navigation (no text)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A209">
+				<xs:annotation>
+					<xs:documentation>DAISY 3: full audio with navigation and partial text</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A210">
+				<xs:annotation>
+					<xs:documentation>DAISY 3: full audio with navigation and full text</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A211">
+				<xs:annotation>
+					<xs:documentation>DAISY 3: full textwith navigation and partial audio</xs:documentation>
+					<xs:documentation>Reading systems may provide full audio via text-to-speech.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A212">
+				<xs:annotation>
+					<xs:documentation>DAISY 3: full text with navigation and no audio</xs:documentation>
+					<xs:documentation>Reading systems may provide full audio via text-to-speech.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A301">
+				<xs:annotation>
+					<xs:documentation>Standalone audio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A302">
+				<xs:annotation>
+					<xs:documentation>Readalong audio</xs:documentation>
+					<xs:documentation>Audio intended exclusively for use alongside a printed copy of the book. Most often a children&apos;s product. Normally contains instructions such as &apos;turn the page now&apos; and other references to the printed item, and is usually sold packaged together with a printed copy.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A303">
+				<xs:annotation>
+					<xs:documentation>Playalong audio</xs:documentation>
+					<xs:documentation>Audio intended for musical accompaniment, eg &apos;Music minus one&apos;, etc, often used for music learning. Includes singalong backing audio for musical learning or for Karaoke-style entertainment.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A304">
+				<xs:annotation>
+					<xs:documentation>Speakalong audio</xs:documentation>
+					<xs:documentation>Audio intended for language learning, which includes speech plus gaps intended to be filled by the listener.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B101">
+				<xs:annotation>
+					<xs:documentation>Mass market (rack) paperback</xs:documentation>
+					<xs:documentation>In North America, a category of paperback characterized partly by page size (typically 4¼ x 7 1/8 inches) and partly by target market and terms of trade. Use with Product Form code BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B102">
+				<xs:annotation>
+					<xs:documentation>Trade paperback (US)</xs:documentation>
+					<xs:documentation>In North America, a category of paperback characterized partly by page size and partly by target market and terms of trade. AKA &apos;quality paperback&apos;, and including textbooks. Most paperback books sold in North America except &apos;mass-market&apos; (B101) and &apos;tall rack&apos; (B107) are correctly described with this code. Use with Product Form code BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B103">
+				<xs:annotation>
+					<xs:documentation>Digest format paperback</xs:documentation>
+					<xs:documentation>In North America, a category of paperback characterized by page size and generally used for children&apos;s books; use with Product Form code BC. Note: was wrongly shown as B102 (duplicate entry) in Issue 3.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B104">
+				<xs:annotation>
+					<xs:documentation>A-format paperback</xs:documentation>
+					<xs:documentation>In UK, a category of paperback characterized by page size (normally 178 x 111 mm approx); use with Product Form code BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B105">
+				<xs:annotation>
+					<xs:documentation>B-format paperback</xs:documentation>
+					<xs:documentation>In UK, a category of paperback characterized by page size (normally 198 x 129 mm approx); use with Product Form code BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B106">
+				<xs:annotation>
+					<xs:documentation>Trade paperback (UK)</xs:documentation>
+					<xs:documentation>In UK, a category of paperback characterized partly by size (usually in traditional hardback dimensions), and often used for paperback originals; use with Product Form code BC (replaces &apos;C-format&apos; from former List 8).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B107">
+				<xs:annotation>
+					<xs:documentation>Tall rack paperback (US)</xs:documentation>
+					<xs:documentation>In North America, a category of paperback characterised partly by page size and partly by target market and terms of trade; use with Product Form code BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B108">
+				<xs:annotation>
+					<xs:documentation>A5 size Tankobon</xs:documentation>
+					<xs:documentation>210x148mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B109">
+				<xs:annotation>
+					<xs:documentation>JIS B5 size Tankobon</xs:documentation>
+					<xs:documentation>Japanese B-series size, 257x182mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B110">
+				<xs:annotation>
+					<xs:documentation>JIS B6 size Tankobon</xs:documentation>
+					<xs:documentation>Japanese B-series size, 182x128mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B111">
+				<xs:annotation>
+					<xs:documentation>A6 size Bunko</xs:documentation>
+					<xs:documentation>148x105mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B112">
+				<xs:annotation>
+					<xs:documentation>B40-dori Shinsho</xs:documentation>
+					<xs:documentation>Japanese format, 182x103mm or 173x105mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B113">
+				<xs:annotation>
+					<xs:documentation>Pocket (Sweden)</xs:documentation>
+					<xs:documentation>A Swedish paperback format, use with Product Form Code BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B114">
+				<xs:annotation>
+					<xs:documentation>Storpocket (Sweden)</xs:documentation>
+					<xs:documentation>A Swedish paperback format, use with Product Form Code BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B115">
+				<xs:annotation>
+					<xs:documentation>Kartonnage (Sweden)</xs:documentation>
+					<xs:documentation>A Swedish hardback format, use with Product Form Code BB.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B116">
+				<xs:annotation>
+					<xs:documentation>Flexband (Sweden)</xs:documentation>
+					<xs:documentation>A Swedish softback format, use with Product Form Code BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B117">
+				<xs:annotation>
+					<xs:documentation>Mook</xs:documentation>
+					<xs:documentation>In Japan, a softback book in the format of a magazine but sold like a book.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B118">
+				<xs:annotation>
+					<xs:documentation>Dwarsligger</xs:documentation>
+					<xs:documentation>Also called &apos;Flipback&apos;. A softback book in a specially compact proprietary format with pages printed in landscape on very thin paper and bound along the long (top) edge - see www.dwarsligger.com.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B119">
+				<xs:annotation>
+					<xs:documentation>46 size</xs:documentation>
+					<xs:documentation>Japanese format: 188x127mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B120">
+				<xs:annotation>
+					<xs:documentation>46-Henkei size</xs:documentation>
+					<xs:documentation>Japanese format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B121">
+				<xs:annotation>
+					<xs:documentation>A4</xs:documentation>
+					<xs:documentation>297x210mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B122">
+				<xs:annotation>
+					<xs:documentation>A4-Henkei size</xs:documentation>
+					<xs:documentation>Japanese format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B123">
+				<xs:annotation>
+					<xs:documentation>A5-Henkei size</xs:documentation>
+					<xs:documentation>Japanese format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B124">
+				<xs:annotation>
+					<xs:documentation>B5-Henkei size</xs:documentation>
+					<xs:documentation>Japanese format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B125">
+				<xs:annotation>
+					<xs:documentation>B6-Henkei size</xs:documentation>
+					<xs:documentation>Japanese format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B126">
+				<xs:annotation>
+					<xs:documentation>AB size</xs:documentation>
+					<xs:documentation>257x210mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B127">
+				<xs:annotation>
+					<xs:documentation>JIS B7 size</xs:documentation>
+					<xs:documentation>Japanese B-series size, 128x91mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B128">
+				<xs:annotation>
+					<xs:documentation>Kiku size</xs:documentation>
+					<xs:documentation>Japanese format: 218x152mm or 227x152mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B129">
+				<xs:annotation>
+					<xs:documentation>Kiku-Henkei size</xs:documentation>
+					<xs:documentation>Japanese format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B130">
+				<xs:annotation>
+					<xs:documentation>JIS B4 size</xs:documentation>
+					<xs:documentation>Japanese B-series size, 257x364mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B201">
+				<xs:annotation>
+					<xs:documentation>Coloring / join-the-dot book</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B202">
+				<xs:annotation>
+					<xs:documentation>Lift-the-flap book</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B204">
+				<xs:annotation>
+					<xs:documentation>Miniature book</xs:documentation>
+					<xs:documentation>Note: was wrongly shown as B203 (duplicate entry) in Issue 3.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B205">
+				<xs:annotation>
+					<xs:documentation>Moving picture / flicker book</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B206">
+				<xs:annotation>
+					<xs:documentation>Pop-up book</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B207">
+				<xs:annotation>
+					<xs:documentation>Scented / &apos;smelly&apos; book</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B208">
+				<xs:annotation>
+					<xs:documentation>Sound story / &apos;noisy&apos; book</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B209">
+				<xs:annotation>
+					<xs:documentation>Sticker book</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B210">
+				<xs:annotation>
+					<xs:documentation>Touch-and-feel book</xs:documentation>
+					<xs:documentation>A book whose pages have a variety of textured inserts designed to stimulate tactile exploration: see also B214 and B215.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B212">
+				<xs:annotation>
+					<xs:documentation>Die-cut book</xs:documentation>
+					<xs:documentation>A book which is cut into a distinctive non-rectilinear shape and/or in which holes or shapes have been cut internally. (&apos;Die-cut&apos; is used here as a convenient shorthand, and does not imply strict limitation to a particular production process.).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B213">
+				<xs:annotation>
+					<xs:documentation>Book-as-toy</xs:documentation>
+					<xs:documentation>A book which is also a toy, or which incorporates a toy as an integral part. (Do not, however, use B213 for a multiple-item product which includes a book and a toy as separate items.).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B214">
+				<xs:annotation>
+					<xs:documentation>Soft-to-touch book</xs:documentation>
+					<xs:documentation>A book whose cover has a soft textured finish, typically over board.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B215">
+				<xs:annotation>
+					<xs:documentation>Fuzzy-felt book</xs:documentation>
+					<xs:documentation>A book with detachable felt pieces and textured pages on which they can be arranged.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B221">
+				<xs:annotation>
+					<xs:documentation>Picture book</xs:documentation>
+					<xs:documentation>Children&apos;s picture book: use with applicable Product Form code.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B222">
+				<xs:annotation>
+					<xs:documentation>&apos;Carousel&apos; Book</xs:documentation>
+					<xs:documentation>(aka &apos;Star&apos; book). Tax treatment of products may differ from that of products with similar codes such as Book as toy or Pop-up book).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B301">
+				<xs:annotation>
+					<xs:documentation>Loose leaf - sheets and binder</xs:documentation>
+					<xs:documentation>Use with Product Form code BD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B302">
+				<xs:annotation>
+					<xs:documentation>Loose leaf - binder only</xs:documentation>
+					<xs:documentation>Use with Product Form code BD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B303">
+				<xs:annotation>
+					<xs:documentation>Loose leaf - sheets only</xs:documentation>
+					<xs:documentation>Use with Product Form code BD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B304">
+				<xs:annotation>
+					<xs:documentation>Sewn</xs:documentation>
+					<xs:documentation>AKA stitched; for &apos;saddle-sewn&apos;, see code B310.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B305">
+				<xs:annotation>
+					<xs:documentation>Unsewn / adhesive bound</xs:documentation>
+					<xs:documentation>Including &apos;perfect bound&apos;, &apos;glued&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B306">
+				<xs:annotation>
+					<xs:documentation>Library binding</xs:documentation>
+					<xs:documentation>Strengthened binding intended for libraries.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B307">
+				<xs:annotation>
+					<xs:documentation>Reinforced binding</xs:documentation>
+					<xs:documentation>Strengthened binding, not specifically intended for libraries.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B308">
+				<xs:annotation>
+					<xs:documentation>Half bound</xs:documentation>
+					<xs:documentation>Must be accompanied by a code specifiying a material, eg &apos;half-bound real leather&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B309">
+				<xs:annotation>
+					<xs:documentation>Quarter bound</xs:documentation>
+					<xs:documentation>Must be accompanied by a code specifiying a material, eg &apos;quarter bound real leather&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B310">
+				<xs:annotation>
+					<xs:documentation>Saddle-sewn</xs:documentation>
+					<xs:documentation>AKA &apos;saddle-stitched&apos; or &apos;wire-stitched&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B311">
+				<xs:annotation>
+					<xs:documentation>Comb bound</xs:documentation>
+					<xs:documentation>Round or oval plastic forms in a clamp-like configuration: use with Product Form code BE.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B312">
+				<xs:annotation>
+					<xs:documentation>Wire-O</xs:documentation>
+					<xs:documentation>Twin loop metal or plastic spine: use with Product Form code BE.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B313">
+				<xs:annotation>
+					<xs:documentation>Concealed wire</xs:documentation>
+					<xs:documentation>Cased over Wire-O binding: use with Product Form code BE.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B401">
+				<xs:annotation>
+					<xs:documentation>Cloth over boards</xs:documentation>
+					<xs:documentation>AKA fabric, linen over boards.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B402">
+				<xs:annotation>
+					<xs:documentation>Paper over boards</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B403">
+				<xs:annotation>
+					<xs:documentation>Leather, real</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B404">
+				<xs:annotation>
+					<xs:documentation>Leather, imitation</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B405">
+				<xs:annotation>
+					<xs:documentation>Leather, bonded</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B406">
+				<xs:annotation>
+					<xs:documentation>Vellum</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B409">
+				<xs:annotation>
+					<xs:documentation>Cloth</xs:documentation>
+					<xs:documentation>Cloth, not necessarily over boards - cf B401.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B410">
+				<xs:annotation>
+					<xs:documentation>Imitation cloth</xs:documentation>
+					<xs:documentation>Spanish &apos;simil-tela&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B411">
+				<xs:annotation>
+					<xs:documentation>Velvet</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B412">
+				<xs:annotation>
+					<xs:documentation>Flexible plastic/vinyl cover</xs:documentation>
+					<xs:documentation>AKA &apos;flexibound&apos;: use with Product Form code BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B413">
+				<xs:annotation>
+					<xs:documentation>Plastic-covered</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B414">
+				<xs:annotation>
+					<xs:documentation>Vinyl-covered</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B415">
+				<xs:annotation>
+					<xs:documentation>Laminated cover</xs:documentation>
+					<xs:documentation>Book, laminating material unspecified: use L101 for &apos;whole product laminated&apos;, eg a laminated sheet map or wallchart.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B501">
+				<xs:annotation>
+					<xs:documentation>With dust jacket</xs:documentation>
+					<xs:documentation>Type unspecified.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B502">
+				<xs:annotation>
+					<xs:documentation>With printed dust jacket</xs:documentation>
+					<xs:documentation>Used to distinguish from B503.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B503">
+				<xs:annotation>
+					<xs:documentation>With translucent dust cover</xs:documentation>
+					<xs:documentation>With translucent paper or plastic protective cover.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B504">
+				<xs:annotation>
+					<xs:documentation>With flaps</xs:documentation>
+					<xs:documentation>For paperback with flaps.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B505">
+				<xs:annotation>
+					<xs:documentation>With thumb index</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B506">
+				<xs:annotation>
+					<xs:documentation>With ribbon marker(s)</xs:documentation>
+					<xs:documentation>If the number of markers is significant, it can be stated as free text in &lt;ProductFormDescription>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B507">
+				<xs:annotation>
+					<xs:documentation>With zip fastener</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B508">
+				<xs:annotation>
+					<xs:documentation>With button snap fastener</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B509">
+				<xs:annotation>
+					<xs:documentation>With leather edge lining</xs:documentation>
+					<xs:documentation>AKA yapp edge?.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B510">
+				<xs:annotation>
+					<xs:documentation>Rough front</xs:documentation>
+					<xs:documentation>With edge trimming such that the front edge is ragged, not neatly and squarely trimmed: AKA deckle edge, feather edge, uncut edge, rough cut.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B601">
+				<xs:annotation>
+					<xs:documentation>Turn-around book</xs:documentation>
+					<xs:documentation>A book in which half the content is printed upside-down, to be read the other way round. Also known as a &apos;flip-book&apos; (usually an omnibus of two works).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B602">
+				<xs:annotation>
+					<xs:documentation>Unflipped manga format</xs:documentation>
+					<xs:documentation>Manga with pages and panels in the sequence of the original Japanese, but with Western text.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B701">
+				<xs:annotation>
+					<xs:documentation>UK Uncontracted Braille</xs:documentation>
+					<xs:documentation>Single letters only. Was formerly identified as UK Braille Grade 1.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B702">
+				<xs:annotation>
+					<xs:documentation>UK Contracted Braille</xs:documentation>
+					<xs:documentation>With some letter combinations. Was formerly identified as UK Braille Grade 2.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B703">
+				<xs:annotation>
+					<xs:documentation>US Braille</xs:documentation>
+					<xs:documentation>DEPRECATED- use B704/B705 as appropriate instead.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B704">
+				<xs:annotation>
+					<xs:documentation>US Uncontracted Braille</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B705">
+				<xs:annotation>
+					<xs:documentation>US Contracted Braille</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B706">
+				<xs:annotation>
+					<xs:documentation>Unified English Braille</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B707">
+				<xs:annotation>
+					<xs:documentation>Moon</xs:documentation>
+					<xs:documentation>Moon embossed alphabet, used by some print-impaired readers who have difficulties with Braille.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D101">
+				<xs:annotation>
+					<xs:documentation>Real Video format</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D102">
+				<xs:annotation>
+					<xs:documentation>Quicktime format</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D103">
+				<xs:annotation>
+					<xs:documentation>AVI format</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D104">
+				<xs:annotation>
+					<xs:documentation>Windows Media Video format</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D105">
+				<xs:annotation>
+					<xs:documentation>MPEG-4</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D201">
+				<xs:annotation>
+					<xs:documentation>MS-DOS</xs:documentation>
+					<xs:documentation>Use with an applicable Product Form code D*; note that more detail of operating system requirements can be given in a Product Form Feature composite.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D202">
+				<xs:annotation>
+					<xs:documentation>Windows</xs:documentation>
+					<xs:documentation>Use with an applicable Product Form code D*; see note on D201.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D203">
+				<xs:annotation>
+					<xs:documentation>Macintosh</xs:documentation>
+					<xs:documentation>Use with an applicable Product Form code D*; see note on D201.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D204">
+				<xs:annotation>
+					<xs:documentation>UNIX / LINUX</xs:documentation>
+					<xs:documentation>Use with an applicable Product Form code D*; see note on D201.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D205">
+				<xs:annotation>
+					<xs:documentation>Other operating system(s)</xs:documentation>
+					<xs:documentation>Use with an applicable Product Form code D*; see note on D201.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D206">
+				<xs:annotation>
+					<xs:documentation>Palm OS</xs:documentation>
+					<xs:documentation>Use with an applicable Product Form code D*; see note on D201.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D207">
+				<xs:annotation>
+					<xs:documentation>Windows Mobile</xs:documentation>
+					<xs:documentation>Use with an applicable Product Form code D*; see note on D201.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D301">
+				<xs:annotation>
+					<xs:documentation>Microsoft XBox</xs:documentation>
+					<xs:documentation>Use with Product Form code DE or DB as applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D302">
+				<xs:annotation>
+					<xs:documentation>Nintendo Gameboy Color</xs:documentation>
+					<xs:documentation>Use with Product Form code DE or DB as applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D303">
+				<xs:annotation>
+					<xs:documentation>Nintendo Gameboy Advanced</xs:documentation>
+					<xs:documentation>Use with Product Form code DE or DB as applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D304">
+				<xs:annotation>
+					<xs:documentation>Nintendo Gameboy</xs:documentation>
+					<xs:documentation>Use with Product Form code DE or DB as applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D305">
+				<xs:annotation>
+					<xs:documentation>Nintendo Gamecube</xs:documentation>
+					<xs:documentation>Use with Product Form code DE or DB as applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D306">
+				<xs:annotation>
+					<xs:documentation>Nintendo 64</xs:documentation>
+					<xs:documentation>Use with Product Form code DE or DB as applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D307">
+				<xs:annotation>
+					<xs:documentation>Sega Dreamcast</xs:documentation>
+					<xs:documentation>Use with Product Form code DE or DB as applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D308">
+				<xs:annotation>
+					<xs:documentation>Sega Genesis/Megadrive</xs:documentation>
+					<xs:documentation>Use with Product Form code DE or DB as applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D309">
+				<xs:annotation>
+					<xs:documentation>Sega Saturn</xs:documentation>
+					<xs:documentation>Use with Product Form code DE or DB as applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D310">
+				<xs:annotation>
+					<xs:documentation>Sony PlayStation 1</xs:documentation>
+					<xs:documentation>Use with Product Form code DE or DB as applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D311">
+				<xs:annotation>
+					<xs:documentation>Sony PlayStation 2</xs:documentation>
+					<xs:documentation>Use with Product Form code DE or DB as applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D312">
+				<xs:annotation>
+					<xs:documentation>Nintendo Dual Screen</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D313">
+				<xs:annotation>
+					<xs:documentation>Sony PlayStation 3</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D314">
+				<xs:annotation>
+					<xs:documentation>Xbox 360</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D315">
+				<xs:annotation>
+					<xs:documentation>Nintendo Wii</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D316">
+				<xs:annotation>
+					<xs:documentation>Sony PlayStation Portable (PSP)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E100">
+				<xs:annotation>
+					<xs:documentation>Altres</xs:documentation>
+					<xs:documentation>No code allocated for this e-publication format yet.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E101">
+				<xs:annotation>
+					<xs:documentation>EPUB</xs:documentation>
+					<xs:documentation>The Open Publication Structure / OPS Container Format standard of the International Digital Publishing Forum (IDPF) [File extension .epub].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E102">
+				<xs:annotation>
+					<xs:documentation>OEB</xs:documentation>
+					<xs:documentation>The Open EBook format of the IDPF, a predecessor of the full EPUB format, still (2008) supported as part of the latter [File extension .opf]. Includes EPUB format up to and including version 2 - but prefer code E101 for EPUB 2, and always use code E101 for EPUB 3.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E103">
+				<xs:annotation>
+					<xs:documentation>DOC</xs:documentation>
+					<xs:documentation>Microsoft Word binary document format [File extension .doc].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E104">
+				<xs:annotation>
+					<xs:documentation>DOCX</xs:documentation>
+					<xs:documentation>Office Open XML / Microsoft Word XML document format (ISO/IEC 29500:2008) [File extension .docx].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E105">
+				<xs:annotation>
+					<xs:documentation>HTML</xs:documentation>
+					<xs:documentation>HyperText Mark-up Language [File extension .html, .htm].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E106">
+				<xs:annotation>
+					<xs:documentation>ODF</xs:documentation>
+					<xs:documentation>Open Document Format [File extension .odt].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E107">
+				<xs:annotation>
+					<xs:documentation>PDF</xs:documentation>
+					<xs:documentation>Portable Document Format (ISO 32000-1:2008) [File extension .pdf].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E108">
+				<xs:annotation>
+					<xs:documentation>PDF/A</xs:documentation>
+					<xs:documentation>PDF archiving format defined by ISO 19005-1:2005 [File extension .pdf].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E109">
+				<xs:annotation>
+					<xs:documentation>RTF</xs:documentation>
+					<xs:documentation>Rich Text Format [File extension .rtf].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E110">
+				<xs:annotation>
+					<xs:documentation>SGML</xs:documentation>
+					<xs:documentation>Standard Generalized Mark-up Language.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E111">
+				<xs:annotation>
+					<xs:documentation>TCR</xs:documentation>
+					<xs:documentation>A compressed text format mainly used on Psion handheld devices [File extension .tcr].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E112">
+				<xs:annotation>
+					<xs:documentation>TXT</xs:documentation>
+					<xs:documentation>Text file format [File extension .txt].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E113">
+				<xs:annotation>
+					<xs:documentation>XHTML</xs:documentation>
+					<xs:documentation>Extensible Hypertext Markup Language [File extension .xhtml, .xht, .xml, .html, .htm].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E114">
+				<xs:annotation>
+					<xs:documentation>zTXT</xs:documentation>
+					<xs:documentation>A compressed text format mainly used on Palm handheld devices [File extension .pdb - see also E121, E125, E130].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E115">
+				<xs:annotation>
+					<xs:documentation>XPS</xs:documentation>
+					<xs:documentation>XML Paper Specification format [File extension .xps].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E116">
+				<xs:annotation>
+					<xs:documentation>Amazon Kindle</xs:documentation>
+					<xs:documentation>A format proprietary to Amazon for use with its Kindle reading devices or software readers [File extensions .azw, .mobi, .prc].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E117">
+				<xs:annotation>
+					<xs:documentation>BBeB</xs:documentation>
+					<xs:documentation>A Sony proprietary format for use with the Sony Reader and LIBRIé reading devices [File extension .lrf].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E118">
+				<xs:annotation>
+					<xs:documentation>DXReader</xs:documentation>
+					<xs:documentation>A proprietary format for use with DXReader software.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E119">
+				<xs:annotation>
+					<xs:documentation>EBL</xs:documentation>
+					<xs:documentation>A format proprietary to the Ebook Library service.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E120">
+				<xs:annotation>
+					<xs:documentation>Ebrary</xs:documentation>
+					<xs:documentation>A format proprietary to the Ebrary service.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E121">
+				<xs:annotation>
+					<xs:documentation>eReader</xs:documentation>
+					<xs:documentation>A proprietary format for use with eReader (AKA &apos;Palm Reader&apos;) software on various hardware platforms [File extension .pdb - see also E114, E125, E130].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E122">
+				<xs:annotation>
+					<xs:documentation>Exebook</xs:documentation>
+					<xs:documentation>A proprietary format with its own reading system for Windows platforms [File extension .exe].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E123">
+				<xs:annotation>
+					<xs:documentation>Franklin eBookman</xs:documentation>
+					<xs:documentation>A proprietary format for use with the Franklin eBookman reader.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E124">
+				<xs:annotation>
+					<xs:documentation>Gemstar Rocketbook</xs:documentation>
+					<xs:documentation>A proprietary format for use with the Gemstar Rocketbook reader [File extension .rb].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E125">
+				<xs:annotation>
+					<xs:documentation>iSilo</xs:documentation>
+					<xs:documentation>A proprietary format for use with iSilo software on various hardware platforms [File extension .pdb - see also E114, E121, E130].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E126">
+				<xs:annotation>
+					<xs:documentation>Microsoft Reader</xs:documentation>
+					<xs:documentation>A proprietary format for use with Microsoft Reader software on Windows and Pocket PC platforms [File extension .lit].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E127">
+				<xs:annotation>
+					<xs:documentation>Mobipocket</xs:documentation>
+					<xs:documentation>A proprietary format for use with Mobipocket software on various hardware platforms [File extensions .mobi, .prc]. Includes Amazon Kindle formats up to and including version 7 - but prefer code E116 for version 7, and always use E116 for KF8.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E128">
+				<xs:annotation>
+					<xs:documentation>MyiLibrary</xs:documentation>
+					<xs:documentation>A format proprietary to the MyiLibrary service.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E129">
+				<xs:annotation>
+					<xs:documentation>NetLibrary</xs:documentation>
+					<xs:documentation>A format proprietary to the NetLibrary service.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E130">
+				<xs:annotation>
+					<xs:documentation>Plucker</xs:documentation>
+					<xs:documentation>A proprietary format for use with Plucker reader software on Palm and other handheld devices [File extension .pdb - see also E114, E121, E125].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E131">
+				<xs:annotation>
+					<xs:documentation>VitalBook</xs:documentation>
+					<xs:documentation>A format proprietary to the VitalSource service.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E132">
+				<xs:annotation>
+					<xs:documentation>Vook</xs:documentation>
+					<xs:documentation>A proprietary digital product combining text and video content and available to be used online or as a downloadable application for a mobile device - see www.vook.com.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E133">
+				<xs:annotation>
+					<xs:documentation>Google Edition</xs:documentation>
+					<xs:documentation>An epublication made available by Google in association with a publisher; readable online on a browser-enabled device and offline on designated ebook readers.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E134">
+				<xs:annotation>
+					<xs:documentation>Book &apos;app&apos; for iOS</xs:documentation>
+					<xs:documentation>Epublication packaged as application for iOS (eg Apple iPhone, iPad etc), containing both executable code and content. Use &lt;ProductContentType> to describe content, and &lt;ProductFormFeatureType> to list detailed technical requirements.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E135">
+				<xs:annotation>
+					<xs:documentation>Book &apos;app&apos; for Android</xs:documentation>
+					<xs:documentation>Epublication packaged as application for Android (eg Android phone or tablet), containing both executable code and content. Use &lt;ProductContentType> to describe content, and &lt;ProductFormFeatureType> to list detailed technical requirements.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E136">
+				<xs:annotation>
+					<xs:documentation>Book &apos;app&apos; for other operating system</xs:documentation>
+					<xs:documentation>Epublication packaged as application, containing both executable code and content. Use where other &apos;app&apos; codes are not applicable. Technical requirements such as target operating system and/or device should be provided eg in &lt;ProductFormFeatureType>. Content type (text or text plus various &apos;enhancements&apos;) may be described with &lt;ProductContentType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E139">
+				<xs:annotation>
+					<xs:documentation>CEB</xs:documentation>
+					<xs:documentation>Founder Apabi&apos;s proprietary basic e-book format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E140">
+				<xs:annotation>
+					<xs:documentation>CEBX</xs:documentation>
+					<xs:documentation>Founder Apabi&apos;s proprietary XML e-book format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E141">
+				<xs:annotation>
+					<xs:documentation>iBook</xs:documentation>
+					<xs:documentation>Apple&apos;s iBook format (a proprietary extension of EPUB), can only be read on Apple iOS devices.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E142">
+				<xs:annotation>
+					<xs:documentation>ePIB</xs:documentation>
+					<xs:documentation>Proprietary format used by Barnes and Noble, readable on NOOK devices and Nook reader software.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E200">
+				<xs:annotation>
+					<xs:documentation>Reflowable</xs:documentation>
+					<xs:documentation>Use when a particular e-publication type (specified using codes E100 and upwards) has both fixed format and reflowable variants.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E201">
+				<xs:annotation>
+					<xs:documentation>Fixed format</xs:documentation>
+					<xs:documentation>Use when a particular e-publication type (specified using codes E100 and upwards) has both fixed format and reflowable variants.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E202">
+				<xs:annotation>
+					<xs:documentation>Readable offline</xs:documentation>
+					<xs:documentation>All e-publication resources are included within the e-publication package.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E203">
+				<xs:annotation>
+					<xs:documentation>Requires network connection</xs:documentation>
+					<xs:documentation>E-publication requires a network connection to access some resources (eg an enhanced e-book where video clips are not stored within the e-publication package itself, but are delivered via an internet connection).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="L101">
+				<xs:annotation>
+					<xs:documentation>Laminated</xs:documentation>
+					<xs:documentation>Whole product laminated (eg laminated map, fold-out chart, wallchart, etc): use B415 for book with laminated cover.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P101">
+				<xs:annotation>
+					<xs:documentation>Desk calendar</xs:documentation>
+					<xs:documentation>Use with Product Form code PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P102">
+				<xs:annotation>
+					<xs:documentation>Mini calendar</xs:documentation>
+					<xs:documentation>Use with Product Form code PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P103">
+				<xs:annotation>
+					<xs:documentation>Engagement calendar</xs:documentation>
+					<xs:documentation>Use with Product Form code PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P104">
+				<xs:annotation>
+					<xs:documentation>Day by day calendar</xs:documentation>
+					<xs:documentation>Use with Product Form code PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P105">
+				<xs:annotation>
+					<xs:documentation>Poster calendar</xs:documentation>
+					<xs:documentation>Use with Product Form code PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P106">
+				<xs:annotation>
+					<xs:documentation>Wall calendar</xs:documentation>
+					<xs:documentation>Use with Product Form code PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P107">
+				<xs:annotation>
+					<xs:documentation>Perpetual calendar</xs:documentation>
+					<xs:documentation>Use with Product Form code PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P108">
+				<xs:annotation>
+					<xs:documentation>Advent calendar</xs:documentation>
+					<xs:documentation>Use with Product Form code PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P109">
+				<xs:annotation>
+					<xs:documentation>Bookmark calendar</xs:documentation>
+					<xs:documentation>Use with Product Form code PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P110">
+				<xs:annotation>
+					<xs:documentation>Student calendar</xs:documentation>
+					<xs:documentation>Use with Product Form code PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P111">
+				<xs:annotation>
+					<xs:documentation>Project calendar</xs:documentation>
+					<xs:documentation>Use with Product Form code PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P112">
+				<xs:annotation>
+					<xs:documentation>Almanac calendar</xs:documentation>
+					<xs:documentation>Use with Product Form code PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P113">
+				<xs:annotation>
+					<xs:documentation>Other calendar</xs:documentation>
+					<xs:documentation>A calendar that is not one of the types specified elsewhere: use with Product Form code PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P114">
+				<xs:annotation>
+					<xs:documentation>Other calendar or organiser product</xs:documentation>
+					<xs:documentation>A product that is associated with or ancillary to a calendar or organiser, eg a deskstand for a calendar, or an insert for an organiser: use with Product Form code PC or PS.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P201">
+				<xs:annotation>
+					<xs:documentation>Hardback (stationery)</xs:documentation>
+					<xs:documentation>Stationery item in hardback book format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P202">
+				<xs:annotation>
+					<xs:documentation>Paperback / softback (stationery)</xs:documentation>
+					<xs:documentation>Stationery item in paperback/softback book format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P203">
+				<xs:annotation>
+					<xs:documentation>Spiral bound (stationery)</xs:documentation>
+					<xs:documentation>Stationery item in spiral-bound book format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P204">
+				<xs:annotation>
+					<xs:documentation>Leather / fine binding (stationery)</xs:documentation>
+					<xs:documentation>Stationery item in leather-bound book format, or other fine binding.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="V201">
+				<xs:annotation>
+					<xs:documentation>PAL</xs:documentation>
+					<xs:documentation>TV standard for video or DVD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="V202">
+				<xs:annotation>
+					<xs:documentation>NTSC</xs:documentation>
+					<xs:documentation>TV standard for video or DVD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="V203">
+				<xs:annotation>
+					<xs:documentation>SECAM</xs:documentation>
+					<xs:documentation>TV standard for video or DVD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List176">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 176">Product form feature value - operating system</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Android</xs:documentation>
+					<xs:documentation>An Open Source mobile device operating system originally developed by Google and supported by the Open Handset Alliance.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>BlackBerry OS</xs:documentation>
+					<xs:documentation>A proprietary operating system supplied by Research In Motion for its BlackBerry handheld devices.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>iOS</xs:documentation>
+					<xs:documentation>A proprietary operating system based on Mac OS X supplied by Apple for its iPhone, iPad and iPod Touch handheld devices.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Linux</xs:documentation>
+					<xs:documentation>An operating system based on the Linux kernel.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Mac OS</xs:documentation>
+					<xs:documentation>[A proprietary operating system supplied by Apple on Macintosh computers up to 2002] DEPRECATED - use code 13 for all Mac OS versions.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Mac OS X</xs:documentation>
+					<xs:documentation>[A proprietary operating system supplied by Apple on Macintosh computers from 2001/2002] DEPRECATED - use code 13 for all Mac OS versions.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Palm OS</xs:documentation>
+					<xs:documentation>A proprietary operating system (AKA Garnet OS) originally developed for handheld devices.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>webOS</xs:documentation>
+					<xs:documentation>A proprietry Linux-based operating system for handheld devices, originally developed by Palm (now owned by HP).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Symbian</xs:documentation>
+					<xs:documentation>An operating system for hand-held devices, originally developed as a proprietary system, but planned to become wholly Open Source by 2010.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Windows</xs:documentation>
+					<xs:documentation>A proprietary operating system supplied by Microsoft.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Windows CE</xs:documentation>
+					<xs:documentation>A proprietary operating system (AKA Windows Embedded Compact, WinCE) supplied by Microsoft for small-scale devices.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Windows Mobile</xs:documentation>
+					<xs:documentation>A proprietary operating system supplied by Microsoft for mobile devices.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Mac OS</xs:documentation>
+					<xs:documentation>A proprietary operating system supplied by Apple on Macintosh computers.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Windows Phone 7</xs:documentation>
+					<xs:documentation>A proprietary operating system supplied by Microsoft for mobile devices, successor to Windows Mobile.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List177">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 177">Person / organization date role</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="50">
+				<xs:annotation>
+					<xs:documentation>Date of birth</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="51">
+				<xs:annotation>
+					<xs:documentation>Date of death</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List178">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 178">Supporting resource file format</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="A103">
+				<xs:annotation>
+					<xs:documentation>MP3</xs:documentation>
+					<xs:documentation>MPEG 1/2 Audio Layer III file.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A104">
+				<xs:annotation>
+					<xs:documentation>WAV</xs:documentation>
+					<xs:documentation>Waveform Audio file.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A105">
+				<xs:annotation>
+					<xs:documentation>Real Audio</xs:documentation>
+					<xs:documentation>Proprietary RealNetworks format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A106">
+				<xs:annotation>
+					<xs:documentation>WMA</xs:documentation>
+					<xs:documentation>Windows Media Audio format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A107">
+				<xs:annotation>
+					<xs:documentation>AAC</xs:documentation>
+					<xs:documentation>Advanced Audio Coding format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A111">
+				<xs:annotation>
+					<xs:documentation>AIFF</xs:documentation>
+					<xs:documentation>Audio Interchange File format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D101">
+				<xs:annotation>
+					<xs:documentation>Real Video</xs:documentation>
+					<xs:documentation>Proprietary RealNetworks format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D102">
+				<xs:annotation>
+					<xs:documentation>Quicktime</xs:documentation>
+					<xs:documentation>Quicktime container format (.mov).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D103">
+				<xs:annotation>
+					<xs:documentation>AVI</xs:documentation>
+					<xs:documentation>Audio Video Interleave format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D104">
+				<xs:annotation>
+					<xs:documentation>WMV</xs:documentation>
+					<xs:documentation>Windows Media Video format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D105">
+				<xs:annotation>
+					<xs:documentation>MPEG-4</xs:documentation>
+					<xs:documentation>MPEG-4 container format (.mp4, .m4a).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D106">
+				<xs:annotation>
+					<xs:documentation>FLV</xs:documentation>
+					<xs:documentation>Flash Video (.flv, .f4v).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D107">
+				<xs:annotation>
+					<xs:documentation>SWF</xs:documentation>
+					<xs:documentation>ShockWave (.swf).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D108">
+				<xs:annotation>
+					<xs:documentation>3GP</xs:documentation>
+					<xs:documentation>3GPP container format (.3gp, .3g2).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D109">
+				<xs:annotation>
+					<xs:documentation>WebM</xs:documentation>
+					<xs:documentation>WebM container format (includes .mkv).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D401">
+				<xs:annotation>
+					<xs:documentation>PDF</xs:documentation>
+					<xs:documentation>Portable Document File format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D501">
+				<xs:annotation>
+					<xs:documentation>GIF</xs:documentation>
+					<xs:documentation>Graphic Interchange File format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D502">
+				<xs:annotation>
+					<xs:documentation>JPEG</xs:documentation>
+					<xs:documentation>Joint Photographic Experts Group format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D503">
+				<xs:annotation>
+					<xs:documentation>PNG</xs:documentation>
+					<xs:documentation>Portable Network Graphics format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D504">
+				<xs:annotation>
+					<xs:documentation>TIFF</xs:documentation>
+					<xs:documentation>Tagged Image File format.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E101">
+				<xs:annotation>
+					<xs:documentation>EPUB</xs:documentation>
+					<xs:documentation>The Open Publication Structure / OPS Container Format standard of the International Digital Publishing Forum (IDPF) [File extension .epub].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E105">
+				<xs:annotation>
+					<xs:documentation>HTML</xs:documentation>
+					<xs:documentation>HyperText Mark-up Language [File extension .html, .htm].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E107">
+				<xs:annotation>
+					<xs:documentation>PDF</xs:documentation>
+					<xs:documentation>Portable Document Format (ISO 32000-1:2008) [File extension .pdf].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E113">
+				<xs:annotation>
+					<xs:documentation>XHTML</xs:documentation>
+					<xs:documentation>Extensible Hypertext Markup Language [File extension .xhtml, .xht, .xml, .html, .htm].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E115">
+				<xs:annotation>
+					<xs:documentation>XPS</xs:documentation>
+					<xs:documentation>XML Paper Specification.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List179">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 179">Price code type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Propietari</xs:documentation>
+					<xs:documentation>A publisher or retailer&apos;s proprietary code list which identifies particular codes with particular price points, price tiers or bands.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Finnish Pocket Book price code</xs:documentation>
+					<xs:documentation>Price Code scheme for Finnish Pocket Books (Pokkareiden hintaryhmä). Price codes expressed as letters A-J in &lt;PriceCode>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List184">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 184">EU Toy Safety Directive hazard warning</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>No warning</xs:documentation>
+					<xs:documentation>Use to provide positive indication that no warnings are applicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Carries &apos;CE&apos; logo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Carries minimum age warning</xs:documentation>
+					<xs:documentation>Use to specify age (in years, or years and months). Provide specific wording in &lt;ProductFormFeatureDescription>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Carries EU Toy Safety Directive &apos;Unsuitable for children ages 0-3&apos; warning logo</xs:documentation>
+					<xs:documentation>Carries logo, and must be accompanied by the default warning &apos;Not suitable for children under 36 months&apos; (or its approved equivalent in a language other than English, as appropriate), unless specific wording is provided in &lt;ProductFormFeatureDescription>. If specific alternative wording is carried in &lt;ProductFormFeatureDescription>, this must be used in place of the default text.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Carries EU Toy Safety Directive hazard warning</xs:documentation>
+					<xs:documentation>Exact text of warning must be included in &lt;ProductFormFeatureDescription>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Carries other text associated with toy safety</xs:documentation>
+					<xs:documentation>Exact text (not in itself a warning) must be included in &lt;ProductFormFeatureDescription>. May be used either without any warning, or as text additional to a warning. Note that if no warnings apply, code 00 can provide positive indication of this. Example use: &apos;Suitable for all ages&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Material Safety Data Sheet available</xs:documentation>
+					<xs:documentation>Material Safety Data Sheet (a document required by the EU Toy Safety Directive) available online, typically as a PDF file or similar. &lt;ProductFormFeatureDescription> must carry the URL of the document.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Declaration of Conformity available</xs:documentation>
+					<xs:documentation>Declaration of Conformity (the document that backs up the CE mark) available online, typically as a PDF file or similar. &lt;ProductFormFeatureDescription> must carry the URL of the document.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List196">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 196">E-publication Accessibility Details</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>LIA Compliance Scheme</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>No reading system accessibility options disabled (except)</xs:documentation>
+					<xs:documentation>No accessibility features offered by the reading system, device or reading software (including but not limited to choice of text size or typeface, choice of text or background color, text-to-speech) are disabled, overridden or otherwise unusable with the product EXCEPT - in ONIX 3 messages only - those specifically noted as subject to restriction or prohibition in &lt;EpubUsageConstraint>. Note that provision of any significant part of the textual content as images (ie as pictures of text, rather than as text) inevitably prevents use of these accessibility options.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Table of contents navigation</xs:documentation>
+					<xs:documentation>Table of contents allows direct (eg hyperlinked) access to all levels of text organization above individual paragraphs (eg to all sections and subsections) and to all tables, figures, illustrations etc. Non-textual items such as illustrations, tables, audio or video content may be directly accessible from the Table of contents, or from a similar List of illustrations, List of tables, etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Index navigation</xs:documentation>
+					<xs:documentation>Index provides direct (eg hyperlinked) access to uses of the index terms in the document body.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Reading order</xs:documentation>
+					<xs:documentation>All or substantially all textual matter is arranged in a single logical reading order (including text that is visually presented as separate from the main text flow, eg in boxouts, captions, tables, footnotes, endnotes, citations, etc). Non-textual content is also linked from within this logical reading order. (Purely decorative non-text content can be ignored.)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Short alternative descriptions</xs:documentation>
+					<xs:documentation>All or substantially all non-text content has short alternative descriptions, usually provided via alt attributes. Note this applies to normal images (eg photographs, charts and diagrams) and also to any embedded audio, video etc. Audio and video content should include alternative descriptions suitable for hearing-impaired as well as for visually-impaired readers. (Purely decorative non-text content can be ignored, but the accessibility of resources delivered via a network connection rather than as part of the e-publication package must be included.)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Full alternative descriptions</xs:documentation>
+					<xs:documentation>All or substantially all non-text content has full alternative descriptions. Note this applies to normal images (eg photographs, charts and diagrams) and also to any embedded audio, video etc. Audio and video content should include full alternative descriptions (eg audio-described video) and subtitles or closed captions suitable for hearing-impaired as well as for visually-impaired readers. (Purely decorative non-text content can be ignored, but the accessibility of resources delivered via a network connection rather than as part of the e-publication package must be included.)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Visualised data also available as non-graphical data</xs:documentation>
+					<xs:documentation>Where data visualisations are provided (eg graphs and charts), the underlying data is also available in non-graphical (usually tabular, textual) form.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Accessible math content</xs:documentation>
+					<xs:documentation>Mathematical content such as equations is usable with assistive technology, eg through use of MathML. Semantic MathML is preferred but Presentational MathML is acceptable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Accessible chem content</xs:documentation>
+					<xs:documentation>Chemistry content such as chemical formulae is usable with assistive technology, eg through use of ChemML.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Print-equivalent page numbering</xs:documentation>
+					<xs:documentation>For a reflowable e-publication, contains references to the page numbering of an equivalent printed product.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Synchronised pre-recorded audio</xs:documentation>
+					<xs:documentation>Text-synchronised pre-recorded audio narration (natural or synthesised voice) is included for substantially all textual matter, including all alternative descriptions.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="97">
+				<xs:annotation>
+					<xs:documentation>Compatibility tested</xs:documentation>
+					<xs:documentation>&lt;ProductFormFeatureDescription> carries a short description of compatibility testing carried out for this product, including detailed compatibility with various assistive technology such as third-party screen-reading software.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="98">
+				<xs:annotation>
+					<xs:documentation>Trusted Intermediary contact</xs:documentation>
+					<xs:documentation>&lt;ProductFormFeatureDescription> carries the e-mail address for a contact at a &apos;trusted intermediary&apos;, to whom detailed questions about accessibility for this product may be directed.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="99">
+				<xs:annotation>
+					<xs:documentation>Publisher contact for further accessibility information</xs:documentation>
+					<xs:documentation>&lt;ProductFormFeatureDescription> carries the e-mail address for a contact at the publisher to whom detailed questions about accessibility of this product may be directed.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List197">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 197">Collection sequence type</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Propietari</xs:documentation>
+					<xs:documentation>A short explanatory label for the sequence should be provided in &lt;CollectionSequenceTypeName>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Title order</xs:documentation>
+					<xs:documentation>Order as specified by the title, eg by volume or part number sequence, provided for confirmation.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Publication order</xs:documentation>
+					<xs:documentation>Order of publication of products within the collection.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Temporal/narrative order</xs:documentation>
+					<xs:documentation>Order defined by a continuing narrative or temporal sequence within products in the collection. Applicable to either fiction or to non-fiction (eg within a collection of history textbooks).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Original publication order</xs:documentation>
+					<xs:documentation>Original publication order, for a republished collection or collected works originally published outside a collection.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List198">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 198">Product contact role</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Accessibility request contact</xs:documentation>
+					<xs:documentation>Eg for requests for supply of mutable digital files for conversion to other formats.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Promotional contact</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SourceTypeCode">
+		<xs:restriction base="List3"/>
+	</xs:simpleType>
+	<xs:simpleType name="TextCaseCode">
+		<xs:restriction base="List14"/>
+	</xs:simpleType>
+	<xs:simpleType name="TextFormatCode">
+		<xs:restriction base="List34"/>
+	</xs:simpleType>
+	<xs:simpleType name="TransliterationCode">
+		<xs:restriction base="List138"/>
+	</xs:simpleType>
+</xs:schema>

--- a/locale/es_ES/ONIX_BookProduct_CodeLists.xsd
+++ b/locale/es_ES/ONIX_BookProduct_CodeLists.xsd
@@ -1,0 +1,23266 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+	**************************************************
+	*                                                *
+	*               ONIX INTERNATIONAL               *
+	*                                                *
+	*     BOOK PRODUCT INFORMATION MESSAGE SCHEMA    *
+	*                                                *
+	*           CODE LIST DATA TYPES MODULE          *
+	*               XML SCHEMA VERSION               *
+	*                                                *
+	*                    ISSUE: 17                   *
+	*                                                *
+	*                 Status: RELEASED               *
+	*            Release date: 2012-04-20            *
+	*                                                *
+	*  Orig filename ONIX_BookProduct_CodeLists.XSD  *
+	*                                                *
+	*          Original author: Francis Cave         *
+	*                                                *
+	*              (c) 2003-2012 EDItEUR             *
+	*             http://www.editeur.org/            *
+	*                                                *
+	**************************************************
+
+	N.B. PRIMARILY DESIGNED FOR USE WITH ONIX SCHEMAS
+
+	TERMS AND CONDITIONS OF USE OF THE ONIX PRODUCT INFORMATION MESSAGE XML SCHEMA
+
+	All ONIX standards and documentation are copyright materials, made available 
+	free of charge for general use.  If you use the ONIX International Code Lists, 
+	you will be deemed to have accepted these terms and conditions:
+
+	1.  You agree that you will not add to, delete from or amend any version of the 
+	ONIX Product Information Message Schema, or any part of the Schema except for 
+	strictly internal use in your own organisation.
+
+	2.  You agree that if you wish to add to, amend, or make extracts of any version 
+	of the Schema for any purpose that is not strictly internal to your own organisation, 
+	you will in the first instance notify EDItEUR and allow EDItEUR to review 
+	and comment on your proposed use, in the interest of securing an orderly 
+	development of the Schema for the benefit of other users.
+
+	If you do not accept these terms, you must not use any version of the ONIX Product 
+	Information Message Schema.
+
+	Full copies of all published versions of the latest release of this Schema and all 
+	associated documentation are available from the EDItEUR web site, where may also be 
+	found details of how to contact EDItEUR for advice on the use of this Schema. The URL 
+	for the EDItEUR web site is:
+
+	http://www.editeur.org/
+
+
+
+	MODULE REVISION HISTORY (IN REVERSE CHRONOLOGICAL ORDER)
+
+	2012-04-20: Module for public release based upon the ONIX International 
+	            Code lists Issue 17 (April 2012)
+
+	2012-01-23: Module for public release based upon the ONIX International 
+	            Code lists Issue 16 (January 2012)
+
+	2011-10-21: Module for public release based upon the ONIX International 
+	            Code lists Issue 15 (October 2011)
+
+	2011-06-27: Module for public release based upon the ONIX International 
+	            Code lists Issue 14 (June 2011)
+
+	2011-03-23: Module for public release based upon the ONIX International 
+	            Code lists Issue 13 (March 2011)
+
+	2010-10-26: Module for public release based upon the ONIX International 
+	            Code lists Issue 12 (October 2010)
+
+	2010-05-17: Module for public release based upon the ONIX International 
+	            Code lists Issue 11, with correction in List 67 (May 2010)
+
+	2010-03-18: Module for public release based upon the ONIX International 
+	            Code lists Issue 11 (March 2010)
+
+	2009-07-15: Module for public release based upon the ONIX International 
+	            Code lists Issue 10 (July 2009)
+
+	2009-04-09: Module for public release based upon the ONIX International 
+	            Code lists Issue 9 (April 2009)
+
+	2009-02-10: Module for public release based upon the ONIX International 
+	            Code Lists Issue 8+ (revised February 2009)
+
+	2008-12-04: Module for public release based upon the ONIX International 
+	            Code Lists Issue 8+ (December 2008)
+
+	2008-04-22: Module for public release based upon the ONIX International 
+	            Code Lists Issue 8 (April 2008)
+
+	2007-03-27: Module for public release based upon the ONIX International
+	            Code Lists Issue 7 (March 2007)
+
+	2006-07-18: Module for public release based upon the ONIX International
+	            Code Lists Issue 6 (July 2006)
+
+	2005-11-28: Module for public release based upon the ONIX International
+	            Code Lists Issue 5 (November 2005)
+
+	2005-02-10: Module for public release based upon the ONIX International
+	            Code Lists Issue 4 (February 2005)
+
+	2004-11-10: Module for public release based upon the ONIX International 
+	            Code Lists Issue 3 (August 2004)
+
+	2004-08-10: Second Draft Module based upon the ONIX International 
+	            Code Lists Issue 3 (August 2004)
+
+	2003-12-30: First Draft Module based upon the ONIX International 
+	            Code Lists Issue 2 (December 2003)
+
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+		<xs:simpleType name="List1">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 1">Código de tipo de actualización o notificación</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Notificación rápida</xs:documentation>
+					<xs:documentation>Emplear para un registro completo emitido antes de, aproximadamente, los seis meses previos a la publicación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Notificación avanzada (confirmado)</xs:documentation>
+					<xs:documentation>Emplear para un registro completo emitido para confirmar información avanzada aproximadamente seis meses antes de la publicación; o para un registro completo emitido después de esa fecha y antes de que la información se confirmara con el libro en la mano.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Notificación confirmada en la publicación</xs:documentation>
+					<xs:documentation>Emplear para un registro completo emitido para confirmar información avanzada en el momento o justo antes de la fecha de publicación real, o para un registro completo emitido en una fecha posterior.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Actualización (parcial)</xs:documentation>
+					<xs:documentation>Solo en ONIX 3.0, usar cuando se envíe un registro de &quot;actualización en bloque&quot;. En versiones anteriores de ONIX, la actualización de ONIX, por lo general, se ha realizado mediante el reemplazo del registro completo utilizando el código 03, y el código 04 no se utiliza.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Borrar</xs:documentation>
+					<xs:documentation>Usar cuando se envíe una instrucción para eliminar un registro que se había emitido anteriormente. Tenga en cuenta que una instrucción de Eliminar NO debería emplearse cuando un proyecto se cancele, se saque de imprenta o se retire de la venta en algún sentido: esta situación no debe tratarse como un estado de la publicación en el que se deja al destinatario con la tarea de decidir si conserva o elimina el registro. Una instrucción de Eliminar solamente se usa cuando existe un motivo en concreto para retirar un registro por completo, p. ej., porque se emitió por error.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Aviso de venta</xs:documentation>
+					<xs:documentation>Aviso de venta de un producto, de una editorial a otra: lo envía la editorial que se deshace del producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Aviso de adquisición</xs:documentation>
+					<xs:documentation>Aviso de adquisición de un producto, de una editorial a otra: lo envía la editorial que adquiere el producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Actualización - Solamente SupplyDetail</xs:documentation>
+					<xs:documentation>Actualización del suministro de ONIX 2.1 para libros - Solamente &lt;SupplyDetail> (no se emplea en ONIX 3.0).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Actualización - Solamente MarketRepresentation</xs:documentation>
+					<xs:documentation>Actualización del suministro de ONIX 2.1 para libros - Solamente &lt;MarketRepresentation> (no se emplea en ONIX 3.0).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Actualización - SupplyDetail y MarketRepresentation</xs:documentation>
+					<xs:documentation>Actualización del suministro de ONIX 2.1 para libros - &lt;SupplyDetail> y &lt;MarketRepresentation> (no se emplea en ONIX 3.0).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List2">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 2">Composición del producto</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Producto de venta de un solo elemento</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Producto de venta con múltiples elementos</xs:documentation>
+					<xs:documentation>Producto con múltiples elementos vendido como uno solo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Recopilación de múltiples elementos, vendidos como piezas por separado</xs:documentation>
+					<xs:documentation>Se usa cuando se necesita un registro de ONIX para una recopilación entera, aunque en la actualidad no se venda como tal.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Producto apto solo para el comercio</xs:documentation>
+					<xs:documentation>Producto no apto para la venta, y que no lleva elementos de venta, p. ej., cubeta vacía, expositor de mesa vacío, material promocional.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>Pack comercial de múltiples elementos</xs:documentation>
+					<xs:documentation>Contiene múltiples copias para la venta como elementos por separado, p. ej., pack comercial con película de plástico, cubeta llena, expositor de mesa lleno.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List3">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 3">Código del tipo de fuente de registro</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Sin especificar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Editor</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Distribuidor de la editorial</xs:documentation>
+					<xs:documentation>Se usa para designar a un distribuidor que proporciona almacenamiento y abastecimiento para una editorial o para el agente comercial de una editorial, que no es un mayorista.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Mayorista</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Organismo bibliográfico</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Librería biblioteca</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Agente comercial de la editorial</xs:documentation>
+					<xs:documentation>Usar para un agente comercial de la editorial encargado de la comercialización de los productos de la editorial en un territorio, y no para un distribuidor de la editorial que se encargue de los pedidos pero no de su comercialización.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Proveedor de servicios de conversión de la editorial</xs:documentation>
+					<xs:documentation>Proveedor de un servicio de conversión de formatos de publicación electrónica (que también puede ser un distribuidor o un vendedor de la publicación electrónica convertida), que aporta metadatos en nombre de la editorial. El número ISBN asignado se obtiene del prefijo ISBN de la editorial.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Proveedor de servicios de conversión</xs:documentation>
+					<xs:documentation>Proveedor de un servicio de conversión de formatos de publicación electrónica (que también puede ser un distribuidor o un vendedor de la publicación electrónica convertida), que aporta metadatos en nombre de la editorial. El número ISBN asignado se obtiene del prefijo ISBN de la editorial (dedique el proveedor de servicios ese prefijo para una editorial en particular o no).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List5">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 5">Código del tipo de identificador del producto</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Propietario</xs:documentation>
+					<xs:documentation>Por ejemplo, el número de producto de una editorial o de un mayorista.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>ISBN-10</xs:documentation>
+					<xs:documentation>International Standard Book Number (Número Internacional Normalizado del Libro), previo a 2007, sin guión (10 caracteres); ahora está OBSOLETO en ONIX para libros, excepto cuando se proporciona información histórica para la compatibilidad con sistemas antiguos. Solo debería usarse en relación con productos publicados antes de 2007 (cuando eI ISBN-13 lo sustituyó) y nunca se debería utilizar como único identificador (debería ir siempre junto con el GTIN-13/ISBN-13 correcto).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>GTIN-13</xs:documentation>
+					<xs:documentation>Global Trade Item Number (número mundial de un artículo comercial) de GS1, antiguamente conocido como &quot;número de artículo EAN&quot; (13 dígitos).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>UPC</xs:documentation>
+					<xs:documentation>Número de producto UPC (12 dígitos).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>ISMN-10</xs:documentation>
+					<xs:documentation>International Standard Music Number (número internacional de identificación de publicaciones de música escrita) (M más nueve dígitos). Es anterior a 2008; ahora está OBSOLETO en ONIX para libros, excepto cuando se proporciona información histórica para la compatibilidad con sistemas antiguos. Solo debería usarse en relación con productos publicados antes de 2008 (cuando eI ISMN-13 lo sustituyó) y nunca se debería utilizar como único identificador (debería ir siempre junto con el ISMN-13 correcto).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Identificador de objeto digital (DOI)</xs:documentation>
+					<xs:documentation>Digital Object Identifier (Identificador de objeto digital) (conjunto de caracteres y longitud variable).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>LCCN</xs:documentation>
+					<xs:documentation>Library of Congress Control Number (número de control de la Biblioteca del Congreso) (12 caracteres, alfanumérico).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>GTIN-14</xs:documentation>
+					<xs:documentation>Global Trade Item Number (número mundial de un artículo comercial) de GS1 (14 dígitos).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>ISBN-13</xs:documentation>
+					<xs:documentation>International Standard Book Number (Número Estándar Internacional de Libros), desde 2007, sin guion (13 dígitos que empiezan por 978 ó 9791-9799).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Número de depósito legal</xs:documentation>
+					<xs:documentation>Número asignado a una publicación como parte del proceso de depósito legal de un país.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Nombre de recurso uniforme</xs:documentation>
+					<xs:documentation>Uniform Resource Name (Nombre de Recurso Uniforme): téngase en cuenta que en aplicaciones comerciales, un ISBN debe enviarse como GTIN-13 y, cuando proceda, como ISBN-13. No debería enviarse como un nombre de recurso uniforme.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Número de OCLC</xs:documentation>
+					<xs:documentation>Número único asignado a un artículo bibliográfico por el Online Computer Library Center (OCLC).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>ISBN-13 de la coeditorial</xs:documentation>
+					<xs:documentation>Un ISBN-13 asignado por una coeditorial. El ISBN &quot;principal&quot; enviado con el código de tipo de Id. 03 o 15 siempre debería ser el ISBN que se utiliza para realizar pedidos a partir del proveedor identificado en Detalle del suministro. Sin embargo, las reglas de ISBN permiten que un título coeditado pueda llevar más de un ISBN. La coeditorial debería identificarse en una instancia de la composición &lt;Publisher>, con el código &lt;PublishingRole> aplicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>ISMN-13</xs:documentation>
+					<xs:documentation>International Standard Music Number (número internacional de identificación de publicaciones de música escrita), desde 2008 (número de 13 dígitos que comience por 9790).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>ISBN-A</xs:documentation>
+					<xs:documentation>ISBN accionable; de hecho, es un DOI especial que incorpora el ISBN-13 dentro de la sintaxis del DOI. Comienza por &quot;10.978.&quot; o &quot;10.979.&quot; e incluye un / carácter entre el elemento de registro (prefijo de la editorial) y el elemento de publicación del ISBN, p. ej., 10.978.000/1234567. Téngase en cuenta que el ISBN-A debería ir siempre con el propio ISBN, utilizando códigos 03 y/o 15.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>Código electrónico JP</xs:documentation>
+					<xs:documentation>Identificador de publicaciones electrónicas controlado por el Comité de Investigación y Gestión de Códigos de Publicaciones Electrónicas de JPOIID.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List6">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 6">Indicador de código de barras</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Sin código de barras</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Con código de barras; régimen indeterminado</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>EAN13</xs:documentation>
+					<xs:documentation>Cargo no especificado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 (precio codificado en dólares estadounidenses)</xs:documentation>
+					<xs:documentation>Cargo no especificado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>UPC12</xs:documentation>
+					<xs:documentation>Tipo y cargo no especificados. OBSOLETO: si puede, utilice valores más específicos a continuación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>UPC12+5</xs:documentation>
+					<xs:documentation>Tipo y cargo no especificados. OBSOLETO: si puede, utilice valores más específicos a continuación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>UPC12 (específico de un elemento)</xs:documentation>
+					<xs:documentation>También conocido como elemento/precio: cargo no especificado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (específico de un elemento)</xs:documentation>
+					<xs:documentation>También conocido como elemento/precio: cargo no especificado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>UPC12 (precio de venta al público)</xs:documentation>
+					<xs:documentation>También conocido como precio/elemento: cargo no especificado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (precio de venta al público)</xs:documentation>
+					<xs:documentation>También conocido como precio/elemento: cargo no especificado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>EAN13 en la portada 4</xs:documentation>
+					<xs:documentation>La &quot;portada 4&quot; se define como la contraportada de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 en la portada 4 (precio codificado en dólares estadounidenses)</xs:documentation>
+					<xs:documentation>La &quot;portada 4&quot; se define como la contraportada de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>UPC12 (específico de un elemento) en la portada 4</xs:documentation>
+					<xs:documentation>También conocido como elemento/precio; la &quot;portada 4&quot; se define como la contraportada de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (específico de un elemento) en la portada 4</xs:documentation>
+					<xs:documentation>También conocido como elemento/precio; la &quot;portada 4&quot; se define como la contraportada de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>UPC12 (precio de venta al público) en la portada 4</xs:documentation>
+					<xs:documentation>También conocido como precio/elemento; la &quot;portada 4&quot; se define como la contraportada de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (precio de venta al público) en la portada 4</xs:documentation>
+					<xs:documentation>También conocido como precio/elemento; la &quot;portada 4&quot; se define como la contraportada de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>EAN13 en la portada 3</xs:documentation>
+					<xs:documentation>La &quot;portada 3&quot; se define como la contraportada interior de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 en la portada 3 (precio codificado en dólares estadounidenses)</xs:documentation>
+					<xs:documentation>La &quot;portada 3&quot; se define como la contraportada interior de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>UPC12 (específico de un elemento) en la portada 3</xs:documentation>
+					<xs:documentation>También conocido como elemento/precio; la &quot;portada 3&quot; se define como la contraportada interior de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (específico de un elemento) en la portada 3</xs:documentation>
+					<xs:documentation>También conocido como elemento/precio; la &quot;portada 3&quot; se define como la contraportada interior de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>UPC12 (precio de venta al público) en la portada 3</xs:documentation>
+					<xs:documentation>También conocido como precio/elemento; la &quot;portada 3&quot; se define como la contraportada interior de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (precio de venta al público) en la portada 3</xs:documentation>
+					<xs:documentation>También conocido como precio/elemento; la &quot;portada 3&quot; se define como la contraportada interior de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>EAN13 en la portada 2</xs:documentation>
+					<xs:documentation>La &quot;portada 2&quot; se define como la portada interior de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 en la portada 2 (precio codificado en dólares estadounidenses)</xs:documentation>
+					<xs:documentation>La &quot;portada 2&quot; se define como la portada interior de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>UPC12 (específico de un elemento) en la portada 2</xs:documentation>
+					<xs:documentation>También conocido como elemento/precio; la &quot;portada 2&quot; se define como la portada interior de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (específico de un elemento) en la portada 2</xs:documentation>
+					<xs:documentation>También conocido como elemento/precio; la &quot;portada 2&quot; se define como la portada interior de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>UPC12 (precio de venta al público) en la portada 2</xs:documentation>
+					<xs:documentation>También conocido como precio/elemento; la &quot;portada 2&quot; se define como la portada interior de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (precio de venta al público) en la portada 2</xs:documentation>
+					<xs:documentation>También conocido como precio/elemento; la &quot;portada 2&quot; se define como la portada interior de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>EAN13 en la caja</xs:documentation>
+					<xs:documentation>Debe usarse solo en productos empaquetados.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="29">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 en la caja (precio codificado en dólares estadounidenses)</xs:documentation>
+					<xs:documentation>Debe usarse solo en productos empaquetados.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>UPC12 (específico de un elemento) en la caja</xs:documentation>
+					<xs:documentation>También conocido como elemento/precio; debe usarse solo en productos empaquetados.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (específico de un elemento) en la caja</xs:documentation>
+					<xs:documentation>También conocido como elemento/precio; debe usarse solo en productos empaquetados.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>UPC12 (precio de venta al público) en la caja</xs:documentation>
+					<xs:documentation>También conocido como precio/elemento; debe usarse solo en productos empaquetados.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (precio de venta al público) en la caja</xs:documentation>
+					<xs:documentation>También conocido como precio/elemento; debe usarse solo en productos empaquetados.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>EAN13 en la etiqueta</xs:documentation>
+					<xs:documentation>Debe usarse solo en productos que cuenten con etiquetas colgantes.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="35">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 en la etiqueta (precio codificado en dólares estadounidenses)</xs:documentation>
+					<xs:documentation>Debe usarse solo en productos que cuenten con etiquetas colgantes.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="36">
+				<xs:annotation>
+					<xs:documentation>UPC12 (específico de un elemento) en la etiqueta</xs:documentation>
+					<xs:documentation>También conocido como elemento/precio; debe usarse solo en productos que cuenten con etiquetas colgantes.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="37">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (específico de un elemento) en la etiqueta</xs:documentation>
+					<xs:documentation>También conocido como elemento/precio; debe usarse solo en productos que cuenten con etiquetas colgantes.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="38">
+				<xs:annotation>
+					<xs:documentation>UPC12 (precio de venta al público) en la etiqueta</xs:documentation>
+					<xs:documentation>También conocido como precio/elemento; debe usarse solo en productos que cuenten con etiquetas colgantes.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="39">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (precio de venta al público) en la etiqueta</xs:documentation>
+					<xs:documentation>También conocido como precio/elemento; debe usarse solo en productos que cuenten con etiquetas colgantes.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="40">
+				<xs:annotation>
+					<xs:documentation>EAN13 en la parte inferior</xs:documentation>
+					<xs:documentation>No debe usarse en libros a menos que estos vengan con embalaje externo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="41">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 en la parte inferior (precio codificado en dólares estadounidenses)</xs:documentation>
+					<xs:documentation>No debe usarse en libros a menos que estos vengan con embalaje externo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="42">
+				<xs:annotation>
+					<xs:documentation>UPC12 (específico de un elemento) en la parte inferior</xs:documentation>
+					<xs:documentation>También conocido como elemento/precio; no debe usarse en libros a menos que estos vengan con embalaje externo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="43">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (específico de un elemento) en la parte inferior</xs:documentation>
+					<xs:documentation>También conocido como elemento/precio; no debe usarse en libros a menos que estos vengan con embalaje externo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="44">
+				<xs:annotation>
+					<xs:documentation>UPC12 (precio de venta al público) en la parte inferior</xs:documentation>
+					<xs:documentation>También conocido como precio/elemento; no debe usarse en libros a menos que estos vengan con embalaje externo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="45">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (precio de venta al público) en la parte inferior</xs:documentation>
+					<xs:documentation>También conocido como precio/elemento; no debe usarse en libros a menos que estos vengan con embalaje externo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="46">
+				<xs:annotation>
+					<xs:documentation>EAN13 en la parte posterior</xs:documentation>
+					<xs:documentation>No debe usarse en libros a menos que estos vengan con embalaje externo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="47">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 en la parte posterior (precio codificado en dólares estadounidenses)</xs:documentation>
+					<xs:documentation>No debe usarse en libros a menos que estos vengan con embalaje externo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="48">
+				<xs:annotation>
+					<xs:documentation>UPC12 (específico de un elemento) en la parte posterior</xs:documentation>
+					<xs:documentation>También conocido como elemento/precio; no debe usarse en libros a menos que estos vengan con embalaje externo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="49">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (específico de un elemento) en la parte posterior</xs:documentation>
+					<xs:documentation>También conocido como elemento/precio; no debe usarse en libros a menos que estos vengan con embalaje externo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="50">
+				<xs:annotation>
+					<xs:documentation>UPC12 (precio de venta al público) en la parte posterior</xs:documentation>
+					<xs:documentation>También conocido como precio/elemento; no debe usarse en libros a menos que estos vengan con embalaje externo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="51">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (precio de venta al público) en la parte posterior</xs:documentation>
+					<xs:documentation>También conocido como precio/elemento; no debe usarse en libros a menos que estos vengan con embalaje externo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="52">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 en la funda externa/parte posterior (precio codificado en dólares estadounidenses)</xs:documentation>
+					<xs:documentation>Debe usarse solo en productos embalados en fundas externas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="53">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 en la funda externa/parte posterior</xs:documentation>
+					<xs:documentation>Debe usarse solo en productos embalados en fundas externas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="54">
+				<xs:annotation>
+					<xs:documentation>UPC12 (específico de un elemento) en la funda externa/parte posterior</xs:documentation>
+					<xs:documentation>También conocido como elemento/precio; debe usarse solo en productos embalados en fundas externas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="55">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (específico de un elemento) en la funda externa/parte posterior</xs:documentation>
+					<xs:documentation>También conocido como elemento/precio; debe usarse solo en productos embalados en fundas externas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="56">
+				<xs:annotation>
+					<xs:documentation>UPC12 (precio de venta al público) en la funda externa/parte posterior</xs:documentation>
+					<xs:documentation>También conocido como precio/elemento; debe usarse solo en productos embalados en fundas externas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="57">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (precio de venta al público) en la funda externa/parte posterior</xs:documentation>
+					<xs:documentation>También conocido como precio/elemento; debe usarse solo en productos embalados en fundas externas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="58">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 (sin precio codificado)</xs:documentation>
+					<xs:documentation>Cargo no especificado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="59">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 en la portada 4 (sin precio codificado)</xs:documentation>
+					<xs:documentation>La &quot;portada 4&quot; se define como la contraportada de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="60">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 en la portada 3 (sin precio codificado)</xs:documentation>
+					<xs:documentation>La &quot;portada 3&quot; se define como la contraportada interior de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="61">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 en la portada 2 (sin precio codificado)</xs:documentation>
+					<xs:documentation>La &quot;portada 2&quot; se define como la portada interior de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="62">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 en la caja (sin precio codificado)</xs:documentation>
+					<xs:documentation>Debe usarse solo en productos empaquetados.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="63">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 en la etiqueta (sin precio codificado)</xs:documentation>
+					<xs:documentation>Debe usarse solo en productos que cuenten con etiquetas colgantes.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="64">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 en la parte inferior (sin precio codificado)</xs:documentation>
+					<xs:documentation>No debe usarse en libros a menos que estos vengan con embalaje externo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="65">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 en la parte posterior (sin precio codificado)</xs:documentation>
+					<xs:documentation>No debe usarse en libros a menos que estos vengan con embalaje externo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="66">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 en la funda externa/parte posterior (sin precio codificado)</xs:documentation>
+					<xs:documentation>Debe usarse solo en productos embalados en fundas externas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="67">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 (precio codificado en dólares canadienses)</xs:documentation>
+					<xs:documentation>Cargo no especificado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="68">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 en la portada 4 (precio codificado en dólares canadienses)</xs:documentation>
+					<xs:documentation>La &quot;portada 4&quot; se define como la contraportada de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="69">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 en la portada 3 (precio codificado en dólares canadienses)</xs:documentation>
+					<xs:documentation>La &quot;portada 3&quot; se define como la contraportada interior de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="70">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 en la portada 2 (precio codificado en dólares canadienses)</xs:documentation>
+					<xs:documentation>La &quot;portada 2&quot; se define como la portada interior de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="71">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 en la caja (precio codificado en dólares canadienses)</xs:documentation>
+					<xs:documentation>Debe usarse solo en productos empaquetados.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="72">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 en la etiqueta (precio codificado en dólares canadienses)</xs:documentation>
+					<xs:documentation>Debe usarse solo en productos que cuenten con etiquetas colgantes.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="73">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 en la parte inferior (precio codificado en dólares canadienses)</xs:documentation>
+					<xs:documentation>No debe usarse en libros a menos que estos vengan con embalaje externo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="74">
+				<xs:annotation>
+					<xs:documentation>EAN13+5 en la parte posterior (precio codificado en dólares canadienses)</xs:documentation>
+					<xs:documentation>No debe usarse en libros a menos que estos vengan con embalaje externo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="75">
+				<xs:annotation>
+					<xs:documentation>EAN13 en la funda externa/parte posterior (precio codificado en dólares canadienses)</xs:documentation>
+					<xs:documentation>Debe usarse solo en productos embalados en fundas externas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List7">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 7">Código del formulario del producto</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Sin definir</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AA">
+				<xs:annotation>
+					<xs:documentation>Audio</xs:documentation>
+					<xs:documentation>Grabación de audio; detalle sin especificar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AB">
+				<xs:annotation>
+					<xs:documentation>Cinta de audio</xs:documentation>
+					<xs:documentation>Cinta de audio (analógica).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AC">
+				<xs:annotation>
+					<xs:documentation>CD de audio</xs:documentation>
+					<xs:documentation>CD de audio en cualquier formato: utilice la codificación que figura en el Detalle del formulario del producto para especificar el formato, si procede.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AD">
+				<xs:annotation>
+					<xs:documentation>DAT</xs:documentation>
+					<xs:documentation>Cinta de audio digital.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AE">
+				<xs:annotation>
+					<xs:documentation>Disco de audio</xs:documentation>
+					<xs:documentation>Disco de audio (sin incluir los CD).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AF">
+				<xs:annotation>
+					<xs:documentation>Cinta de audio</xs:documentation>
+					<xs:documentation>Cinta de audio (cinta de bobina abierta).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AG">
+				<xs:annotation>
+					<xs:documentation>MiniDisc</xs:documentation>
+					<xs:documentation>Formato MiniDisc de Sony.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AH">
+				<xs:annotation>
+					<xs:documentation>CD-Extra</xs:documentation>
+					<xs:documentation>CD de audio con una parte para contenido de CD-ROM.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AI">
+				<xs:annotation>
+					<xs:documentation>DVD Audio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AJ">
+				<xs:annotation>
+					<xs:documentation>Archivo de audio descargable</xs:documentation>
+					<xs:documentation>Grabación de audio descargable en línea.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AK">
+				<xs:annotation>
+					<xs:documentation>Reproductor de audio digital pregrabado</xs:documentation>
+					<xs:documentation>Por ejemplo, el reproductor y audiolibro Playaway: utilice la codificación que figura en el Detalle del formulario del producto para especificar el formato de grabación, si procede.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AL">
+				<xs:annotation>
+					<xs:documentation>Tarjeta SD pregrabada</xs:documentation>
+					<xs:documentation>Por ejemplo, un chip del audiolibro Audiofy.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AZ">
+				<xs:annotation>
+					<xs:documentation>Otro formato de audio</xs:documentation>
+					<xs:documentation>Otro formato de audio no especificado de AB a AL.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BA">
+				<xs:annotation>
+					<xs:documentation>Libro</xs:documentation>
+					<xs:documentation>Libro; detalle sin especificar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BB">
+				<xs:annotation>
+					<xs:documentation>Tapa dura</xs:documentation>
+					<xs:documentation>Libro de tapa dura o encuadernado en tapa suelta.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BC">
+				<xs:annotation>
+					<xs:documentation>En rústica/de tapa blanda</xs:documentation>
+					<xs:documentation>Libro en rústica u otro tipo de libro de tapa blanda.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BD">
+				<xs:annotation>
+					<xs:documentation>Hojas sueltas</xs:documentation>
+					<xs:documentation>Libro de hojas sueltas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BE">
+				<xs:annotation>
+					<xs:documentation>Encuadernación de espiral</xs:documentation>
+					<xs:documentation>Libro con encuadernación de espiral, con tornillos o en bobina.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BF">
+				<xs:annotation>
+					<xs:documentation>Panfleto</xs:documentation>
+					<xs:documentation>Panfleto o folleto, grapado; en alemán: &apos;geheftet&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BG">
+				<xs:annotation>
+					<xs:documentation>Encuadernación fina/de cuero</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BH">
+				<xs:annotation>
+					<xs:documentation>Libro de tapas de cartón</xs:documentation>
+					<xs:documentation>Libro infantil con todas las páginas impresas en cartón.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BI">
+				<xs:annotation>
+					<xs:documentation>Libro de tela</xs:documentation>
+					<xs:documentation>Libro infantil con todas las páginas impresas en tela.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BJ">
+				<xs:annotation>
+					<xs:documentation>Libro acuático</xs:documentation>
+					<xs:documentation>Libro infantil impreso en material impermeable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BK">
+				<xs:annotation>
+					<xs:documentation>Libro novedoso</xs:documentation>
+					<xs:documentation>Libro cuya novedad consiste total o parcialmente en un formato que no puede describirse mediante ningún otro código de los disponibles (se prefiere utilizar siempre un código de un formato &quot;convencional&quot;); siempre que sea posible se debería utilizar uno o más códigos de Detalle del formulario del producto, p. ej., del grupo B2nn, para proporcionar más información.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BL">
+				<xs:annotation>
+					<xs:documentation>Con diapositivas</xs:documentation>
+					<xs:documentation>Libro con diapositivas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BM">
+				<xs:annotation>
+					<xs:documentation>Libro grande</xs:documentation>
+					<xs:documentation>Formato extragrande para profesores, etc.; este formato y esta terminología pueden ser específicos del Reino Unido; necesario como diferenciador de máximo nivel.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BN">
+				<xs:annotation>
+					<xs:documentation>Trabajo parcial (fascículo)</xs:documentation>
+					<xs:documentation>Fascículo emitido con su propio ISBN y pensado para recopilarse y encuadernarse en un libro completo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BO">
+				<xs:annotation>
+					<xs:documentation>Gráfico o libro desplegable</xs:documentation>
+					<xs:documentation>Gráfico o libro con plegado de acordeón, diseñado para plegarlo hasta un tamaño de bolsillo o de una página normal: uso para el alemán &apos;Leporello&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BP">
+				<xs:annotation>
+					<xs:documentation>Libro de espuma</xs:documentation>
+					<xs:documentation>Libro infantil cuyas páginas y portada están hechas de espuma.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BZ">
+				<xs:annotation>
+					<xs:documentation>Otro formato de libro</xs:documentation>
+					<xs:documentation>Otro formato de libro o encuadernación no especificado de BB a BP.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA">
+				<xs:annotation>
+					<xs:documentation>Hoja cartográfica</xs:documentation>
+					<xs:documentation>Hoja cartográfica; detalle sin especificar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CB">
+				<xs:annotation>
+					<xs:documentation>Hoja cartográfica, plegada</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CC">
+				<xs:annotation>
+					<xs:documentation>Hoja cartográfica, aplanada</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CD">
+				<xs:annotation>
+					<xs:documentation>Hoja cartográfica, enrollada</xs:documentation>
+					<xs:documentation>Para &quot;enrollado en un tubo&quot; véase la lista de códigos 80.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CE">
+				<xs:annotation>
+					<xs:documentation>Globo</xs:documentation>
+					<xs:documentation>Globo o planisferio.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CZ">
+				<xs:annotation>
+					<xs:documentation>Otro cartográfico</xs:documentation>
+					<xs:documentation>Otro formato cartográfico no especificado de CB a CE.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DA">
+				<xs:annotation>
+					<xs:documentation>Digital</xs:documentation>
+					<xs:documentation>Digital o multimedia (detalle sin especificar).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DB">
+				<xs:annotation>
+					<xs:documentation>CD-ROM</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DC">
+				<xs:annotation>
+					<xs:documentation>CD-I</xs:documentation>
+					<xs:documentation>CD interactivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DD">
+				<xs:annotation>
+					<xs:documentation>DVD</xs:documentation>
+					<xs:documentation>OBSOLETO; utilizar VI para DVD de vídeo, AI para DVD de audio y DI para DVD-ROM.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DE">
+				<xs:annotation>
+					<xs:documentation>Cartucho de juego</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DF">
+				<xs:annotation>
+					<xs:documentation>Disquete</xs:documentation>
+					<xs:documentation>También conocido como &quot;disco flexible&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DG">
+				<xs:annotation>
+					<xs:documentation>Texto de libro electrónico</xs:documentation>
+					<xs:documentation>Texto de libro electrónico en formato estándar abierto o de propietario.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DH">
+				<xs:annotation>
+					<xs:documentation>Recurso en línea</xs:documentation>
+					<xs:documentation>Base de datos electrónica u otro recurso o servicio al que se puede acceder a través de redes en línea.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DI">
+				<xs:annotation>
+					<xs:documentation>DVD-ROM</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DJ">
+				<xs:annotation>
+					<xs:documentation>Tarjeta de memoria digital segura (SD)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DK">
+				<xs:annotation>
+					<xs:documentation>Tarjeta de memoria Flash compacta</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DL">
+				<xs:annotation>
+					<xs:documentation>Tarjeta de memoria</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DM">
+				<xs:annotation>
+					<xs:documentation>Memoria USB</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DN">
+				<xs:annotation>
+					<xs:documentation>CD/DVD de dos caras</xs:documentation>
+					<xs:documentation>Disco de dos caras, por una cara es CD/CD-ROM de audio y, por la otra, DVD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DZ">
+				<xs:annotation>
+					<xs:documentation>Otro medio digital</xs:documentation>
+					<xs:documentation>Otro medio digital o multimedia no especificado de DB a DN.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FA">
+				<xs:annotation>
+					<xs:documentation>Película o transparencia</xs:documentation>
+					<xs:documentation>Película o transparencia; detalle sin especificar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FB">
+				<xs:annotation>
+					<xs:documentation>Película</xs:documentation>
+					<xs:documentation>Película o tira de película continua: OBSOLETO; utilizar FE o FF.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FC">
+				<xs:annotation>
+					<xs:documentation>Diapositivas</xs:documentation>
+					<xs:documentation>Transparencias fotográficas montadas para la proyección.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FD">
+				<xs:annotation>
+					<xs:documentation>Transparencias para retroproyector</xs:documentation>
+					<xs:documentation>Transparencias para retroproyector.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FE">
+				<xs:annotation>
+					<xs:documentation>Tira de película</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FF">
+				<xs:annotation>
+					<xs:documentation>Película</xs:documentation>
+					<xs:documentation>Película continua frente a una tira de película.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FZ">
+				<xs:annotation>
+					<xs:documentation>Otro formato de película o transparencia</xs:documentation>
+					<xs:documentation>Otro formato de película o transparencia no especificado de FB a FF.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MA">
+				<xs:annotation>
+					<xs:documentation>Microforma</xs:documentation>
+					<xs:documentation>Microforma; detalle sin especificar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MB">
+				<xs:annotation>
+					<xs:documentation>Microficha</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MC">
+				<xs:annotation>
+					<xs:documentation>Microfilm</xs:documentation>
+					<xs:documentation>Microfilm en bobina.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MZ">
+				<xs:annotation>
+					<xs:documentation>Otra microforma</xs:documentation>
+					<xs:documentation>Otra microforma no especificada por MB o MC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PA">
+				<xs:annotation>
+					<xs:documentation>Impresiones variadas</xs:documentation>
+					<xs:documentation>Material impreso variado; detalle sin especificar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PB">
+				<xs:annotation>
+					<xs:documentation>Agenda de direcciones</xs:documentation>
+					<xs:documentation>Se pueden utilizar los códigos P201 a P204 del Detalle del formulario del producto para especificar la encuadernación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PC">
+				<xs:annotation>
+					<xs:documentation>Calendario</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PD">
+				<xs:annotation>
+					<xs:documentation>Tarjetas</xs:documentation>
+					<xs:documentation>Tarjetas, flash cards (p. ej., para enseñar a leer).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PE">
+				<xs:annotation>
+					<xs:documentation>Fichas fotocopiables</xs:documentation>
+					<xs:documentation>Fichas fotocopiables.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PF">
+				<xs:annotation>
+					<xs:documentation>Diario</xs:documentation>
+					<xs:documentation>Se pueden utilizar los códigos P201 a P204 del Detalle del formulario del producto para especificar la encuadernación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PG">
+				<xs:annotation>
+					<xs:documentation>Friso</xs:documentation>
+					<xs:documentation>Hoja impresa estrecha en forma de tira empleada sobre todo para la enseñanza o en productos infantiles (p. ej., un abecedario ilustrado, una línea de números, procesión de caracteres ilustrados, etc.). Normalmente pensado para una presentación horizontal.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PH">
+				<xs:annotation>
+					<xs:documentation>Kit</xs:documentation>
+					<xs:documentation>Piezas para un montaje posterior a la compra.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PI">
+				<xs:annotation>
+					<xs:documentation>Partituras</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PJ">
+				<xs:annotation>
+					<xs:documentation>Pack o libro de tarjetas postales</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PK">
+				<xs:annotation>
+					<xs:documentation>Póster</xs:documentation>
+					<xs:documentation>Póster para la venta; véase también XF.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PL">
+				<xs:annotation>
+					<xs:documentation>Libro de registro</xs:documentation>
+					<xs:documentation>Libro de registro (p. ej., &quot;álbum de cumpleaños&quot;, &quot;álbum de recién nacido&quot;): se pueden utilizar los códigos P201 a P204 del Detalle del formulario del producto para especificar la encuadernación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PM">
+				<xs:annotation>
+					<xs:documentation>Cartera o carpeta</xs:documentation>
+					<xs:documentation>Cartera o carpeta (que alberga hojas sueltas, etc.): es preferible codificar los contenidos y tratar &quot;cartera&quot; como un embalaje (lista 80), pero, de no ser posible, el producto en su conjunto se puede codificar como &quot;cartera&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PN">
+				<xs:annotation>
+					<xs:documentation>Imágenes o fotografías</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PO">
+				<xs:annotation>
+					<xs:documentation>Gráfico mural</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PP">
+				<xs:annotation>
+					<xs:documentation>Pegatinas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PQ">
+				<xs:annotation>
+					<xs:documentation>Lámina</xs:documentation>
+					<xs:documentation>Una hoja de tamaño libro (frente al tamaño póster), normalmente impresa en calidad alta o en color.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PR">
+				<xs:annotation>
+					<xs:documentation>Cuaderno/libro en blanco</xs:documentation>
+					<xs:documentation>Libro con todas las páginas en blanco para que el comprador les dé un uso propio: se pueden utilizar los códigos P201 a P204 del Detalle del formulario del producto para especificar la encuadernación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PS">
+				<xs:annotation>
+					<xs:documentation>Organizador</xs:documentation>
+					<xs:documentation>Se pueden utilizar los códigos P201 a P204 del Detalle del formulario del producto para especificar la encuadernación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PT">
+				<xs:annotation>
+					<xs:documentation>Marcador</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PZ">
+				<xs:annotation>
+					<xs:documentation>Otro elemento impreso</xs:documentation>
+					<xs:documentation>Otro elemento impreso no especificado de PB a PT.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VA">
+				<xs:annotation>
+					<xs:documentation>Vídeo</xs:documentation>
+					<xs:documentation>Vídeo; detalle sin especificar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VB">
+				<xs:annotation>
+					<xs:documentation>Vídeo, VHS, PAL</xs:documentation>
+					<xs:documentation>OBSOLETO; utilizar el nuevo VJ.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VC">
+				<xs:annotation>
+					<xs:documentation>Vídeo, VHS, NTSC</xs:documentation>
+					<xs:documentation>OBSOLETO; utilizar el nuevo VJ.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VD">
+				<xs:annotation>
+					<xs:documentation>Vídeo, Betamax, PAL</xs:documentation>
+					<xs:documentation>OBSOLETO; utilizar el nuevo VK.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VE">
+				<xs:annotation>
+					<xs:documentation>Vídeo, Betamax, NTSC</xs:documentation>
+					<xs:documentation>OBSOLETO; utilizar el nuevo VK.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VF">
+				<xs:annotation>
+					<xs:documentation>Videodisco</xs:documentation>
+					<xs:documentation>p. ej., Laserdisc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VG">
+				<xs:annotation>
+					<xs:documentation>Vídeo, VHS, SECAM</xs:documentation>
+					<xs:documentation>OBSOLETO; utilizar el nuevo VJ.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VH">
+				<xs:annotation>
+					<xs:documentation>Vídeo, Betamax, SECAM</xs:documentation>
+					<xs:documentation>OBSOLETO; utilizar el nuevo VK.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VI">
+				<xs:annotation>
+					<xs:documentation>DVD vídeo</xs:documentation>
+					<xs:documentation>DVD vídeo: especificar el estándar de TV en la lista 78.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VJ">
+				<xs:annotation>
+					<xs:documentation>VHS vídeo</xs:documentation>
+					<xs:documentation>Cinta VHS: especificar el estándar de TV en la lista 78.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VK">
+				<xs:annotation>
+					<xs:documentation>Vídeo Betamax</xs:documentation>
+					<xs:documentation>Cinta Betamax: especificar el estándar de TV en la lista 78.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VL">
+				<xs:annotation>
+					<xs:documentation>VCD</xs:documentation>
+					<xs:documentation>Vídeo CD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VM">
+				<xs:annotation>
+					<xs:documentation>SVCD</xs:documentation>
+					<xs:documentation>Super Video CD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VN">
+				<xs:annotation>
+					<xs:documentation>HD DVD</xs:documentation>
+					<xs:documentation>Disco DVD de alta definición, formato HD DVD de Toshiba.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VO">
+				<xs:annotation>
+					<xs:documentation>Blu-ray</xs:documentation>
+					<xs:documentation>Disco DVD de alta definición, formato Blu-ray de Sony.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VP">
+				<xs:annotation>
+					<xs:documentation>UMD Video</xs:documentation>
+					<xs:documentation>Universal Media Disc de Sony.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VZ">
+				<xs:annotation>
+					<xs:documentation>Otro formato de vídeo</xs:documentation>
+					<xs:documentation>Otro formato de vídeo no especificado de VB a VP.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WW">
+				<xs:annotation>
+					<xs:documentation>Producto de medios mixtos</xs:documentation>
+					<xs:documentation>Producto compuesto por dos o más elementos en medios distintos, p. ej., libro y CD-ROM, libro y juguete, etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WX">
+				<xs:annotation>
+					<xs:documentation>Pack de múltiples copias</xs:documentation>
+					<xs:documentation>Producto que contiene múltiples copias de uno o más elementos embalados juntos para la venta, y compuesto de a) varias copias de un mismo elemento (p. ej., 6 copias de una lectura graduada) o b) varias copias de cada uno de los distintos elementos (p. ej., 3 copias cada uno de 3 lecturas graduadas distintas) o c) varias copias de uno o más elementos individuales más una única copia de uno o más elementos relacionados (p. ej., 30 copias de un libro de texto de un alumno más 1 libro de texto del profesor). NO HAY QUE CONFUNDIRLO CON: conjuntos de múltiples volúmenes o conjuntos que contienen una única copia de varios elementos diferentes (que vengan en caja, estuche u otro); elementos con varios componentes o con formas físicas distintas (véase WW), o packs pensados solamente para su distribución, y cuyo contenido se vende por separado (véase XC, XE y XL).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XA">
+				<xs:annotation>
+					<xs:documentation>Material solo para venta</xs:documentation>
+					<xs:documentation>Material solo para venta (sin especificar).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XB">
+				<xs:annotation>
+					<xs:documentation>Cubeta; vacía</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XC">
+				<xs:annotation>
+					<xs:documentation>Cubeta; llena</xs:documentation>
+					<xs:documentation>Cubeta con contenidos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XD">
+				<xs:annotation>
+					<xs:documentation>Expositor de mesa; vacío</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XE">
+				<xs:annotation>
+					<xs:documentation>Expositor de mesa; lleno</xs:documentation>
+					<xs:documentation>Expositor de mesa con contenidos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XF">
+				<xs:annotation>
+					<xs:documentation>Póster, promocional</xs:documentation>
+					<xs:documentation>Póster promocional para exposición, no para venta; véase también PK.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XG">
+				<xs:annotation>
+					<xs:documentation>Cinta portaprecios</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XH">
+				<xs:annotation>
+					<xs:documentation>Pieza para ventana</xs:documentation>
+					<xs:documentation>Pieza promocional para exponer en escaparates.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XI">
+				<xs:annotation>
+					<xs:documentation>Banderín</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XJ">
+				<xs:annotation>
+					<xs:documentation>Exhibidor giratorio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XK">
+				<xs:annotation>
+					<xs:documentation>Presentación de un libro de gran tamaño</xs:documentation>
+					<xs:documentation>Facsímil a gran escala de un libro para su exposición promocional.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XL">
+				<xs:annotation>
+					<xs:documentation>Paquete con película de plástico</xs:documentation>
+					<xs:documentation>Paquete con varios artículos con su propio código de producto, para abastecimiento comercial solamente: los elementos de venta que contiene están destinados a la venta por separado; véase también WX. Para productos o paquetes de productos suministrados con película de plástico para la venta comercial, utilice el código del Formulario del producto de los contenidos más el código 21 de la lista 80.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XZ">
+				<xs:annotation>
+					<xs:documentation>Otro punto de venta</xs:documentation>
+					<xs:documentation>Otro material existente en el punto de venta no especificado de XB a XL.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZA">
+				<xs:annotation>
+					<xs:documentation>Mercancía general </xs:documentation>
+					<xs:documentation>Mercancía general; sin especificar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZB">
+				<xs:annotation>
+					<xs:documentation>Muñeca</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZC">
+				<xs:annotation>
+					<xs:documentation>Peluche</xs:documentation>
+					<xs:documentation>Muñeco de peluche.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZD">
+				<xs:annotation>
+					<xs:documentation>Juguete</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZE">
+				<xs:annotation>
+					<xs:documentation>Juego</xs:documentation>
+					<xs:documentation>Juego de mesa u otro juego (excepto juego de ordenador: véase DE).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZF">
+				<xs:annotation>
+					<xs:documentation>Camiseta</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZZ">
+				<xs:annotation>
+					<xs:documentation>Otros productos</xs:documentation>
+					<xs:documentation>Otros productos no especificados de ZB a ZF.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List8">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 8">Detalle en forma de libro</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Libro en rústica en formato A</xs:documentation>
+					<xs:documentation>OBSOLETO.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Libro en rústica en formato B</xs:documentation>
+					<xs:documentation>Libro en rústica en formato B: Reino Unido 198 x 129 mm; OBSOLETO.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Libro en rústica en formato C</xs:documentation>
+					<xs:documentation>Libro en rústica en formato C: Reino Unido 216 x 135 mm; OBSOLETO.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Papel sobre las tapas</xs:documentation>
+					<xs:documentation>OBSOLETO.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Tela</xs:documentation>
+					<xs:documentation>OBSOLETO.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Con sobrecubierta</xs:documentation>
+					<xs:documentation>OBSOLETO.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Encuadernación reforzada</xs:documentation>
+					<xs:documentation>OBSOLETO.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List9">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 9">Código de tipo de la clasificación del producto</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Sistema armonizado de la OMA</xs:documentation>
+					<xs:documentation>Sistema Armonizado de Designación y Codificación de Mercancías de la Organización Mundial de Aduanas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>UNSPSC</xs:documentation>
+					<xs:documentation>Catálogo de Productos y Servicios Estándar de las Naciones Unidas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>HMRC</xs:documentation>
+					<xs:documentation>Clasificaciones de la Agencia Tributaria y de Aduanas británica, basadas en el Sistema armonizado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Warenverzeichnis für die Außenhandelsstatistik</xs:documentation>
+					<xs:documentation>Clasificación del comercio de exportación de Alemania, basada en el Sistema armonizado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>TARIC</xs:documentation>
+					<xs:documentation>Códigos TARIC de la Unión Europea, una versión ampliada del Sistema armonizado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Fondsgroep</xs:documentation>
+					<xs:documentation>Campo de libre clasificación Centraal Boekhuis para las editoriales.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Categoría de producto del emisor</xs:documentation>
+					<xs:documentation>Categoría del producto (no una clasificación temática) asignada por el emisor.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Clase de producto de la GAPP</xs:documentation>
+					<xs:documentation>Clasificación de los productos mantenida por la Administración General de Prensa y Publicaciones de China (http://www.gapp.gov.cn).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>CPA</xs:documentation>
+					<xs:documentation>Clasificación estadística de productos por actividades en la Comunidad Económica Europea, véase http://ec.europa.eu/eurostat/ramon/nomenclatures/index.cfm?TargetUrl=LST_NOM_DTL&amp;StrNom=CPA_2008. Hasta seis dígitos, con uno o dos puntos. Por ejemplo, los libros infantiles impresos son &quot;58.11.13&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List10">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 10">Código de tipo de publicación electrónica</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="000">
+				<xs:annotation>
+					<xs:documentation>&quot;Paquete de contenidos&quot; de publicación electrónica</xs:documentation>
+					<xs:documentation>Publicación electrónica considerada como un paquete de contenido único que puede convertirse en uno de varios tipos distintos para su entrega al consumidor. Este código se emplea cuando en un registro &lt;Product> de ONIX se describe el paquete de contenidos y se enumeran dentro del registro las distintas formas en las que está disponible.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="001">
+				<xs:annotation>
+					<xs:documentation>HTML</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato HTML básico, sin proteger. NO utilizar para formatos basados en HTML que cuenten con protección DRM.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="002">
+				<xs:annotation>
+					<xs:documentation>PDF</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato PDF básico, sin proteger. NO utilizar para formatos basados en PDF que cuenten con protección DRM.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="003">
+				<xs:annotation>
+					<xs:documentation>PDF-Merchant</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato PDF, legible con el Acrobat Reader estándar y protegida por las funciones DRM de PDF-Merchant. (Este formato no es compatible con las aplicaciones nuevas).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="004">
+				<xs:annotation>
+					<xs:documentation>Adobe eBook Reader</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato PDF mejorado, que utiliza el EBX, DRM propietario de Adobe, legible con el programa Adobe eBook Reader (anteriormente conocido como Glassbook) en cualquier plataforma compatible.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="005">
+				<xs:annotation>
+					<xs:documentation>Microsoft Reader Nivel 1/Nivel 3</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato Microsoft.LIT no cifrado, legible con Microsoft Reader en cualquier nivel y en cualquier plataforma compatible. (El nivel 3 solo se diferencia del nivel 1 en que incluye el nombre del comprador original).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="006">
+				<xs:annotation>
+					<xs:documentation>Microsoft Reader Nivel 5</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato Microsoft.LIT, totalmente cifrada, legible con Microsoft Reader en Nivel 5 en cualquier plataforma compatible.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="007">
+				<xs:annotation>
+					<xs:documentation>NetLibrary</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato propietario basado en HTML u OEBF, legible únicamente mediante suscripción al servicio de NetLibrary.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="008">
+				<xs:annotation>
+					<xs:documentation>MetaText</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato propietario suministrada a través de un navegador de Internet, legible únicamente mediante suscripción al servicio MetaText (división educativa de NetLibrary).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="009">
+				<xs:annotation>
+					<xs:documentation>MightyWords</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato propietario basado en PDF, legible únicamente mediante suscripción al servicio MightyWords.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="010">
+				<xs:annotation>
+					<xs:documentation>eReader (tabién conocido como Palm Reader)</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato propietario basado en HTML, legible mediante software de lectura compatibles con dispositivos portátiles que utilicen los sistemas operativos OS Palm o Pocket PC/Windows CE.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="011">
+				<xs:annotation>
+					<xs:documentation>Softbook</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato propietario, legible mediante software de lectura específicos de la plataforma hardware Softbook. También puede leerse en el sucesor de Softbook, el Gemstar REB 1200.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="012">
+				<xs:annotation>
+					<xs:documentation>RocketBook</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato propietario .RB, legible mediante software de lectura específicos de la plataforma hardware RocketBook. También puede leerse en el sucesor de RocketBook, el Gemstar REB 1100.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="013">
+				<xs:annotation>
+					<xs:documentation>Gemstar REB 1100</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato propietario .RB, legible mediante software de lectura específicos de la plataforma hardware Gemstar REB 1100. También puede leerse en el RocketBook con alguna pérdida de funcionalidad.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="014">
+				<xs:annotation>
+					<xs:documentation>Gemstar REB 1200</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato propietario, legible mediante software de lectura específicos de la plataforma hardware Gemstar REB 1200. También puede leerse en el Softbook con alguna pérdida de funcionalidad.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="015">
+				<xs:annotation>
+					<xs:documentation>Franklin eBookman</xs:documentation>
+					<xs:documentation>Publicación electrónica en el formato propietario Franklin basado en HTML, legible mediante software de lectura específicos de la plataforma Franklin eBookman.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="016">
+				<xs:annotation>
+					<xs:documentation>Books24x7</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato propietario basado en XML, solo accesible en línea y por suscripción al servicio Books24x7.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="017">
+				<xs:annotation>
+					<xs:documentation>DigitalOwl</xs:documentation>
+					<xs:documentation>Publicación electrónica disponible a través del sistema propietario de empaquetado, distribución y DRM de DigitalOwl, suministrado en diferentes formatos para distintas plataformas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="018">
+				<xs:annotation>
+					<xs:documentation>Handheldmed</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato propietario basado en HTML, legible mediante el software de lectura Haldheldmed en los dispositivos de mano con los sistemas operativos Palm OS, Windows y EPOC/Psion, disponible únicamente mediante suscripción al servicio Handheldmed.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="019">
+				<xs:annotation>
+					<xs:documentation>WizeUp</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato propietario, disponible para su descarga mediante suscripción al servicio WizeUp.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="020">
+				<xs:annotation>
+					<xs:documentation>TK3</xs:documentation>
+					<xs:documentation>Publicación electrónica en el formato propietario TK3, legible únicamente con el software de lecturaTK3 Reader de Night Kitchen Inc., en plataformas compatibles.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="021">
+				<xs:annotation>
+					<xs:documentation>Litraweb</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato .RTF cifrado, legible únicamente mediante el software Litraweb Visor, y disponible únicamente en Litraweb.com.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="022">
+				<xs:annotation>
+					<xs:documentation>MobiPocket</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato propietario, legible mediante el software MobiPocket en dispositivos de mano con los sistemas operativos Palm OS, WindowsCE/Pocket, Franklin eBookman y EPOC32. Disponible únicamente a través del servicio MobiPocket. Incluye los formatos de Amazon Kindle hasta la versión 7 inclusive, pero es preferible utilizar el código 031 para la versión 7, y usar ese mismo código siempre para KF8.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="023">
+				<xs:annotation>
+					<xs:documentation>Open Ebook</xs:documentation>
+					<xs:documentation>Publicación electrónica en el formato estándar de distribución especificado en el formato Open Ebook Publication Structure (OEBPS), legible mediante todos los sistemas de lectura compatibles con OEBPS. Incluye el formato EPUB hasta la versión 2 inclusive, pero es preferible utilizar el código 029 para EPUB 2, y emplear ese mismo código siempre para EPUB 3.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="024">
+				<xs:annotation>
+					<xs:documentation>Town Compass DataViewer</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato propietario, legible mediante el software de lectura Town Compass DataViewer en un dispositivo de mano con sistema operativo Palm OS.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="025">
+				<xs:annotation>
+					<xs:documentation>TXT</xs:documentation>
+					<xs:documentation>Publicación en formato .TXT abierto, con codificación ASCII o UTF-8, como el utilizado, por ejemplo, en el proyecto Gutemberg.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="026">
+				<xs:annotation>
+					<xs:documentation>ExeBook</xs:documentation>
+					<xs:documentation>Publicación electrónica en un archivo autoejecutable que incluye su propio software de lectura y creada con el software propietario ExeBook Self-Publisher.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="027">
+				<xs:annotation>
+					<xs:documentation>Sony BBeB</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato propietario de Sony para su uso con los lectores LIBRIé y Sony Reader.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="028">
+				<xs:annotation>
+					<xs:documentation>VitalSource Bookshelf</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="029">
+				<xs:annotation>
+					<xs:documentation>EPUB</xs:documentation>
+					<xs:documentation>Publicación electrónica suministrada en el estándar OPS Container Format (Open Publication Structure) del IDPF (International Digital Publishing Forum). [En un principio este valor era denominado &quot;Adobe Digital Editions&quot;, que no es un formato de publicación electrónica, sino un lector compatible con los formatos PDF y EPUB (de IDPF). Dado que el formato PDF ya se contempla en el código 002, se decidió redefinir el código 029 para representar al formato EPUB, y se anunció a la listserv de ONIX en septiembre de 2009.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="030">
+				<xs:annotation>
+					<xs:documentation>MyiLibrary</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="031">
+				<xs:annotation>
+					<xs:documentation>Kindle</xs:documentation>
+					<xs:documentation>Formato de archivo propietario de Amazon derivado del formato Mobipocket, empleado para dispositivos Kindle y para el software de lectura Kindle.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="032">
+				<xs:annotation>
+					<xs:documentation>Google Edition</xs:documentation>
+					<xs:documentation>Publicación electrónica distribuida por Google en asociación con una editorial, que se puede leer en línea mediante un navegador o bien sin conexión en lectores de libros electrónicos específicos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="033">
+				<xs:annotation>
+					<xs:documentation>Vook</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato propietario que combina texto y vídeo y está disponible para su uso tanto en línea como en forma de aplicación descargable para un dispositivo móvil; véase www.vook.com.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="034">
+				<xs:annotation>
+					<xs:documentation>DXReader</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato propietario para su uso con el software DXReader.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="035">
+				<xs:annotation>
+					<xs:documentation>EBL</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato propietario del servicio Ebook Library.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="036">
+				<xs:annotation>
+					<xs:documentation>Ebrary</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato propietario del servicio Ebrary.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="037">
+				<xs:annotation>
+					<xs:documentation>iSilo</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato propietario para su uso con el software iSilo en distintas plataformas de hardware.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="038">
+				<xs:annotation>
+					<xs:documentation>Plucker</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato propietario para su uso con el software de lectura Plucker en dispositivos de mano Palm y en otros dispositivos de mano.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="039">
+				<xs:annotation>
+					<xs:documentation>VitalBook</xs:documentation>
+					<xs:documentation>Formato propietario del servicio VitalSource.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="040">
+				<xs:annotation>
+					<xs:documentation>Aplicación de lectura para iOS</xs:documentation>
+					<xs:documentation>Publicación electrónica empaquetada como aplicación para iOS (p. ej., el iPhone o el iPad de Apple) que contiene el contenido y el código ejecutable. El contenido se puede describir con &lt;ProductContentType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="041">
+				<xs:annotation>
+					<xs:documentation>Aplicación para Android</xs:documentation>
+					<xs:documentation>Publicación electrónica empaquetada como aplicación para Android (p. ej., un teléfono o una tableta con sistema Android) que contiene el contenido y el código ejecutable. El contenido se puede describir con &lt;ProductContentType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="042">
+				<xs:annotation>
+					<xs:documentation>Otras aplicaciones</xs:documentation>
+					<xs:documentation>Publicación electrónica empaquetada como aplicación. Los requisitos técnicos como el sistema operativo de destino o el dispositivo deben proporcionarse en &lt;EpubTypeNote>. El contenido se puede describir con &lt;ProductContentType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="043">
+				<xs:annotation>
+					<xs:documentation>XPS</xs:documentation>
+					<xs:documentation>Formato XML Paper Specification [extensión de archivo: .xps] para Blio (por ejemplo).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="044">
+				<xs:annotation>
+					<xs:documentation>iBook</xs:documentation>
+					<xs:documentation>Formato iBook de Apple (una extensión propietaria de EPUB), únicamente legible con dispositivos que cuenten con el sistema operativo iOS de Apple.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="045">
+				<xs:annotation>
+					<xs:documentation>ePIB</xs:documentation>
+					<xs:documentation>Formato propietario utilizado por Barnes and Noble, legible en dispositivos NOOK y con el software de lectura Nook.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="098">
+				<xs:annotation>
+					<xs:documentation>Formatos múltiples</xs:documentation>
+					<xs:documentation>Producto integrado por partes que tienen distintos formatos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="099">
+				<xs:annotation>
+					<xs:documentation>Sin especificar</xs:documentation>
+					<xs:documentation>Desconocido, o no se ha asignado aún un código para este formato.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List11">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 11">Código de formato de publicación electrónica</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>HTML</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>PDF</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Microsoft Reader</xs:documentation>
+					<xs:documentation>Formato de archivo &quot;.LIT&quot; utilizado por el software Microsoft Reader.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>RocketBook</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Formato de texto enriquecido (RTF)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Estándar de formato Open Ebook Publication Structure (OEBPS)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>XML</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>SGML</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>EXE</xs:documentation>
+					<xs:documentation>Formato de archivo &quot;.EXE&quot; utilizado cuando una publicación electrónica se distribuye como paquete autoejecutable que incluye los contenidos y el software.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>ASCII</xs:documentation>
+					<xs:documentation>Formato de archivo &quot;.TXT&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Formato MobiPocket</xs:documentation>
+					<xs:documentation>Archivo en formato propietario empleado para el software de lectura MobiPocket.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List12">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 12">Código de categoría comercial</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>UK open market edition</xs:documentation>
+					<xs:documentation>Edición de una editorial del Reino Unido para la venta únicamente en territorios en los que no existen derechos de exclusividad. Como es habitual, la información detallada relativa a los derechos debe figurar en PR.21 (ONIX 2.1) o P.21 (ONIX 3.0).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Edición de aeropuerto</xs:documentation>
+					<xs:documentation>En el Reino Unido, edición específica para venta en tiendas libres de impuestos en aeropuertos del Reino Unido, aunque puede estar disponible en otros territorios en los que no existan derechos de exclusividad. Como es habitual, la información detallada relativa a los derechos debe figurar en PR.21 (ONIX 2.1) o P.21 (ONIX 3.0).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Sonderausgabe</xs:documentation>
+					<xs:documentation>En Alemania, edición impresa especial más barata que la normal de tapa dura.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Libro de bolsillo en rústica</xs:documentation>
+					<xs:documentation>En países donde se reconoce como una categoría de negocio distinta, p.ej., en Francia &quot;livre de poche&quot;, en Alemania &quot;Taschenbuch&quot;, en Italia &quot;tascabile&quot;, y en España &quot;libro de bolsillo&quot;. </xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Edición internacional (EE.UU.)</xs:documentation>
+					<xs:documentation>Edición producida exclusivamente para la venta en los mercados de exportación designados.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Edición de audio de biblioteca</xs:documentation>
+					<xs:documentation>Producto de audio que se vende en embalaje duradero especial y con garantía de reemplazo durante un período de conservación determinado en cuanto a los casetes o CD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Edición de mercado abierto para EE.UU.</xs:documentation>
+					<xs:documentation>Edición de una editorial de EE.UU. que se vende únicamente en territorios sin derechos exclusivos. Como es habitual, la información detallada relativa a los derechos debe figurar en PR.21 (ONIX 2.1) o P.21 (ONIX 3.0).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Livre scolaire, déclaré par l&apos;éditeur</xs:documentation>
+					<xs:documentation>En Francia es una categoría de libros que tiene un estado legal particular, declarado por la editorial. </xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Livre scolaire (non spécifié)</xs:documentation>
+					<xs:documentation>En Francia es una categoría de libros que tiene un estatus legal particular, designado independientemente de la editorial.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Suplemento de periódico</xs:documentation>
+					<xs:documentation>Edición publicada para la venta exclusiva con un periódico o boletín.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Libro de texto por precio libre</xs:documentation>
+					<xs:documentation>En España es un libro de texto escolar por el cual no hay un precio de venta establecido o sugerido. Se suministra por la editorial bajo términos negociados individualmente con la librería.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Edición de difusión de noticias</xs:documentation>
+					<xs:documentation>Para ediciones que se venden exclusivamente en quioscos o puestos de periódicos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Libro de texto de EE.UU.</xs:documentation>
+					<xs:documentation>En EE.UU. y Canadá es un libro publicado principalmente para el uso de los escolares o universitarios como base para su estudio. Libros de texto publicados para los mercados de la escuela primaria y secundaria. Generalmente se adquieren por los distritos escolares para el uso de los alumnos. Los libros de texto publicados para el mercado de enseñanza superior generalmente se usan en clases determinadas por el profesor. Generalmente los libros de texto no se dirigen al público general, lo que los diferencia de los libros comerciales. Note que los libros comerciales adoptados para su uso en cursos no se consideran como libros de texto (aunque puede que ciertas ediciones educativas lo sean).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List13">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 13">Código de tipo de identificador de serie</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Propietario</xs:documentation>
+					<xs:documentation>Por ejemplo, la propia identificación de la serie de la editorial.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>ISSN (Número Internacional Normalizado de Publicaciones Seriadas)</xs:documentation>
+					<xs:documentation>Número Internacional Normalizado de Publicaciones Seriadas, sin guiones, 8 dígitos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Identificación de la serie de la Bibliografía Nacional Alemana</xs:documentation>
+					<xs:documentation>Mantenido por Deutsche Nationalbibliothek.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Identificación de la serie de Libros alemanes en formato impreso</xs:documentation>
+					<xs:documentation>Mantenido por VLB.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Identificación de la serie de Electre</xs:documentation>
+					<xs:documentation>Mantenido por Electre Information, Francia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Identificador de objeto digital (DOI)</xs:documentation>
+					<xs:documentation>Digital Object Identifier (Identificador de objeto digital) (conjunto de caracteres y longitud variable).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>ISBN-13</xs:documentation>
+					<xs:documentation>Uso exclusivo cuando la colección (series o conjunto) está disponible como un único producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Nombre de recurso uniforme</xs:documentation>
+					<xs:documentation>Nombre de recurso uniforme.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List14">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 14">Marcador de uso de mayúsculas en el texto</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Sin definir</xs:documentation>
+					<xs:documentation>Por defecto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Uso de la mayúscula inicial en la primera palabra</xs:documentation>
+					<xs:documentation>Uso de la mayúscula inicial en la primera palabra y a partir de ahí, sólo en los nombres propios, p.ej. &quot;La conquista de México&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Uso de la mayúscula inicial en cada palabra</xs:documentation>
+					<xs:documentation>Uso de la mayúscula en la primera palabra y, a partir de ahí, en todas las palabras importantes, p.ej. &quot;La Conquista de México&quot;. </xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Todo en mayúsculas</xs:documentation>
+					<xs:documentation>Por ejemplo, &quot;LA CONQUISTA DE MÉXICO&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List15">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 15">Código de tipo de título</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Sin definir</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Título distintivo (libro); Título de la portada (revista por entregas); Título del elemento (elemento de contenido de la revista por entregas o recurso revisado)</xs:documentation>
+					<xs:documentation>El texto completo del título distinto del elemento, sin abreviaciones o compendio. Para libros cuyo título no es distintivo, se puede tomar elementos del título o número de parte de una serie o colección para crear un título más distintivo. Cuando el elemento es una edición antológica que contiene dos o más obras del mismo autor/a, y no tiene algún título colectivo, se puede crear un título distintivo al concatenar los títulos individuales con la puntuación adecuada como, por ejemplo, &quot;Orgullo y prejuicio / Sentido y sensibilidad / La abadía de Northanger&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Título clave ISSN de la revista por entregas</xs:documentation>
+					<xs:documentation>Sólo revistas por entregas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Título en el idioma original</xs:documentation>
+					<xs:documentation>Cuando el sujeto del registro ONIX es un elemento traducido.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Acrónimo o siglas de título</xs:documentation>
+					<xs:documentation>Para revistas por entregas: un acrónimo o una sigla del tipo de título 01, p.ej. &quot;JAMA&quot;, &quot;JACM&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Título abreviado</xs:documentation>
+					<xs:documentation>Una forma abreviada del tipo de título 01.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Título en otro idioma</xs:documentation>
+					<xs:documentation>Una traducción del tipo de título 01 en otro idioma.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Título temático de edición de revista</xs:documentation>
+					<xs:documentation>Sólo para revistas por entregas: cuando una edición de revista se dedica expresamente a un tema específico.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Título anterior</xs:documentation>
+					<xs:documentation>Libros o revistas por entregas: cuando un elemento se publicó anteriormente con otro título.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Título de distribuidor</xs:documentation>
+					<xs:documentation>Para libros: el título que figura en el archivo de título del distribuidor del libro es frecuentemente incompleto, y puede incluir elementos que normalmente no forman parte del título.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Título alternativo en la portada</xs:documentation>
+					<xs:documentation>Un título alternativo que figura en la portada de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Título alternativo en la contraportada</xs:documentation>
+					<xs:documentation>Un título alternativo que figura en la contraportada de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Título expandido</xs:documentation>
+					<xs:documentation>Una forma expandida del título, p. ej, el título de un libro de texto escolar con grado y tipo y otros detalles añadidos para que el título tenga sentido ya que, de otra manera, constaría solamente de la materia curricular. Este tipo de título se necesita para los envíos a la Agencia del ISBN española.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List16">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 16">Código de tipo de identificador de trabajo</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Propietario</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>ISBN-10</xs:documentation>
+					<xs:documentation>ISBN de 10 caracteres de señal de trabajo, cuando éste es el único identificador de trabajo disponible - ahora EN DESUSO en ONIX para libros, excepto cuando se proporciona información histórica para la compatibilidad con sistemas antiguos. Debería usarse sólo cuando se trata de productos anteriores a 2007 - cuando fue sustituido por ISBN-13 - y nunca debe usarse como el ÚNICO identificador (debe acompañarse siempre por el GTIN-13 / ISBN-13 correcto de la señal de trabajo).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Identificador de objeto digital (DOI)</xs:documentation>
+					<xs:documentation>Digital Object Identifier (Identificador de objeto digital) (conjunto de caracteres y longitud variable).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>ISTC</xs:documentation>
+					<xs:documentation>International Standard Text Code (Código Estándar Internacional de Texto) (16 caracteres: numéricos o alfabéticos A-F, sin guiones).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>ISBN-13</xs:documentation>
+					<xs:documentation>ISBN de 13 caracteres de señal de trabajo, cuando éste es el único identificador de trabajo disponible.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>ISRC</xs:documentation>
+					<xs:documentation>International Standard Recording Code (Código Estándar Internacional de Grabación).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List17">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 17">Código de rol del colaborador</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="A01">
+				<xs:annotation>
+					<xs:documentation>Por autor/a</xs:documentation>
+					<xs:documentation>Autor/a de un trabajo textual.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A02">
+				<xs:annotation>
+					<xs:documentation>Con</xs:documentation>
+					<xs:documentation>Con o &quot;como se lo contó&quot;: autor/a &quot;anónimo&quot; de una obra literaria.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A03">
+				<xs:annotation>
+					<xs:documentation>Guión por</xs:documentation>
+					<xs:documentation>Escritor/a de guión (película o vídeo).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A04">
+				<xs:annotation>
+					<xs:documentation>Libreto por</xs:documentation>
+					<xs:documentation>Escritor/a de libreto (opera): véase también A31.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A05">
+				<xs:annotation>
+					<xs:documentation>Letra por</xs:documentation>
+					<xs:documentation>Autor/a de letras (canción): véase también A31.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A06">
+				<xs:annotation>
+					<xs:documentation>Por compositor/a</xs:documentation>
+					<xs:documentation>Compositor/a de música.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A07">
+				<xs:annotation>
+					<xs:documentation>Por artista</xs:documentation>
+					<xs:documentation>Artista visual designado como el creador principal, p. ej., en un libro con reproducciones de obras de arte.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A08">
+				<xs:annotation>
+					<xs:documentation>Por fotógrafo/a</xs:documentation>
+					<xs:documentation>Fotógrafo/a designado como el creador principal, p. ej., un libro de fotografías.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A09">
+				<xs:annotation>
+					<xs:documentation>Creado por</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A10">
+				<xs:annotation>
+					<xs:documentation>A partir de una idea de</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A11">
+				<xs:annotation>
+					<xs:documentation>Diseñado por</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A12">
+				<xs:annotation>
+					<xs:documentation>Ilustrado por</xs:documentation>
+					<xs:documentation>Artista designado como el creador de las ilustraciones de un texto, una novela gráfica o un cómic.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A13">
+				<xs:annotation>
+					<xs:documentation>Fotografías por</xs:documentation>
+					<xs:documentation>Fotógrafo/a designado como el creador principal de las fotografías que ilustran un texto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A14">
+				<xs:annotation>
+					<xs:documentation>Texto por</xs:documentation>
+					<xs:documentation>Autor/a de texto que acompaña obras de arte o fotografías que forman parte de una novela gráfica o un cómic.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A15">
+				<xs:annotation>
+					<xs:documentation>Prefacio por</xs:documentation>
+					<xs:documentation>Autor/a de prefacio.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A16">
+				<xs:annotation>
+					<xs:documentation>Prólogo por</xs:documentation>
+					<xs:documentation>Autor/a de prólogo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A17">
+				<xs:annotation>
+					<xs:documentation>Resumen por</xs:documentation>
+					<xs:documentation>Autor/a de resumen.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A18">
+				<xs:annotation>
+					<xs:documentation>Suplemento por</xs:documentation>
+					<xs:documentation>Autor/a de suplemento.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A19">
+				<xs:annotation>
+					<xs:documentation>Epílogo por</xs:documentation>
+					<xs:documentation>Autor/a de epílogo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A20">
+				<xs:annotation>
+					<xs:documentation>Notas por</xs:documentation>
+					<xs:documentation>Autor/a de notas o anotaciones: véase también A29.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A21">
+				<xs:annotation>
+					<xs:documentation>Comentarios por</xs:documentation>
+					<xs:documentation>Autor/a de comentarios en el texto principal.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A22">
+				<xs:annotation>
+					<xs:documentation>Epílogo por</xs:documentation>
+					<xs:documentation>Autor/a de epílogo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A23">
+				<xs:annotation>
+					<xs:documentation>Preámbulo por</xs:documentation>
+					<xs:documentation>Autor/a de preámbulo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A24">
+				<xs:annotation>
+					<xs:documentation>Introducción por</xs:documentation>
+					<xs:documentation>Autor/a de introducción: véase también A29.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A25">
+				<xs:annotation>
+					<xs:documentation>Notas a pie de página por</xs:documentation>
+					<xs:documentation>Autor/a o compilador/a de notas a pie de página.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A26">
+				<xs:annotation>
+					<xs:documentation>Memorias por</xs:documentation>
+					<xs:documentation>Autor/a de memorias que acompañan el texto principal.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A27">
+				<xs:annotation>
+					<xs:documentation>Ensayo por</xs:documentation>
+					<xs:documentation>Persona que realizó los ensayos relatados en el texto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A29">
+				<xs:annotation>
+					<xs:documentation>Introducción y notas por</xs:documentation>
+					<xs:documentation>Autor/a de introducción y notas: véase también A20 y A24.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A30">
+				<xs:annotation>
+					<xs:documentation>Software desarrollado por</xs:documentation>
+					<xs:documentation>Desarrollador/a de programas informáticos complementarios al texto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A31">
+				<xs:annotation>
+					<xs:documentation>Libro y letra por</xs:documentation>
+					<xs:documentation>Autor/a de contenido textual de un drama musical: véase también A04 y A05.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A32">
+				<xs:annotation>
+					<xs:documentation>Contribuciones por</xs:documentation>
+					<xs:documentation>Autor/a de contribuciones adicionales al texto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A33">
+				<xs:annotation>
+					<xs:documentation>Apéndice por</xs:documentation>
+					<xs:documentation>Autor/a de apéndice.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A34">
+				<xs:annotation>
+					<xs:documentation>Índice por</xs:documentation>
+					<xs:documentation>Compilador/a de índice.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A35">
+				<xs:annotation>
+					<xs:documentation>Dibujos por</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A36">
+				<xs:annotation>
+					<xs:documentation>Diseño de portada e ilustraciones por</xs:documentation>
+					<xs:documentation>Usar también para el/la artista de portada de una novela gráfica o un cómic si son diferentes.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A37">
+				<xs:annotation>
+					<xs:documentation>Trabajo preliminar por</xs:documentation>
+					<xs:documentation>Responsable por el trabajo preliminar en el cual está basada la obra.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A38">
+				<xs:annotation>
+					<xs:documentation>Autor/a original</xs:documentation>
+					<xs:documentation>Autor/a de la primera edición (generalmente de un trabajo estándar) que no es el autor/a de la edición actual.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A39">
+				<xs:annotation>
+					<xs:documentation>Mapas por</xs:documentation>
+					<xs:documentation>Mapas dibujados o aportados de otra manera por.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A40">
+				<xs:annotation>
+					<xs:documentation>Pintado o coloreado por</xs:documentation>
+					<xs:documentation>Cuando en una obra de arte se designaron personas distintas para hacer las ilustraciones y para colorear, p. ej., en una novela gráfica o un cómic, use A12 para &quot;dibujado por&quot; y A40 para &quot;coloreado por&quot;, respectivamente. </xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A41">
+				<xs:annotation>
+					<xs:documentation>Libros animados por</xs:documentation>
+					<xs:documentation>Diseñador/a de animaciones de un libro animado, que puede ser una persona distinta a la que hace las ilustraciones.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A42">
+				<xs:annotation>
+					<xs:documentation>Continuado por</xs:documentation>
+					<xs:documentation>Usar cuando el trabajo estándar se continúa por una persona distinta al autor/a original.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A43">
+				<xs:annotation>
+					<xs:documentation>Entrevistador</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A44">
+				<xs:annotation>
+					<xs:documentation>Entrevistado</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A99">
+				<xs:annotation>
+					<xs:documentation>Otro creador/a primario</xs:documentation>
+					<xs:documentation>Otro tipo de creador primario no especificado anteriormente.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B01">
+				<xs:annotation>
+					<xs:documentation>Editado por</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B02">
+				<xs:annotation>
+					<xs:documentation>Revisado por</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B03">
+				<xs:annotation>
+					<xs:documentation>Versión de</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B04">
+				<xs:annotation>
+					<xs:documentation>Resumido por</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B05">
+				<xs:annotation>
+					<xs:documentation>Adaptado por</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B06">
+				<xs:annotation>
+					<xs:documentation>Traducido por</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B07">
+				<xs:annotation>
+					<xs:documentation>Relatado por</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B08">
+				<xs:annotation>
+					<xs:documentation>Traducido con comentarios de</xs:documentation>
+					<xs:documentation>Este código es aplicable cuando el traductor/a proporcionó comentarios sobre problemas de traducción.  Si el traductor/a proporcionó también un comentario sobre el propio trabajo, se deben usar los códigos B06 y A21.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B09">
+				<xs:annotation>
+					<xs:documentation>Serie editada por</xs:documentation>
+					<xs:documentation>Nombre de editor/a de serie cuando el producto forma parte de una serie.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B10">
+				<xs:annotation>
+					<xs:documentation>Editado y traducido por</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B11">
+				<xs:annotation>
+					<xs:documentation>Editor/a jefe</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B12">
+				<xs:annotation>
+					<xs:documentation>Editor/a invitado</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B13">
+				<xs:annotation>
+					<xs:documentation>Coordinador de obra</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B14">
+				<xs:annotation>
+					<xs:documentation>Miembro del comité editorial</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B15">
+				<xs:annotation>
+					<xs:documentation>Coordinación editorial por</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B16">
+				<xs:annotation>
+					<xs:documentation>Director/a de edición</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B17">
+				<xs:annotation>
+					<xs:documentation>Fundado por</xs:documentation>
+					<xs:documentation>Generalmente es el editor/a fundador de una publicación de revista por entregas: Begruendet von.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B18">
+				<xs:annotation>
+					<xs:documentation>Listo para su publicación por</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B19">
+				<xs:annotation>
+					<xs:documentation>Editor/a asociado</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B20">
+				<xs:annotation>
+					<xs:documentation>Editor/a asesor</xs:documentation>
+					<xs:documentation>Usar también para &quot;editor/a consultor&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B21">
+				<xs:annotation>
+					<xs:documentation>Editor/a general</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B22">
+				<xs:annotation>
+					<xs:documentation>Dramatizado por</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B23">
+				<xs:annotation>
+					<xs:documentation>Relator/a general</xs:documentation>
+					<xs:documentation>En Europa es un editor/a experto que asume la responsabilidad del contenido legal de un trabajo legal colaborativo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B24">
+				<xs:annotation>
+					<xs:documentation>Editor/a literario</xs:documentation>
+					<xs:documentation>Un editor/a que es responsable de establecer el texto usado en una edición de trabajo literario donde esto se reconoce como un rol distinto (en España, &quot;editor/a literario&quot;). </xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B25">
+				<xs:annotation>
+					<xs:documentation>Arreglado por (música)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B26">
+				<xs:annotation>
+					<xs:documentation>Editor/a técnico</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B99">
+				<xs:annotation>
+					<xs:documentation>Otra adaptación por</xs:documentation>
+					<xs:documentation>Otro tipo de adaptación o edición no especificado anteriormente.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="C01">
+				<xs:annotation>
+					<xs:documentation>Recopilado por</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="C02">
+				<xs:annotation>
+					<xs:documentation>Seleccionado por</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="C99">
+				<xs:annotation>
+					<xs:documentation>Otra recopilación por</xs:documentation>
+					<xs:documentation>Otro tipo de recopilación no especificado anteriormente.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D01">
+				<xs:annotation>
+					<xs:documentation>Productor</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D02">
+				<xs:annotation>
+					<xs:documentation>Director</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D03">
+				<xs:annotation>
+					<xs:documentation>Director/a de orquesta</xs:documentation>
+					<xs:documentation>Director/a de una interpretación musical.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D99">
+				<xs:annotation>
+					<xs:documentation>Otra dirección por</xs:documentation>
+					<xs:documentation>Otro tipo de dirección no especificado anteriormente.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E01">
+				<xs:annotation>
+					<xs:documentation>Actor/actriz</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E02">
+				<xs:annotation>
+					<xs:documentation>Bailarín/a</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E03">
+				<xs:annotation>
+					<xs:documentation>Narrador/a</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E04">
+				<xs:annotation>
+					<xs:documentation>Comentador/a</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E05">
+				<xs:annotation>
+					<xs:documentation>Solista vocal</xs:documentation>
+					<xs:documentation>Cantante, etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E06">
+				<xs:annotation>
+					<xs:documentation>Solista instrumental</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E07">
+				<xs:annotation>
+					<xs:documentation>Leído por</xs:documentation>
+					<xs:documentation>Lector/a de texto grabado en un audiolibro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E08">
+				<xs:annotation>
+					<xs:documentation>Interpretado por (orquesta, banda, conjunto)</xs:documentation>
+					<xs:documentation>Nombre de un grupo musical que interpreta.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E09">
+				<xs:annotation>
+					<xs:documentation>Orador/a</xs:documentation>
+					<xs:documentation>De un discurso, una lección, etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E99">
+				<xs:annotation>
+					<xs:documentation>Interpretado por</xs:documentation>
+					<xs:documentation>Otro tipo de intérprete no especificado anteriormente. Usar en caso de una interpretación grabada que no se ajuste a ninguna de las categorías anteriores, p. ej., la interpretación de un comediante.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="F01">
+				<xs:annotation>
+					<xs:documentation>Dirigido/fotografiado por</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="F99">
+				<xs:annotation>
+					<xs:documentation>Otro tipo de registro por</xs:documentation>
+					<xs:documentation>Otro tipo de registro no especificado anteriormente.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Z01">
+				<xs:annotation>
+					<xs:documentation>Asistido por</xs:documentation>
+					<xs:documentation>Puede estar asociado con cualquier rol de colaborador/a y, por lo tanto, la disposición debe controlarse por la numeración de secuencia del contribuidor.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Z99">
+				<xs:annotation>
+					<xs:documentation>Otro</xs:documentation>
+					<xs:documentation>Otra responsabilidad creativa que no esté clasificada entre A y F.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List18">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 18">Tipo de nombre de persona u organización</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Sin especificar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Seudónimo</xs:documentation>
+					<xs:documentation>Puede usarse para atribuir un seudónimo conocido cuando el nombre principal es un nombre &quot;real&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Nombre controlado por una autoridad</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Nombre anterior</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Nombre &quot;real&quot;</xs:documentation>
+					<xs:documentation>Puede usarse para identificar un nombre real conocido cuando el nombre principal es un seudónimo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Forma transliterada del nombre principal</xs:documentation>
+					<xs:documentation>Usar sólo en &lt;AlternativeName> cuando el nombre principal no se especifica.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List19">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 19">Persona(s) sin nombre</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Desconocido</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Anónimo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>et al</xs:documentation>
+					<xs:documentation>Y otros: colaboradores/as adicionales no listados.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Varios autores/as</xs:documentation>
+					<xs:documentation>Cuando el producto es un conjunto de libros de varios autores/as.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Voz sintetizada - hombre</xs:documentation>
+					<xs:documentation>Usar con Rol de colaborador/a E07 &quot;leído por&quot;, para audiolibros para ciegos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Voz sintetizada - mujer</xs:documentation>
+					<xs:documentation>Usar con Rol de colaborador/a E07 &quot;leído por&quot;, para audiolibros para ciegos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Voz sintetizada - no especificada</xs:documentation>
+					<xs:documentation>Usar con Rol de colaborador/a E07 &quot;leído por&quot;, para audiolibros para ciegos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List20">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 20">Rol de conferencia</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="List21">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 21">Código de tipo de edición</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ABR">
+				<xs:annotation>
+					<xs:documentation>Resumido</xs:documentation>
+					<xs:documentation>El contenido se redujo: usar para resumido, reducido, conciso, condensado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ACT">
+				<xs:annotation>
+					<xs:documentation>Edición de actuación</xs:documentation>
+					<xs:documentation>Versión de una obra o un guión destinado a utilizarse por la personas directamente implicadas en una producción, la cual generalmente incluye también instrucciones de escenario completo además del texto del guión. </xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ADP">
+				<xs:annotation>
+					<xs:documentation>Adaptado</xs:documentation>
+					<xs:documentation>Se adaptó el contenido para servir a un objetivo o público distinto, o de un medio a otro: usar en dramatización, novelización, etc. Usar &lt;EditionStatement> para describir la naturaleza exacta de la adaptación. </xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ALT">
+				<xs:annotation>
+					<xs:documentation>Alternativo</xs:documentation>
+					<xs:documentation>No usar. Este código ahora está EN DESUSO, pero se mantiene en la lista por razones de compatibilidad &quot;hacia atrás&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ANN">
+				<xs:annotation>
+					<xs:documentation>Anotado</xs:documentation>
+					<xs:documentation>El contenido aumenta con la adición de notas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BLL">
+				<xs:annotation>
+					<xs:documentation>Edición bilingüe</xs:documentation>
+					<xs:documentation>Se deben especificar ambos idiomas en el grupo &quot;Idioma&quot;. Usar MML (Music Macro Language) para editar en más de dos idiomas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BRL">
+				<xs:annotation>
+					<xs:documentation>Braille</xs:documentation>
+					<xs:documentation>Edición en Braille.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CMB">
+				<xs:annotation>
+					<xs:documentation>Volumen combinado</xs:documentation>
+					<xs:documentation>Una edición en la cual dos o más obras publicadas separadamente se combinan en un único volumen, también conocida como edición &quot;antológica&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CRI">
+				<xs:annotation>
+					<xs:documentation>Crítico</xs:documentation>
+					<xs:documentation>El contenido incluye comentarios críticos sobre el texto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CSP">
+				<xs:annotation>
+					<xs:documentation>Colecciones de lectura añadida</xs:documentation>
+					<xs:documentation>El contenido fue elaborado para un curso específico.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DGO">
+				<xs:annotation>
+					<xs:documentation>Original digital</xs:documentation>
+					<xs:documentation>Un producto digital el cual no tiene y no se espera que tenga en el futuro un contraparte impreso.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ENH">
+				<xs:annotation>
+					<xs:documentation>Mejorado</xs:documentation>
+					<xs:documentation>Usar en publicaciones electrónicas que se mejoraron con contenido adicional como texto, discurso, otro tipo de audio, vídeo, contenido interactivo u otro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ENL">
+				<xs:annotation>
+					<xs:documentation>Ampliado</xs:documentation>
+					<xs:documentation>Se amplió o expandió el contenido en relación con una versión anterior.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EXP">
+				<xs:annotation>
+					<xs:documentation>Expurgado</xs:documentation>
+					<xs:documentation>Se eliminó el contenido &quot;ofensivo&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FAC">
+				<xs:annotation>
+					<xs:documentation>Facsímil</xs:documentation>
+					<xs:documentation>Reproducción exacta del contenido y del formato de una versión anterior.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FST">
+				<xs:annotation>
+					<xs:documentation>Festschrift</xs:documentation>
+					<xs:documentation>Una colección de escritos publicados en honor a una persona, institución o sociedad.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ILL">
+				<xs:annotation>
+					<xs:documentation>Ilustrado</xs:documentation>
+					<xs:documentation>El contenido incluye numerosas ilustraciones que no forman parte de otras ediciones.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LTE">
+				<xs:annotation>
+					<xs:documentation>Tipo grande o edición letra grande</xs:documentation>
+					<xs:documentation>Edición letra grande, tamaño de impresión de 14 a 19 puntos - véase también ULP.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MCP">
+				<xs:annotation>
+					<xs:documentation>Microimpresión</xs:documentation>
+					<xs:documentation>Una edición impresa en un tamaño de fuente tan pequeño que sólo se puede leer con lupa.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MDT">
+				<xs:annotation>
+					<xs:documentation>Producto licenciado o tie-in</xs:documentation>
+					<xs:documentation>Una edición publicada para coincidir con el lanzamiento de una película, programa de televisión o videojuego basado en el mismo trabajo. Usar &lt;EditionStatement> para describir la naturaleza exacta de la conexión.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MLL">
+				<xs:annotation>
+					<xs:documentation>Edición multilingüe</xs:documentation>
+					<xs:documentation>Se deben especificar todos los idiomas en el grupo &quot;Idioma&quot;. Usar BLL para una edición bilingüe.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NED">
+				<xs:annotation>
+					<xs:documentation>Nueva edición</xs:documentation>
+					<xs:documentation>Cuando no hay más información o no hay ningún tipo de código aplicable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NUM">
+				<xs:annotation>
+					<xs:documentation>Edición de copias numeradas</xs:documentation>
+					<xs:documentation>Una edición limitada en la cual cada copia tiene un número individual.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PRB">
+				<xs:annotation>
+					<xs:documentation>Edición reencuadernada</xs:documentation>
+					<xs:documentation>En EE.UU. es un libro que ya se encuadernó, generalmente en rústica, y que se encuaderna de nuevo con una tapada dura de gran calidad por un proveedor que no es la editorial original. Véase también los compuestos &lt;Publisher> y &lt;RelatedProduct> para consultar otros aspectos del tratamiento de ediciones reencuadernadas en ONIX.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="REV">
+				<xs:annotation>
+					<xs:documentation>Revisado</xs:documentation>
+					<xs:documentation>Contenido revisado de una edición anterior.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SCH">
+				<xs:annotation>
+					<xs:documentation>Edición escolar</xs:documentation>
+					<xs:documentation>Una edición especifica destinada a utilizarse en las escuelas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SMP">
+				<xs:annotation>
+					<xs:documentation>Edición en lenguaje sencillo</xs:documentation>
+					<xs:documentation>Una edición que usa lenguaje sencillo (en finés &quot;Selkokirja&quot;).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SPE">
+				<xs:annotation>
+					<xs:documentation>Edición especial</xs:documentation>
+					<xs:documentation>Usar para ediciones de aniversario, coleccionista, de lujo, de regalo, limitadas, numeradas y autografiadas. Usar &lt;EditionStatement> para describir la naturaleza exacta de la edición especial.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="STU">
+				<xs:annotation>
+					<xs:documentation>Edición de estudiante</xs:documentation>
+					<xs:documentation>Cuando un texto está disponible en la edición del estudiante y del profesor.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TCH">
+				<xs:annotation>
+					<xs:documentation>Edición de profesor</xs:documentation>
+					<xs:documentation>Cuando un texto está disponible en la edición del estudiante y del profesor. Usar también para las ediciones del instructor o guía.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="UBR">
+				<xs:annotation>
+					<xs:documentation>Sin resumir</xs:documentation>
+					<xs:documentation>Cuando un título se publicó también en una edición resumida. Usar también para audiolibros, independientemente de si existe también una versión de audio resumida.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ULP">
+				<xs:annotation>
+					<xs:documentation>Edición letra ultra grande</xs:documentation>
+					<xs:documentation>Para impresiones grandes de 20 puntos o más, y con tipos de letra diseñados para personas con discapacidad visual - véase también LTE.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="UXP">
+				<xs:annotation>
+					<xs:documentation>No expurgado</xs:documentation>
+					<xs:documentation>Contenido previamente considerado como &quot;ofensivo&quot; fue recuperado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VAR">
+				<xs:annotation>
+					<xs:documentation>Variorum</xs:documentation>
+					<xs:documentation>El contenido incluye notas de varios comentadores o incluye y compara distintas variantes de textos de la misma obra.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List22">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 22">Código de rol del idioma</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Idioma de texto</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Idioma original de un texto traducido</xs:documentation>
+					<xs:documentation>Cuando el texto en el idioma original NO forma parte del producto actual.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Idioma de resúmenes</xs:documentation>
+					<xs:documentation>Cuando es diferente del idioma de texto. Usado principalmente para revistas por entregas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Idioma de derechos</xs:documentation>
+					<xs:documentation>Idioma en el cual se aplican derechos específicos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Idioma sin derechos exclusivos</xs:documentation>
+					<xs:documentation>Idioma en el cual no se aplican derechos específicos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Idioma original en una edición multilingüe</xs:documentation>
+					<xs:documentation>Cuando el texto en el idioma original forma parte de una edición bilingüe o multilingüe.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Idioma traducido en una edición multilingüe</xs:documentation>
+					<xs:documentation>Cuando el texto en el idioma traducido forma parte de una edición bilingüe o multilingüe.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Idioma de pista de audio</xs:documentation>
+					<xs:documentation>Por ejemplo, en un DVD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Idioma de subtítulos</xs:documentation>
+					<xs:documentation>Por ejemplo, en un DVD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List23">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 23">Código de tipo de extensión</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Recuento de paginas del contenido principal</xs:documentation>
+					<xs:documentation>La página más alta en una única secuencia numerada de contenido principal, normalmente el número arábico más alto de página en un libro, o en libros sin números de página o (raramente) sin múltiples secuencias numeradas de contenido principal, el número total de páginas que posee el contenido principal del libro. Note que esto puede incluir páginas numeradas pero en blanco (p. ej., páginas insertadas para asegurarse que los capítulos empiezan por una página &quot;recto&quot;) y puede excluir páginas no numeradas (pero con contenido) como en los casos de páginas insertadas o ex libris. Éste o el número de páginas de contenido son los métodos preferidos de recuento de páginas usados en la mayoría de los libros dirigidos al lector/ageneral. Para libros con contenido significativo en las páginas iniciales o finales, incluya también el recuento de estas páginas, o el total de las páginas numeradas. Para libros con páginas insertadas (ex libris), incluya también el recuento total de las páginas insertadas no numeradas cuando sea posible.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Número de palabras</xs:documentation>
+					<xs:documentation>Número de palabras de lenguaje de texto natural.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Recuento de páginas iniciales</xs:documentation>
+					<xs:documentation>El número total de páginas numeradas (normalmente en números romanos) que precede al contenido principal del libro. Éste consiste generalmente en varias páginas de título e información de la impresión, tabla de contenidos, una introducción, prefacio, prólogo, etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Recuento de páginas finales</xs:documentation>
+					<xs:documentation>El número total de las páginas numeradas (normalmente en números romanos) que sucede al contenido principal del libro. Éste consiste generalmente en un epílogo, apéndices, notas finales, índice, etc. Excluye páginas en blanco (o de publicidad) que existen sólo para facilitar la impresión o el encuadernado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Número total de páginas</xs:documentation>
+					<xs:documentation>La suma de todas las páginas numeradas (en números romanos y arábicos). Note que esto puede incluir páginas numeradas pero en blanco (p. ej., páginas insertadas para asegurarse que los capítulos empiezan por una página &quot;recto&quot;) y puede excluir páginas no numeradas (pero con contenido) como en los casos de páginas insertadas o ex libris.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Recuento de páginas de producción</xs:documentation>
+					<xs:documentation>El número total de las páginas de un libro, incluso páginas no numeradas, iniciales, finales, etc. Éste incluye todas las páginas en blanco en la contraportada que no llevan ningún contenido y que existen sólo para facilitar la impresión o el encuadernado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Recuento absoluto de páginas</xs:documentation>
+					<xs:documentation>El número total de las páginas de un libro contando tanto la cubierta como la primera página. Este tipo de recuento de páginas debe usarse exclusivamente en publicaciones digitales con paginación fija.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Número de páginas de contraparte impreso</xs:documentation>
+					<xs:documentation>Éste es el número total de páginas (equivalente al recuento de páginas de contenido) del contraparte impreso de un producto digital sin paginación fija.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Duración</xs:documentation>
+					<xs:documentation>Duración en tiempo, expresada en la unidad de extensión especificada.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Número teórico de páginas de un producto digital</xs:documentation>
+					<xs:documentation>Una estimación del número de &quot;páginas&quot; en un producto digital sin paginación fija, y sin contraparte impreso, como indicación del tamaño de la obra. Equivalente al código 08, pero exclusivo para productos digitales.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Recuento de páginas de contenido</xs:documentation>
+					<xs:documentation>La suma de todas las páginas numeradas (en números románicos y arábicos) y las páginas sin numeración con contenido significativo. La suma de los recuentos de página con los códigos 00, 03, 04 y 12, así como la suma de 05 y 12.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Recuento total de páginas insertadas no numeradas</xs:documentation>
+					<xs:documentation>El número total de páginas no numeradas con contenido insertadas dentro del contenido principal del libro - como por ejemplo las páginas insertadas o ex libris no numeradas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Tamaño de archivo</xs:documentation>
+					<xs:documentation>El tamaño de un archivo digital, expresado en la unidad de extensión especifica.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List24">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 24">Código de unidad de extensión</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Palabras</xs:documentation>
+					<xs:documentation>Palabras de lenguaje de texto natural.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Páginas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Horas (enteros y decimales)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Minutos (enteros y decimales)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Segundos (sólo enteros)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Horas HHH</xs:documentation>
+					<xs:documentation>Rellenar con ceros a la izquierda si falta algún elemento.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Horas y minutos HHHMM</xs:documentation>
+					<xs:documentation>Rellenar con ceros a la izquierda si falta algún elemento.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Horas minutos segundos HHHMMSS</xs:documentation>
+					<xs:documentation>Rellenar con ceros a la izquierda si falta algún elemento.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Bytes</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Kbytes</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Mbytes</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List25">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 25">Código de tipo de ilustración y otro contenido</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>No especificado, véase descripción</xs:documentation>
+					<xs:documentation>Véase descripción en el elemento &lt;IllustrationTypeDescription>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Ilustraciones, blanco y negro</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Ilustraciones, color</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Medios tonos, blanco y negro</xs:documentation>
+					<xs:documentation>Incluyendo fotografías en blanco y negro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Medios tonos, color</xs:documentation>
+					<xs:documentation>Incluso fotografías en color.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Dibujos lineales, blanco y negro</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Dibujos lineales, color</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Tablas, blanco y negro</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Tablas, color</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Ilustraciones sin especificar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Semitonos sin especificar</xs:documentation>
+					<xs:documentation>Incluye fotografías.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Tablas sin especificar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Dibujos a línea sin especificar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Semitonos, duotono</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Mapas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Frontispicio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Diagramas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Figuras</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Gráficos</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Elementos de música grabada</xs:documentation>
+					<xs:documentation>Ejemplos o extractos de música grabada, o bien obras completas que acompañan a texto u otros contenidos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Elementos de música impresa</xs:documentation>
+					<xs:documentation>Ejemplos o extractos de música impresa, o bien partituras completas que acompañan a texto u otros contenidos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>Gráficos cartesianos</xs:documentation>
+					<xs:documentation>Usar en el sentido matemático de diagramas que representan valores numéricos trazados con referencia al origen y ejes cartesianos (vea códigos 16 y 18).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Láminas, no especificadas</xs:documentation>
+					<xs:documentation>&quot;Láminas&quot; se refiere a ilustraciones realizadas en páginas separadas encuadernadas al cuerpo del libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Láminas en blanco y negro</xs:documentation>
+					<xs:documentation>&quot;Láminas&quot; se refiere a ilustraciones realizadas en páginas separadas encuadernadas al cuerpo del libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Láminas en color</xs:documentation>
+					<xs:documentation>&quot;Láminas&quot; se refiere a ilustraciones realizadas en páginas separadas encuadernadas al cuerpo del libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Índice</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Bibliografía</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>Mapas de detalle</xs:documentation>
+					<xs:documentation>Mapas de detalle a gran escala que representan lugares o elementos de interés incluidos en un producto cartográfico.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>Cuadrículas de GPS</xs:documentation>
+					<xs:documentation>Cuadrículas de GPS incluidas en un producto cartográfico.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List26">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 26">Código identificador de la materia principal</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Dewey</xs:documentation>
+					<xs:documentation>Sistema de Clasificación Decimal Dewey.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Dewey abreviado</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Clasificación LC</xs:documentation>
+					<xs:documentation>Clasificación de la US Library of Congress.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Encabezamiento de materia de la LC</xs:documentation>
+					<xs:documentation>Encabezamiento de materia de la US Library of Congress.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Clasificación NLM</xs:documentation>
+					<xs:documentation>Clasificación médica de la US National Library of Medicine.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>MeSH (encabezamiento de materia médica)</xs:documentation>
+					<xs:documentation>Encabezamiento de materia médica de la US National Library of Medicine.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Encabezamiento de materia de la NAL</xs:documentation>
+					<xs:documentation>Encabezamiento de materia de la US National Agricultural Library.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>AAT</xs:documentation>
+					<xs:documentation>Encabezamiento del Tesauro de Arte y Arquitectura del Getty Research Institute.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>CDU</xs:documentation>
+					<xs:documentation>Clasificación Decimal Universal.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Encabezamiento de materia BISAC</xs:documentation>
+					<xs:documentation>Los encabezamientos de materia de BISAC (Book Industry Standards and Communications) se usan en el mercado norteamericano para clasificar libros según el tema. Sirven de directrices para ordenar libros en tiendas físicas y para examinar librerías en línea. Consulte http://www.bisg.org/what-we-do-cat-20-classification-schemes.php.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Código regional BISAC</xs:documentation>
+					<xs:documentation>Un calificador geográfico utilizado con la categoría de materias BISAC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Categoría de materias BIC</xs:documentation>
+					<xs:documentation>Para consultar todos los códigos y calificadores de materia, vea http://www.bic.org.uk/7/BIC-Standard-Subject-Categories/.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Calificador geográfico BIC</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Calificador de idioma BIC</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Calificador cronológico BIC</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Calificador de objetivo escolar BIC</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Calificador de nivel de lectura e interés especial BIC</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>DDC-Sachgruppen der Deutschen Nationalbibliografie</xs:documentation>
+					<xs:documentation>Usado por la Bibliografía Nacional Alemana desde 2004 (100 materias). Es distinto del valor 30. Consulte http://www.d-nb.de/service/pdf/ddc_wv_aktuell.pdf (en alemán) o http://www.d-nb.de/eng/service/pdf/ddc_wv_aktuell_eng.pdf (en inglés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Encabezamiento del género ficción de la LC</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Palabras clave</xs:documentation>
+					<xs:documentation>Cuando se envían múltiples palabras clave o frases de palabra clave en una única instancia del elemento &lt;SubjectHeadingText>, es recomendable separarlas por punto y coma (en consonancia con la práctica recomendada por la US Library of Congress).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>Categoría comercial BIC para literatura infantil</xs:documentation>
+					<xs:documentation>Consulte http://www.bic.org.uk/8/Children&apos;s-Books-Marketing-Classifications/.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Tema para la comercialización BISAC</xs:documentation>
+					<xs:documentation>Los temas para la comercialización BISAC se utilizan junto con los encabezamientos de materia BISAC para indicar un tipo de público para el cual una obra puede ser de especial interés, una época del año o un acontecimiento para los que un libro puede ser especialmente relevante, o para describir más detalladamente obras de ficción que llevan una codificación de materia por género.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Código de categoría propio de la editorial</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Sistema propio de clasificación por materias</xs:documentation>
+					<xs:documentation>Especificado en &lt;SubjectSchemeName>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Tabla de materias ISBN</xs:documentation>
+					<xs:documentation>América Latina.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Warengruppen-Systematik des deutschen Buchhandels</xs:documentation>
+					<xs:documentation>Consulte http://www.boersenverein.de/sixcms/media.php/976/WGSneuVersion2_0.pdf.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>SWD</xs:documentation>
+					<xs:documentation>Schlagwortnormdatei - El registro de autoridad de encabezamientos de materia en los países de habla alemana. Consulte http://www.d-nb.de/standardisierung/normdateien/swd.htm (en alemán) y http://www.d-nb.de/eng/standardisierung/normdateien/swd.htm (en inglés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>Thèmes Electre</xs:documentation>
+					<xs:documentation>Clasificación por materias usado por Electre (Francia).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="29">
+				<xs:annotation>
+					<xs:documentation>CLIL</xs:documentation>
+					<xs:documentation>Francia, consulte Apéndice en http://www.clil.org/information/telechargementDoc.html?action=ouvrir&amp;id=313 (en francés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>DNB-Sachgruppen</xs:documentation>
+					<xs:documentation>Clasificación de materias de la Deutsche Bibliothek. Usado por la Bibliografía Nacional Alemana hasta 2003 (65 materias). Es distinto del valor 18. Consulte http://www.d-nb.de/service/pdf/ddc_wv_alt_neu.pdf.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>NUGI</xs:documentation>
+					<xs:documentation>Nederlandse Uniforme Genre-Indeling (antiguo sistema de clasificación del sector del libro en Holanda).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>NUR</xs:documentation>
+					<xs:documentation>Nederlandstalige Uniforme Rubrieksindeling (sistema de clasificación del sector del libro en Holanda desde 2002), consulte http://reeks.boekwinkeltjes.nl/downloads/NUR-lijst.pdf (en holandés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>ECPA Christian Book Category</xs:documentation>
+					<xs:documentation>Codificación de libros cristianos ECPA. Consiste en hasta tres bloques de tres letras (Categoría Superior, Categoría Primaria y Subcategoría). Consulte http://www.ecpa.org/ECPA/cbacategories.xls.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>SISO</xs:documentation>
+					<xs:documentation>Schema Indeling Systematische Catalogus Openbare Bibliotheken (sistema de clasificación de las bibliotecas holandesas).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="35">
+				<xs:annotation>
+					<xs:documentation>Clasificación Decimal Coreana (KDC)</xs:documentation>
+					<xs:documentation>Sistema de Clasificación Decimal Dewey modificado, utilizado en Corea del Sur.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="36">
+				<xs:annotation>
+					<xs:documentation>DDC Deutsch 22</xs:documentation>
+					<xs:documentation>Traducción alemana del Sistema de Clasificación Decimal Dewey 22. También conocido como DDC 22 ger. Consulte http://www.ddc-deutsch.de/produkte/uebersichten/.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="37">
+				<xs:annotation>
+					<xs:documentation>Bokgrupper</xs:documentation>
+					<xs:documentation>Categorías de productos del sector del libro en Noruega (4701).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="38">
+				<xs:annotation>
+					<xs:documentation>Varegrupper</xs:documentation>
+					<xs:documentation>Categorías de materias en la venta de libros en Noruega (4702).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="39">
+				<xs:annotation>
+					<xs:documentation>Læreplaner</xs:documentation>
+					<xs:documentation>Versión del currículo escolar noruego (4703).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="40">
+				<xs:annotation>
+					<xs:documentation>Clasificación Decimal Nipona</xs:documentation>
+					<xs:documentation>Sistema japonés de clasificación por materias.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="41">
+				<xs:annotation>
+					<xs:documentation>BSQ</xs:documentation>
+					<xs:documentation>BookSelling Qualifier: clasificación del sector del libro en Rusia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="42">
+				<xs:annotation>
+					<xs:documentation>ANELE Materias</xs:documentation>
+					<xs:documentation>España: sistema de codificación de materias de la Asociación Nacional de Editores de Libros y Material de Enseñanza.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="43">
+				<xs:annotation>
+					<xs:documentation>Skolefag</xs:documentation>
+					<xs:documentation>Categorías de materias escolares en la educación primaria y secundaria en Noruega (4705).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="44">
+				<xs:annotation>
+					<xs:documentation>Videregående</xs:documentation>
+					<xs:documentation>Categorías de materias de la educación secundaria postobligatoria y formación profesional en Noruega (4706).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="45">
+				<xs:annotation>
+					<xs:documentation>Undervisningsmateriell</xs:documentation>
+					<xs:documentation>Lista de categorías para libros y otro material didáctico usado en Noruega (4707).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="46">
+				<xs:annotation>
+					<xs:documentation>Norsk DDK</xs:documentation>
+					<xs:documentation>La versión noruega del Sistema de Clasificación Decimal Dewey.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="47">
+				<xs:annotation>
+					<xs:documentation>Varugrupper</xs:documentation>
+					<xs:documentation>Categorías de materias en la venta de libros en Suecia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="48">
+				<xs:annotation>
+					<xs:documentation>SAB</xs:documentation>
+					<xs:documentation>Sistema de clasificación sueco.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="49">
+				<xs:annotation>
+					<xs:documentation>Läromedel</xs:documentation>
+					<xs:documentation>Categorías en la venta de libros de materia educativa en Suecia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="50">
+				<xs:annotation>
+					<xs:documentation>Förhandsbeskrivning</xs:documentation>
+					<xs:documentation>Clasificación por materias preliminar de las editoriales suecas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="51">
+				<xs:annotation>
+					<xs:documentation>Subcategoría de UDC del ISBN español</xs:documentation>
+					<xs:documentation>Subconjunto controlado de códigos UDC usado por la Agencia Española del ISBN.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="52">
+				<xs:annotation>
+					<xs:documentation>Categorías de materias ECI</xs:documentation>
+					<xs:documentation>Categorías de materias definidas por El Corte Inglés y ampliamente usadas en el sector del libro español.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="53">
+				<xs:annotation>
+					<xs:documentation>Soggetto CCE</xs:documentation>
+					<xs:documentation>Classificazione Commerciale Editoriale (categoría de materias del sector del libro italiano basada en BIC).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="54">
+				<xs:annotation>
+					<xs:documentation>Qualificatore geografico CCE</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="55">
+				<xs:annotation>
+					<xs:documentation>Qualificatore di lingua CCE</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="56">
+				<xs:annotation>
+					<xs:documentation>Qualificatore di periodo storico CCE</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="57">
+				<xs:annotation>
+					<xs:documentation>Qualificatore di livello scolastico CCE</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="58">
+				<xs:annotation>
+					<xs:documentation>Qualificatore di età di lettura CCE</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="59">
+				<xs:annotation>
+					<xs:documentation>VdS Bildungsmedien Fächer</xs:documentation>
+					<xs:documentation>Listado de códigos de materias de la asociación alemana de las editoriales de materiales educativos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="60">
+				<xs:annotation>
+					<xs:documentation>Fagkoder</xs:documentation>
+					<xs:documentation>Undervisningsdirektoratets fagkoder for kunnskapsløftet I videregående (currículo de la enseñanza secundaria en Noruega) (4708).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="61">
+				<xs:annotation>
+					<xs:documentation>Clasificación JEL</xs:documentation>
+					<xs:documentation>Sistema de clasificación del Journal of Economic Literature.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="62">
+				<xs:annotation>
+					<xs:documentation>CSH</xs:documentation>
+					<xs:documentation>Encabezamientos de materia de la National Library of Canada (en inglés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="63">
+				<xs:annotation>
+					<xs:documentation>RVM</xs:documentation>
+					<xs:documentation>Répertoire de vedettes-matière (Bibliothèque et Archives Canada et Bibliothèque de l&apos;Université Laval) (en francés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="64">
+				<xs:annotation>
+					<xs:documentation>YSA</xs:documentation>
+					<xs:documentation>Yleinen suomalainen asiasanasto: Tesauro General Finlandés. Consulte http://onki.fi/fi/browser/ (en finlandés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="65">
+				<xs:annotation>
+					<xs:documentation>Allärs</xs:documentation>
+					<xs:documentation>Allmän tesaurus på svenska: traducción sueca del Tesauro General Finlandés. Consulte http://onki.fi/fi/browser/ (en finlandés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="66">
+				<xs:annotation>
+					<xs:documentation>YKL</xs:documentation>
+					<xs:documentation>Yleisten kirjastojen luokitusjärjestelmä: Sistema de Clasificación de las Bibliotecas Públicas de Finlandia. Consulte http://ykl.kirjastot.fi/ (en finlandés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="67">
+				<xs:annotation>
+					<xs:documentation>MUSA</xs:documentation>
+					<xs:documentation>Musiikin asiasanasto: Tesauro Musical Finlandés. Consulte http://onki.fi/fi/browser/ (en finlandés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="68">
+				<xs:annotation>
+					<xs:documentation>CILLA</xs:documentation>
+					<xs:documentation>Specialtesaurus för musik: traducción sueca del Tesauro Musical Finlandés. Consulte http://onki.fi/fi/browser/ (en finlandés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="69">
+				<xs:annotation>
+					<xs:documentation>Kaunokki</xs:documentation>
+					<xs:documentation>Fiktiivisen aineiston asiasanasto: Tesauro Finlandés para ficción. Consulte http://kaunokki.kirjastot.fi/ (en finlandés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="70">
+				<xs:annotation>
+					<xs:documentation>Bella</xs:documentation>
+					<xs:documentation>Specialtesaurus för fiktivt material: traducción sueca del Tesauro Finlandés de Ficción. Consulte http://kaunokki.kirjastot.fi/sv-FI/ (en finlandés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="71">
+				<xs:annotation>
+					<xs:documentation>YSO</xs:documentation>
+					<xs:documentation>Yleinen suomalainen ontologia: Ontología Fundamental Finlandesa. Consulte http://onki.fi/fi/browser/ (en finlandés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="72">
+				<xs:annotation>
+					<xs:documentation>Paikkatieto ontologia</xs:documentation>
+					<xs:documentation>Ontología de los Lugares Finlandesa. Consulte http://onki.fi/fi/browser/ (en finlandés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="73">
+				<xs:annotation>
+					<xs:documentation>Suomalainen kirja-alan luokitus</xs:documentation>
+					<xs:documentation>Clasificación del sector del libro finlandés.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="74">
+				<xs:annotation>
+					<xs:documentation>Sears</xs:documentation>
+					<xs:documentation>Encabezamientos de materia de Sears.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="75">
+				<xs:annotation>
+					<xs:documentation>BIC E4L</xs:documentation>
+					<xs:documentation>BIC E4Libraries Category Headings (encabezamientos de categorías), consulte http://www.bic.org.uk/51/E4libraries-Subject-Category-Headings/.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="76">
+				<xs:annotation>
+					<xs:documentation>CSR</xs:documentation>
+					<xs:documentation>Code Sujet Rayon: clasificación por materias usado por las librerías en Francia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="77">
+				<xs:annotation>
+					<xs:documentation>Suomalainen oppiaineluokitus</xs:documentation>
+					<xs:documentation>Clasificación de materias escolares usada en Finlandia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="78">
+				<xs:annotation>
+					<xs:documentation>Código C del sector del libro en Japón</xs:documentation>
+					<xs:documentation>Consulte http://www.asahi-net.or.jp/~ax2s-kmtn/ref/ccode.html (en japonés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="79">
+				<xs:annotation>
+					<xs:documentation>Código de género literario del sector del libro en Japón</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="80">
+				<xs:annotation>
+					<xs:documentation>Fiktiivisen aineiston lisäluokitus</xs:documentation>
+					<xs:documentation>Clasificación finlandesa del género ficción. Consulte http://ykl.kirjastot.fi/fi-FI/lisaluokat/ (en finlandés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="85">
+				<xs:annotation>
+					<xs:documentation>Código postal</xs:documentation>
+					<xs:documentation>Ubicación definida por código postal. El formato es: código de país de dos letras (de la Lista 91), espacio, código postal. Observe que algunos códigos postales de por sí contienen espacios, p.ej. &quot;GB N7 9DP&quot; o &quot;US 10125&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="86">
+				<xs:annotation>
+					<xs:documentation>GeoNames ID</xs:documentation>
+					<xs:documentation>Número de identificación de lugares geográficos, definido en http://www.geonames.org (p.ej. 2825297 es Stuttgart, Alemania; consulte http://www.geonames.org/2825297).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="87">
+				<xs:annotation>
+					<xs:documentation>Clasificación por materias NewBooks</xs:documentation>
+					<xs:documentation>Usado para la clasificación de publicaciones académicas y especializadas en países de habla alemana. Consulte http://www.newbooks-services.com/de/top/unternehmensportrait/klassifikation-und-mapping.html (en alemán) y http://www.newbooks-services.com/en/top/about-newbooks/classification-mapping.html (en inglés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List27">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 27">Código identificador de la materia</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Dewey</xs:documentation>
+					<xs:documentation>Sistema de Clasificación Decimal Dewey.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Dewey abreviado</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Clasificación LC</xs:documentation>
+					<xs:documentation>Clasificación de la US Library of Congress.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Encabezamiento de materia de la LC</xs:documentation>
+					<xs:documentation>Encabezamiento de materia de la US Library of Congress.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Clasificación NLM</xs:documentation>
+					<xs:documentation>Clasificación médica de la US National Library of Medicine.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>MeSH (encabezamiento de materia médica)</xs:documentation>
+					<xs:documentation>Encabezamiento de materia médica de la US National Library of Medicine.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Encabezamiento de materia de la NAL</xs:documentation>
+					<xs:documentation>Encabezamiento de materia de la US National Agricultural Library.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>AAT</xs:documentation>
+					<xs:documentation>Encabezamiento del Tesauro de Arte y Arquitectura del Getty Research Institute.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>CDU</xs:documentation>
+					<xs:documentation>Clasificación Decimal Universal.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Encabezamiento de materia BISAC</xs:documentation>
+					<xs:documentation>Los encabezamientos de materia de BISAC (Book Industry Standards and Communications) se usan en el mercado norteamericano para clasificar libros según el tema. Sirven de directrices para ordenar libros en tiendas físicas y para examinar librerías en línea. Consulte http://www.bisg.org/what-we-do-cat-20-classification-schemes.php.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Código regional BISAC</xs:documentation>
+					<xs:documentation>Un calificador geográfico utilizado con la categoría de materias BISAC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Categoría de materias BIC</xs:documentation>
+					<xs:documentation>Para consultar todos los códigos y calificadores de materia, vea http://www.bic.org.uk/7/BIC-Standard-Subject-Categories/.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Calificador geográfico BIC</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Calificador de idioma BIC</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Calificador cronológico BIC</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Calificador de objetivo escolar BIC</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Calificador de nivel de lectura e interés especial BIC</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>DDC-Sachgruppen der Deutschen Nationalbibliografie</xs:documentation>
+					<xs:documentation>Usado por la Bibliografía Nacional Alemana desde 2004 (100 materias). Es distinto del valor 30. Consulte http://www.d-nb.de/service/pdf/ddc_wv_aktuell.pdf (en alemán) o http://www.d-nb.de/eng/service/pdf/ddc_wv_aktuell_eng.pdf (en inglés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Encabezamiento del género ficción de la LC</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Palabras clave</xs:documentation>
+					<xs:documentation>Cuando se envían múltiples palabras clave o frases de palabra clave en una única instancia del elemento &lt;SubjectHeadingText>, es recomendable separarlas por punto y coma (en consonancia con la práctica recomendada por la US Library of Congress).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>Categoría comercial BIC para literatura infantil</xs:documentation>
+					<xs:documentation>Consulte http://www.bic.org.uk/8/Children&apos;s-Books-Marketing-Classifications/.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Tema para la comercialización BISAC</xs:documentation>
+					<xs:documentation>Los temas para la comercialización BISAC se utilizan junto con los encabezamientos de materia BISAC para indicar un tipo de público para el cual una obra puede ser de especial interés, una época del año o un acontecimiento para los que un libro puede ser especialmente relevante, o para describir más detalladamente obras de ficción que llevan una codificación de materia por género.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Código de categoría propio de la editorial</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Sistema propio de clasificación por materias</xs:documentation>
+					<xs:documentation>Especificado en &lt;SubjectSchemeName>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Tabla de materias ISBN</xs:documentation>
+					<xs:documentation>América Latina.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Warengruppen-Systematik des deutschen Buchhandels</xs:documentation>
+					<xs:documentation>Consulte http://www.boersenverein.de/sixcms/media.php/976/WGSneuVersion2_0.pdf (en alemán).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>SWD</xs:documentation>
+					<xs:documentation>Schlagwortnormdatei - El registro de autoridad de encabezamientos de materia en los países de habla alemana. Consulte http://www.d-nb.de/standardisierung/normdateien/swd.htm (en alemán) y http://www.d-nb.de/eng/standardisierung/normdateien/swd.htm (en inglés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>Thèmes Electre</xs:documentation>
+					<xs:documentation>Clasificación por materias usado por Electre (Francia).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="29">
+				<xs:annotation>
+					<xs:documentation>CLIL</xs:documentation>
+					<xs:documentation>Francia, consulte Apéndice en http://www.clil.org/information/telechargementDoc.html?action=ouvrir&amp;id=313 (en francés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>DNB-Sachgruppen</xs:documentation>
+					<xs:documentation>Clasificación de materias de la Deutsche Bibliothek. Usado por la Bibliografía Nacional Alemana hasta 2003 (65 materias). Es distinto del valor 18. Consulte http://www.d-nb.de/service/pdf/ddc_wv_alt_neu.pdf (en alemán).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>NUGI</xs:documentation>
+					<xs:documentation>Nederlandse Uniforme Genre-Indeling (antiguo sistema de clasificación del sector del libro en Holanda).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>NUR</xs:documentation>
+					<xs:documentation>Nederlandstalige Uniforme Rubrieksindeling (sistema de clasificación del sector del libro en Holanda, desde 2002, consulte http://reeks.boekwinkeltjes.nl/downloads/NUR-lijst.pdf (en holandés)).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>ECPA Christian Book Category</xs:documentation>
+					<xs:documentation>Codificación de libros cristianos ECPA. Consiste en hasta tres bloques de tres letras (Categoría Superior, Categoría Primaria y Subcategoría). Consulte http://www.ecpa.org/ECPA/cbacategories.xls.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>SISO</xs:documentation>
+					<xs:documentation>Schema Indeling Systematische Catalogus Openbare Bibliotheken (sistema de clasificación de las bibliotecas holandesas).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="35">
+				<xs:annotation>
+					<xs:documentation>Clasificación Decimal Coreana (KDC)</xs:documentation>
+					<xs:documentation>Sistema de Clasificación Decimal Dewey modificado, utilizado en Corea del Sur.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="36">
+				<xs:annotation>
+					<xs:documentation>DDC Deutsch 22</xs:documentation>
+					<xs:documentation>Traducción alemana del Sistema de Clasificación Decimal Dewey 22. También conocido como DDC 22 ger. Consulte http://www.ddc-deutsch.de/produkte/uebersichten/.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="37">
+				<xs:annotation>
+					<xs:documentation>Bokgrupper</xs:documentation>
+					<xs:documentation>Categorías de productos del sector del libro en Noruega (4701).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="38">
+				<xs:annotation>
+					<xs:documentation>Varegrupper</xs:documentation>
+					<xs:documentation>Categorías de materias en la venta de libros en Noruega (4702).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="39">
+				<xs:annotation>
+					<xs:documentation>Læreplaner</xs:documentation>
+					<xs:documentation>Versión del currículo escolar noruego (4703).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="40">
+				<xs:annotation>
+					<xs:documentation>Clasificación Decimal Nipona</xs:documentation>
+					<xs:documentation>Sistema japonés de clasificación por materias.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="41">
+				<xs:annotation>
+					<xs:documentation>BSQ</xs:documentation>
+					<xs:documentation>BookSelling Qualifier: clasificación del sector del libro en Rusia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="42">
+				<xs:annotation>
+					<xs:documentation>ANELE Materias</xs:documentation>
+					<xs:documentation>España: sistema de codificación de materias de la Asociación Nacional de Editores de Libros y Material de Enseñanza.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="43">
+				<xs:annotation>
+					<xs:documentation>Skolefag</xs:documentation>
+					<xs:documentation>Categorías de materias escolares en la educación primaria y secundaria en Noruega (4705).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="44">
+				<xs:annotation>
+					<xs:documentation>Videregående</xs:documentation>
+					<xs:documentation>Categorías de materias de la educación secundaria postobligatoria y formación profesional en Noruega (4706).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="45">
+				<xs:annotation>
+					<xs:documentation>Undervisningsmateriell</xs:documentation>
+					<xs:documentation>Lista de categorías para libros y otro material didáctico usado en Noruega (4707).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="46">
+				<xs:annotation>
+					<xs:documentation>Norsk DDK</xs:documentation>
+					<xs:documentation>La versión noruega del Sistema de Clasificación Decimal Dewey.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="47">
+				<xs:annotation>
+					<xs:documentation>Varugrupper</xs:documentation>
+					<xs:documentation>Categorías de materias en la venta de libros en Suecia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="48">
+				<xs:annotation>
+					<xs:documentation>SAB</xs:documentation>
+					<xs:documentation>Sistema de clasificación sueco.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="49">
+				<xs:annotation>
+					<xs:documentation>Läromedel</xs:documentation>
+					<xs:documentation>Categorías en la venta de libros de materia educativa en Suecia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="50">
+				<xs:annotation>
+					<xs:documentation>Förhandsbeskrivning</xs:documentation>
+					<xs:documentation>Clasificación por materias preliminar de las editoriales suecas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="51">
+				<xs:annotation>
+					<xs:documentation>Subcategoría de UDC del ISBN español</xs:documentation>
+					<xs:documentation>Subconjunto controlado de códigos UDC usado por la Agencia Española del ISBN.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="52">
+				<xs:annotation>
+					<xs:documentation>Categorías de materias ECI</xs:documentation>
+					<xs:documentation>Categorías de materias definidas por El Corte Inglés y ampliamente usadas en el sector del libro español.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="53">
+				<xs:annotation>
+					<xs:documentation>Soggetto CCE</xs:documentation>
+					<xs:documentation>Classificazione Commerciale Editoriale (categoría de materias del sector del libro italiano basada en BIC). Documentación sobre CCE disponible en http://www.ie-online.it/CCE2_2.0.pdf.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="54">
+				<xs:annotation>
+					<xs:documentation>Qualificatore geografico CCE</xs:documentation>
+					<xs:documentation>Calificador CCE de localización geográfica.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="55">
+				<xs:annotation>
+					<xs:documentation>Qualificatore di lingua CCE</xs:documentation>
+					<xs:documentation>Calificador CCE de lengua.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="56">
+				<xs:annotation>
+					<xs:documentation>Qualificatore di periodo storico CCE</xs:documentation>
+					<xs:documentation>Calificador CCE de periodos históricos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="57">
+				<xs:annotation>
+					<xs:documentation>Qualificatore di livello scolastico CCE</xs:documentation>
+					<xs:documentation>Calificador CCE de fines didácticos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="58">
+				<xs:annotation>
+					<xs:documentation>Qualificatore di età di lettura CCE</xs:documentation>
+					<xs:documentation>Calificador CCE de nivel de lectura.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="59">
+				<xs:annotation>
+					<xs:documentation>VdS Bildungsmedien Fächer</xs:documentation>
+					<xs:documentation>Listado de códigos de materias de la asociación alemana de las editoriales de materiales educativos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="60">
+				<xs:annotation>
+					<xs:documentation>Fagkoder</xs:documentation>
+					<xs:documentation>Undervisningsdirektoratets fagkoder for kunnskapsløftet I videregående (currículo de la enseñanza secundaria en Noruega) (4708).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="61">
+				<xs:annotation>
+					<xs:documentation>Clasificación JEL</xs:documentation>
+					<xs:documentation>Sistema de clasificación del Journal of Economic Literature.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="62">
+				<xs:annotation>
+					<xs:documentation>CSH</xs:documentation>
+					<xs:documentation>Encabezamientos de materia de la National Library of Canada (en inglés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="63">
+				<xs:annotation>
+					<xs:documentation>RVM</xs:documentation>
+					<xs:documentation>Répertoire de vedettes-matière (Bibliothèque et Archives Canada et Bibliothèque de l&apos;Université Laval) (en francés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="64">
+				<xs:annotation>
+					<xs:documentation>YSA</xs:documentation>
+					<xs:documentation>Yleinen suomalainen asiasanasto: Tesauro General Finlandés. Consulte http://onki.fi/fi/browser/ (en finlandés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="65">
+				<xs:annotation>
+					<xs:documentation>Allärs</xs:documentation>
+					<xs:documentation>Allmän tesaurus på svenska: traducción sueca del Tesauro General Finlandés. Consulte http://onki.fi/fi/browser/ (en finlandés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="66">
+				<xs:annotation>
+					<xs:documentation>YKL</xs:documentation>
+					<xs:documentation>Yleisten kirjastojen luokitusjärjestelmä: Sistema de Clasificación de las Bibliotecas Públicas de Finlandia. Consulte http://ykl.kirjastot.fi/ (en finlandés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="67">
+				<xs:annotation>
+					<xs:documentation>MUSA</xs:documentation>
+					<xs:documentation>Musiikin asiasanasto: Tesauro Musical Finlandés. Consulte http://onki.fi/fi/browser/ (en finlandés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="68">
+				<xs:annotation>
+					<xs:documentation>CILLA</xs:documentation>
+					<xs:documentation>Specialtesaurus för musik: traducción sueca del Tesauro Musical Finlandés. Consulte http://onki.fi/fi/browser/ (en finlandés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="69">
+				<xs:annotation>
+					<xs:documentation>Kaunokki</xs:documentation>
+					<xs:documentation>Fiktiivisen aineiston asiasanasto: Tesauro Finlandés para ficción. Consulte http://kaunokki.kirjastot.fi/ (en finlandés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="70">
+				<xs:annotation>
+					<xs:documentation>Bella</xs:documentation>
+					<xs:documentation>Specialtesaurus för fiktivt material: traducción sueca del Tesauro Finlandés de Ficción. Consulte http://kaunokki.kirjastot.fi/sv-FI/ (en finlandés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="71">
+				<xs:annotation>
+					<xs:documentation>YSO</xs:documentation>
+					<xs:documentation>Yleinen suomalainen ontologia: Ontología Fundamental Finlandesa. Consulte http://onki.fi/fi/browser/ (en finlandés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="72">
+				<xs:annotation>
+					<xs:documentation>Paikkatieto ontologia</xs:documentation>
+					<xs:documentation>Ontología de los Lugares Finlandesa. Consulte http://onki.fi/fi/browser/ (en finlandés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="73">
+				<xs:annotation>
+					<xs:documentation>Suomalainen kirja-alan luokitus</xs:documentation>
+					<xs:documentation>Clasificación del sector del libro finlandés.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="74">
+				<xs:annotation>
+					<xs:documentation>Sears</xs:documentation>
+					<xs:documentation>Encabezamientos de materia de Sears.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="75">
+				<xs:annotation>
+					<xs:documentation>BIC E4L</xs:documentation>
+					<xs:documentation>BIC E4Libraries Category Headings (encabezamientos de categorías), consulte http://www.bic.org.uk/51/E4libraries-Subject-Category-Headings/.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="76">
+				<xs:annotation>
+					<xs:documentation>CSR</xs:documentation>
+					<xs:documentation>Code Sujet Rayon: clasificación por materias usado por las librerías en Francia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="77">
+				<xs:annotation>
+					<xs:documentation>Suomalainen oppiaineluokitus</xs:documentation>
+					<xs:documentation>Clasificación de materias escolares usada en Finlandia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="78">
+				<xs:annotation>
+					<xs:documentation>Código C del sector del libro en Japón</xs:documentation>
+					<xs:documentation>Consulte http://www.asahi-net.or.jp/~ax2s-kmtn/ref/ccode.html (en japonés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="79">
+				<xs:annotation>
+					<xs:documentation>Código de género literario del sector del libro en Japón</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="80">
+				<xs:annotation>
+					<xs:documentation>Fiktiivisen aineiston lisäluokitus</xs:documentation>
+					<xs:documentation>Clasificación finlandesa del género ficción. Consulte http://ykl.kirjastot.fi/fi-FI/lisaluokat/ (en finlandés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="81">
+				<xs:annotation>
+					<xs:documentation>Sistema árabe de encabezamientos de materia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="82">
+				<xs:annotation>
+					<xs:documentation>Categoría de materias BIC arabizada</xs:documentation>
+					<xs:documentation>Versión arabizada del sistema de categorías de materias BIC, desarrollada por EIKotob.com.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="83">
+				<xs:annotation>
+					<xs:documentation>Encabezamientos de materia de la LC arabizados</xs:documentation>
+					<xs:documentation>Versión arabizada del sistema de categorías de materias de la Library of Congress.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="84">
+				<xs:annotation>
+					<xs:documentation>Encabezamientos de materia de la Bibliotheca Alexandrina</xs:documentation>
+					<xs:documentation>Sistema de clasificación usado por la Biblioteca de Alexandria.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="85">
+				<xs:annotation>
+					<xs:documentation>Código postal</xs:documentation>
+					<xs:documentation>Ubicación definida por código postal. El formato es: código de país de dos letras (de la Lista 91), espacio, código postal. Observe que algunos códigos postales de por sí contienen espacios, p.ej. &quot;GB N7 9DP&quot; o &quot;US 10125&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="86">
+				<xs:annotation>
+					<xs:documentation>GeoNames ID</xs:documentation>
+					<xs:documentation>Número de identificación de lugares geográficos, definido en http://www.geonames.org (p.ej. 2825297 es Stuttgart, Alemania; consulte http://www.geonames.org/2825297).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="87">
+				<xs:annotation>
+					<xs:documentation>Clasificación por materias NewBooks</xs:documentation>
+					<xs:documentation>Usado para la clasificación de publicaciones académicas y especializadas en países de habla alemana. Consulte http://www.newbooks-services.com/de/top/unternehmensportrait/klassifikation-und-mapping.html (en alemán) y http://www.newbooks-services.com/en/top/about-newbooks/classification-mapping.html (en inglés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="88">
+				<xs:annotation>
+					<xs:documentation>Sistema de Clasificación de las Bibliotecas Chinas</xs:documentation>
+					<xs:documentation>Clasificación por materias mantenida por el Comité Editorial del Sistema de Clasificación de las Bibliotecas Chinas. Consulte http://cct.nlc.gov.cn para acceder a más detalles sobre el sistema de clasificación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="89">
+				<xs:annotation>
+					<xs:documentation>Clasificación NTCPDSAC</xs:documentation>
+					<xs:documentation>Clasificación por materias para libros, productos audiovisuales y publicaciones electrónicas formulada por el Comité Técnico Nacional Chino 505.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List28">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 28">Código de público</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>General/comercial</xs:documentation>
+					<xs:documentation>Para el público adulto no experto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Infantil/juvenil</xs:documentation>
+					<xs:documentation>Para el público juvenil, sin finalidad educativa.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Jóvenes adultos</xs:documentation>
+					<xs:documentation>Para el público adolescente, sin finalidad educativa.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Enseñanza primaria y secundaria obligatoria y postobligatoria</xs:documentation>
+					<xs:documentation>Para el público en la enseñanza infantil, preescolar, primaria o secundaria.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Educación superior</xs:documentation>
+					<xs:documentation>Para el público en instituciones de educación superior.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Profesional/académico</xs:documentation>
+					<xs:documentation>Para el público adulto experto, incluida la investigación académica.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Enseñanza de inglés (ELT/ESL)</xs:documentation>
+					<xs:documentation>Para la enseñanza del inglés como segunda lengua.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Formación de adultos</xs:documentation>
+					<xs:documentation>Para centros que ofrecen cursos de formación para adultos (cursos académicos, profesionales o recreativos).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List29">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 29">Tipo de código de público</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Códigos de público ONIX</xs:documentation>
+					<xs:documentation>Utilizar Lista 28.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Propietario</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Clasificación MPAA</xs:documentation>
+					<xs:documentation>Clasificación de la Motion Picture Association of America aplicada a películas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Clasificación BBFC</xs:documentation>
+					<xs:documentation>Clasificación del British Board of Film Classification aplicada a películas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Clasificación FSK</xs:documentation>
+					<xs:documentation>Clasificación alemana del FSK (Freiwillige Selbstkontrolle der Filmwirtschaft) aplicada a películas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Código de público BTLF</xs:documentation>
+					<xs:documentation>Listado de códigos del público canadiense francófono, usado por el BTLF para Memento.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Código de público Electre</xs:documentation>
+					<xs:documentation>Código de público usado por Electre (Francia).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>ANELE Tipo</xs:documentation>
+					<xs:documentation>España: codificación por tipo de material y público en la enseñanza de la Asociación Nacional de Editores de Libros y Material de Enseñanza.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>AVI</xs:documentation>
+					<xs:documentation>Listado de códigos usado para especificar niveles de lectura en libros infantiles, usado en Flandes y antiguamente en los Países Bajos (véase también código 18).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Clasificación USK</xs:documentation>
+					<xs:documentation>Clasificación USK (Unterhaltungssoftware Selbstkontrolle) aplicada a videojuegos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>AWS</xs:documentation>
+					<xs:documentation>Código de público usado en Flandes.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Schulform</xs:documentation>
+					<xs:documentation>Tipo de centro educativo: listado de códigos mantenido por el VdS Bildungsmedien eV, la asociación alemana de editoriales de materiales educativos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Bundesland</xs:documentation>
+					<xs:documentation>Región educativa: listado de códigos mantenido por el VdS Bildungsmedien eV, la asociación alemana de editoriales de materiales educativos, que indica el lugar donde los productos se pueden usar en los centros educativos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Ausbildungsberuf</xs:documentation>
+					<xs:documentation>Ocupación: listado de códigos de material para formación profesional, mantenido por el VdS Bildungsmedien eV, la asociación alemana de editoriales de materiales educativos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Suomalainen kouluasteluokitus</xs:documentation>
+					<xs:documentation>Niveles educativos finlandeses.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Recomendación de edad del CBG</xs:documentation>
+					<xs:documentation>Codificación de edad recomendada mostrada en la portada del libro, gestionada por el Children&apos;s Book Group de la UK Publishers Association.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Código de público de Nielsen Book</xs:documentation>
+					<xs:documentation>Código de público usado por Nielsen Book Services.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>AVI (revisado)</xs:documentation>
+					<xs:documentation>Listado de códigos usado para especificar niveles de lectura en libros infantiles, usado en los Países Bajos (vea también código 09).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Medida de Lexile</xs:documentation>
+					<xs:documentation>Medida de Lexile (la medida en &lt;ComplexityCode> puede llevar como prefijo el código Lexile). Algunos ejemplos: &quot;880L&quot;, &quot;AD0L&quot; o &quot;HL600L&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Puntuación de legibilidad de Fry</xs:documentation>
+					<xs:documentation>Métrica de legibilidad de Fry basada en el número de frases y sílabas por 100 palabras. Expresado en números (del 1 al 15) en &lt;AudienceCodeValue>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List30">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 30">Calificador de la variedad de lector</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Nivel escolar en EE. UU.</xs:documentation>
+					<xs:documentation>Valores para &lt;AudienceRangeValue> se especifican en la Lista 77.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Nivel escolar en el Reino Unido</xs:documentation>
+					<xs:documentation>Los valores están definidos por el BIC para Inglaterra y Gales, Escocia e Irlanda del Norte.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Velocidad de lectura, en palabras por minuto</xs:documentation>
+					<xs:documentation>El elemento &lt;AudienceRangeValue> solo admite números enteros.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Edad de interés, en meses</xs:documentation>
+					<xs:documentation>Utilizar solo hasta 30 meses. El elemento &lt;AudienceRangeValue> solo admite números enteros.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Edad de interés, en años</xs:documentation>
+					<xs:documentation>El elemento &lt;AudienceRangeValue> solo admite números enteros.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Edad de lectura, en años</xs:documentation>
+					<xs:documentation>El elemento &lt;AudienceRangeValue> solo admite números enteros.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Nivel escolar en España</xs:documentation>
+					<xs:documentation>España: código que combina el nivel escolar y la Comunidad Autónoma, gestionado por el Ministerio de Educación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Skoletrinn</xs:documentation>
+					<xs:documentation>Niveles escolares en Noruega (4704).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>Nivå</xs:documentation>
+					<xs:documentation>Calificador educativo en Suecia (código).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Nivel escolar en Italia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Schulform</xs:documentation>
+					<xs:documentation>OBSOLETO - asignado por error: ver Lista 29.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Bundesland</xs:documentation>
+					<xs:documentation>OBSOLETO - asignado por error: ver Lista 29.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Ausbildungsberuf</xs:documentation>
+					<xs:documentation>OBSOLETO - asignado por error: ver Lista 29.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Nivel escolar en Canadá</xs:documentation>
+					<xs:documentation>Valores para &lt;AudienceRangeValue> se especifican en la Lista 77.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>Nivel escolar en Finlandia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>Enseñanza secundaria postobligatoria en Finlandia</xs:documentation>
+					<xs:documentation>Lukion kurssi.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="29">
+				<xs:annotation>
+					<xs:documentation>Código de nivel escolar en China</xs:documentation>
+					<xs:documentation>Los valores son P, K, 1-17 (incluye el público en la enseñanza superior).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List31">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 31">Precisión de la variedad de lector</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Exacta</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Desde</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Para</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List32">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 32">Identificador de la clasificación de complejidad</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Código Lexile</xs:documentation>
+					<xs:documentation>OBSOLETO en ONIX 3 - usar &lt;Audience> en su lugar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Número Lexile</xs:documentation>
+					<xs:documentation>OBSOLETO en ONIX 3 - usar &lt;Audience> en su lugar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Puntuación de legibilidad de Fry</xs:documentation>
+					<xs:documentation>OBSOLETO en ONIX 3 - usar &lt;Audience> en su lugar. Métrica de legibilidad de Fry basada en el número de frases y sílabas por 100 palabras. Expresado en números (del 1 al 15) en &lt;ComplexityCode>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List33">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 33">Otro código de tipo de texto</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Descripción principal</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Breve descripción/anotación</xs:documentation>
+					<xs:documentation>Límite máximo: 350 caracteres.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Descripción larga</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Tabla de contenidos</xs:documentation>
+					<xs:documentation>Se usa cuando la tabla de contenidos consta de un único campo de texto que puede contener, o no, estructuras expresadas en HTML, etc. Asimismo, el grupo &lt;ContentItem> permite enviar una tabla de contenidos completamente estructurada.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Cita de reseña de longitud limitada</xs:documentation>
+					<xs:documentation>Una cita de reseña cuya longitud máxima se acuerda entre el remitente y el destinatario/a de un archivo ONIX.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Cita de reseña de una edición anterior</xs:documentation>
+					<xs:documentation>Cita tomada de una reseña de una edición anterior de la obra.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Texto de reseña</xs:documentation>
+					<xs:documentation>Texto completo de la reseña del producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Cita de reseña</xs:documentation>
+					<xs:documentation>Cita de la reseña del producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Titular promocional</xs:documentation>
+					<xs:documentation>Frase promocional utilizada como titular de la descripción de un producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Cita de reseña anterior</xs:documentation>
+					<xs:documentation>Cita tomada de una reseña de una obra anterior del mismo autor/a o de la misma serie.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Comentarios del autor/a</xs:documentation>
+					<xs:documentation>Puede formar parte del material de la guía de lectura en grupo: para otros comentarios, véase código 42.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Descripción para lectores/as</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Nota bibliográfica</xs:documentation>
+					<xs:documentation>Nota referida a todos los colaboradores/as de un producto, no a una persona en concreto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Descripción para la guía de lectura en grupo</xs:documentation>
+					<xs:documentation>Para enlazar con una guía de lectura en grupo completa, vea código 41.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Pregunta para la discusión en una guía de lectura en grupo</xs:documentation>
+					<xs:documentation>Cada instancia debe contener una sola pregunta. Para enlazar con una guía de lectura en grupo completa, vea código 41.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Títulos en competición</xs:documentation>
+					<xs:documentation>Lista en texto libre de otros títulos con los que el producto compite. Aunque este texto puede no aparecer en los registros &quot;públicos&quot; de ONIX, puede ser necesario cuando ONIX se utilice como formato de comunicación dentro de un grupo de editoriales y distribuidoras.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Texto de solapa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Texto de contraportada</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Destacar</xs:documentation>
+					<xs:documentation>Texto que describe una característica del producto que la editorial quiere destacar para fines promocionales. Cada característica se debe escribir en un campo separado para que el destinatario/a del registro ONIX puede darles formato según su criterio.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Nueva característica</xs:documentation>
+					<xs:documentation>Igual que el código 19, pero utilizado para una característica que es nueva en una nueva edición del producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>Nota de la editorial</xs:documentation>
+					<xs:documentation>Declaración de la editorial en cumplimiento de sus obligaciones contractuales: por ejemplo, una cláusula de limitación de responsabilidad, nota de un patrocinador, o cualquier otro tipo de advertencia legal. La inclusión de una nota de este tipo no obliga a su reproducción por parte de quien utiliza el registro ONIX.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Índice</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Extracto del libro</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Primer capítulo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Descripción para el canal de venta</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Descripción para la prensa u otros medios de comunicación</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>Descripción para el departamento de derechos subsidiarios</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>Descripción para profesores/as y formadores/as</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>Testimonio inédito</xs:documentation>
+					<xs:documentation>Una cita generalmente facilitada por un famoso para promocionar un nuevo libro, no de una reseña.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>Descripción para librerías</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>Descripción para bibliotecas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>Introducción o prefacio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>Texto completo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="35">
+				<xs:annotation>
+					<xs:documentation>Texto promocional</xs:documentation>
+					<xs:documentation>Texto promocional que no figura en ninguna portada.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="40">
+				<xs:annotation>
+					<xs:documentation>Entrevista al autor/a / Preguntas y respuestas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="41">
+				<xs:annotation>
+					<xs:documentation>Guía de lectura en grupo</xs:documentation>
+					<xs:documentation>Guía completa: ver también los códigos 14 y 15.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="42">
+				<xs:annotation>
+					<xs:documentation>Comentario/discusión</xs:documentation>
+					<xs:documentation>Comentarios distintos de los del autor/a: ver código 11.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="43">
+				<xs:annotation>
+					<xs:documentation>Descripción breve de una serie o un conjunto</xs:documentation>
+					<xs:documentation>(de la que el producto forma parte). Limitada a un máximo de 350 caracteres.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="44">
+				<xs:annotation>
+					<xs:documentation>Descripción larga de una serie o un conjunto</xs:documentation>
+					<xs:documentation>(de los que el producto forma parte).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="99">
+				<xs:annotation>
+					<xs:documentation>País de fabricación final</xs:documentation>
+					<xs:documentation>Un único código de país de la Lista 91 de la ISO 3166-1 que designa el país de fabricación final del producto. (Esta funcionalidad se proporciona como una solución alternativa en ONIX 2.1. ONIX 3.0 tiene la cláusula específica para el país de fabricación como un elemento aparte).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List34">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 34">Código de texto de formato</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Texto ASCII</xs:documentation>
+					<xs:documentation>OBSOLETO: use el código 06 o 07 según sea apropiado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>SGML</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>HTML</xs:documentation>
+					<xs:documentation>Otro diferente de XHTML.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>XML</xs:documentation>
+					<xs:documentation>Otro diferente de XHTML.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>PDF</xs:documentation>
+					<xs:documentation>OBSOLETO: había sido asignado anteriormente a un PDF y a un XHTML.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>XHTML</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Formato de texto por defecto</xs:documentation>
+					<xs:documentation>Por defecto: el texto en la codificación declarado en el encabezado del mensaje o en el XML por defecto (UTF-8 o UTF-16) si no se declaró de forma explícita.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Texto ASCII básico</xs:documentation>
+					<xs:documentation>El texto plano no contiene etiquetas de ningún tipo, excepto las etiquetas &amp;amp; y &amp;lt; que XML insiste en que se usen para representar los caracteres ampersand y menor que en texto; así como el conjunto de caracteres limitados al conjunto ASCII, como por ejemplo los caracteres válidos UTF-8 cuyo número se sitúa entre el 32 (el espacio) y el 126 (la tilde).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>PDF</xs:documentation>
+					<xs:documentation>Reemplaza 04 por el elemento &lt;TextFormat>, pero no puede emplearse como un atributo de formato de texto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Formato de texto enriquecido de Microsoft (RTF)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Formato binario de Microsoft Word (DOC)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>ECMA 376 WordprocessingML</xs:documentation>
+					<xs:documentation>Archivo de formato Office Open XML/OOXML/DOCX.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>ISO 26300 ODF</xs:documentation>
+					<xs:documentation>Formato ISO Open Document.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Formato binario Corel Wordperfect (DOC)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>EPUB</xs:documentation>
+					<xs:documentation>Open Publication Structure / formato contenedor estándar OPS del International Digital Publishing Forum (IDPF) [Extensión de archivo .epub].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>XPS</xs:documentation>
+					<xs:documentation>XML Paper Specification.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List35">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 35">Código de tipo de enlace de texto</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>URL</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Identificador de objeto digital (DOI)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>PURL</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Nombre de recurso uniforme</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Dirección FTP</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>nombre del archivo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List36">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 36">Código de formato del archivo de imagen de la portada</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>GIF</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>JPEG</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>TIF</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List37">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 37">Código de tipo de enlace del archivo de la imagen de portada</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>URL</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Identificador de objeto digital (DOI)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>PURL</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Nombre de recurso uniforme</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Dirección FTP</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>nombre del archivo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List38">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 38">Código del tipo de archivo de imagen/audio/vídeo</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Todo el producto</xs:documentation>
+					<xs:documentation>Enlace a la ubicación en la que se encuentra todo el producto: utilizado para publicaciones digitales.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Aplicación: demo del software</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Imagen: toda la portada</xs:documentation>
+					<xs:documentation>Incluye portada, contraportada, lomo y solapas, si las hubiera. Calidad no especificada: si se envía una imagen de calidad estándar y una de alta calidad, se usa 03 para la de calidad estándar y 05 para la de alta calidad.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Imagen: portada</xs:documentation>
+					<xs:documentation>Calidad no especificada: si se envía una imagen de calidad estándar y una de alta calidad, se usa 04 para la de calidad estándar y 06 para la de alta calidad.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Imagen: toda la portada, alta calidad</xs:documentation>
+					<xs:documentation>Debe tener una resolución mínima de 300 ppp cuando se presenta en el tamaño deseado para su presentación o impresión.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Imagen: portada, alta calidad</xs:documentation>
+					<xs:documentation>Debe tener una resolución mínima de 300 ppp cuando se presenta en el tamaño deseado para su presentación o impresión.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Imagen: miniatura de la portada</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Imagen: colaborador(es)/a(as)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Imagen: para series</xs:documentation>
+					<xs:documentation>Utilizar para una imagen, distinta de un logotipo, que forme parte de la marca de una serie.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Imagen: logotipo de la serie</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Imagen: logotipo del producto</xs:documentation>
+					<xs:documentation>Utilizar solo para un logotipo que es específico de un producto individual.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Imagen: logotipo de la editorial</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Imagen: logotipo de impresión</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Imagen: tabla de contenidos</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Imagen: contenido de muestra</xs:documentation>
+					<xs:documentation>Utilizar para una imagen de página interior de libro o una captura de pantalla para un programa o juego (definición revisada del número 8).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Imagen: contraportada</xs:documentation>
+					<xs:documentation>Calidad no especificada: si se envía una imagen de calidad estándar y una de alta calidad, emplear 24 para la de calidad estándar y 26 para la de alta calidad.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Imagen: contraportada, alta calidad</xs:documentation>
+					<xs:documentation>Debe tener una resolución mínima de 300 ppp cuando se presenta en el tamaño deseado para su presentación o impresión.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Imagen: miniatura de la contraportada</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>Imagen: otro material de la portada</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>Imagen: material promocional</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="29">
+				<xs:annotation>
+					<xs:documentation>Segmento de vídeo: no especificado</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>Segmento de audio: no especificado</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>Vídeo: presentación/comentario del autor/a</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>Vídeo: entrevista del autor/a</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>Vídeo: lectura del autor/a</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>Vídeo: material de la portada</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="35">
+				<xs:annotation>
+					<xs:documentation>Vídeo: contenido de muestra</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="36">
+				<xs:annotation>
+					<xs:documentation>Vídeo: material promocional</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="37">
+				<xs:annotation>
+					<xs:documentation>Vídeo: reseña</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="38">
+				<xs:annotation>
+					<xs:documentation>Vídeo: otro comentario/otra discusión</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="41">
+				<xs:annotation>
+					<xs:documentation>Audio: presentación/comentario del autor/a</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="42">
+				<xs:annotation>
+					<xs:documentation>Audio: entrevista del autor/a</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="43">
+				<xs:annotation>
+					<xs:documentation>Audio: lectura del autor/a</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="44">
+				<xs:annotation>
+					<xs:documentation>Audio: contenido de muestra</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="45">
+				<xs:annotation>
+					<xs:documentation>Audio: material promocional</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="46">
+				<xs:annotation>
+					<xs:documentation>Audio: reseña</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="47">
+				<xs:annotation>
+					<xs:documentation>Audio: otro comentario/otra discusión</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="51">
+				<xs:annotation>
+					<xs:documentation>Aplicación: contenido de muestra</xs:documentation>
+					<xs:documentation>Utilizar la función &quot;mirar dentro&quot; o &quot;widget&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="52">
+				<xs:annotation>
+					<xs:documentation>Aplicación: material promocional</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List39">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 39">Código de formato del archivo de imagen/audio/vídeo</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>GIF</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>JPEG</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>PDF</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>TIF</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>RealAudio 28.8</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>MP3</xs:documentation>
+					<xs:documentation>Archivo MPEG-1/2 Audio Layer III.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>MPEG-4</xs:documentation>
+					<xs:documentation>Formato contenedor MPEG-4 (.mp4, .m4a).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>PNG</xs:documentation>
+					<xs:documentation>Formato de imagen de mapa de bits Portable Network Graphics (.png).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>WMA</xs:documentation>
+					<xs:documentation>Formato Windows Media Audio.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>AAC</xs:documentation>
+					<xs:documentation>Formato Advanced Audio Codec.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>WAV</xs:documentation>
+					<xs:documentation>Archivo de audio Waveform.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>AIFF</xs:documentation>
+					<xs:documentation>Audio Interchange File Format (formato de archivo de intercambio de audio).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>WMV</xs:documentation>
+					<xs:documentation>Formato Windows Media Video.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>OGG</xs:documentation>
+					<xs:documentation>Formato contenedor de Ogg.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>AVI</xs:documentation>
+					<xs:documentation>Formato contenedor de Audio Video Interleaved.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>MOV</xs:documentation>
+					<xs:documentation>Formato contenedor de Quicktime.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Flash</xs:documentation>
+					<xs:documentation>Formato contenedor de Flash (incluye .flv, .swf, .f4v., etc.).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>3GP</xs:documentation>
+					<xs:documentation>Formato contenedor de 3GP (.3gp, 3g2).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>WebM</xs:documentation>
+					<xs:documentation>Formato contenedor de WebM (incluye .webm y .mkv).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List40">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 40">Tipo de enlace del archivo de imagen/audio/vídeo</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>URL</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Identificador de objeto digital (DOI)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>PURL</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Nombre de recurso uniforme</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Dirección FTP</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>nombre del archivo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List41">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 41">Código de obtención de premio o galardón</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Ganador</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Segundo</xs:documentation>
+					<xs:documentation>En segundo lugar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Mencionado</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Seleccionado</xs:documentation>
+					<xs:documentation>Nominado durante el proceso de selección para ser uno de los seleccionados de los que se obtendrá el ganador.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Preseleccionado</xs:documentation>
+					<xs:documentation>Nominado durante el proceso de selección para ser uno de los preseleccionados de los que se obtendrán los seleccionados y posteriormente el ganador.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Ganador conjunto</xs:documentation>
+					<xs:documentation>O coganador.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List42">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 42">Código de tipo de elemento de texto</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Obra textual</xs:documentation>
+					<xs:documentation>Una obra completa que se publica como elemento de contenido en un producto que incluye dos o más obras, por ejemplo: dos o tres novelas que se publican dentro de una única antología.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Preliminares</xs:documentation>
+					<xs:documentation>Los elementos de texto como el prefacio, la introducción, etc. que se incluyen como preliminares en el contenido de la estructura principal del texto en un producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Cuerpo del texto</xs:documentation>
+					<xs:documentation>Los elementos de texto como las partes, los capítulos, las secciones, etc. que se incluyen como parte del contenido de la estructura principal del texto en un producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Apéndices</xs:documentation>
+					<xs:documentation>Los elementos de texto como el índice que se incluyen después de la estructura principal del texto en un producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Elemento de serie, miscelánea o no especificado</xs:documentation>
+					<xs:documentation>Para revistas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Artículo de investigación</xs:documentation>
+					<xs:documentation>Para revistas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Artículo de reseña</xs:documentation>
+					<xs:documentation>Para revistas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Letra</xs:documentation>
+					<xs:documentation>Para revistas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Comunicación breve</xs:documentation>
+					<xs:documentation>Para revistas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Fe de errores</xs:documentation>
+					<xs:documentation>Para revistas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Resumen</xs:documentation>
+					<xs:documentation>Para revistas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Reseña de libro (o reseña de otra publicación)</xs:documentation>
+					<xs:documentation>Para revistas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Editorial</xs:documentation>
+					<xs:documentation>Para revistas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Reseña de producto</xs:documentation>
+					<xs:documentation>Para revistas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Índice</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>Obituario</xs:documentation>
+					<xs:documentation>Para revistas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List43">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 43">Código de tipo identificador del elemento de texto</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Propietario</xs:documentation>
+					<xs:documentation>Por ejemplo, el identificador propio de una editorial.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>GTIN-13</xs:documentation>
+					<xs:documentation>Anteriormente conocido como EAN-13 (sin guion).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Identificador de objeto digital (DOI)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Identificador de elemento editorial (PII)</xs:documentation>
+					<xs:documentation>Identificador de elemento editorial.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Identificador de número y contribución de publicación seriada (SICI)</xs:documentation>
+					<xs:documentation>Solo para elementos de una serie.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>ISBN-13</xs:documentation>
+					<xs:documentation>(sin guion).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List44">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 44">Tipo de código de nombre</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Propietario</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Propietario</xs:documentation>
+					<xs:documentation>OBSOLETO - use 01.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Identificador editorial DNB</xs:documentation>
+					<xs:documentation>Identificador editorial de Deutsche Nationalbibliothek.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Börsenverein Verkehrsnummer</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Identificador editorial de la Agencia ISBN de Alemania</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>GLN</xs:documentation>
+					<xs:documentation>Número de ubicación global GS1 (anteriormente número de ubicación EAN).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>SAN</xs:documentation>
+					<xs:documentation>Número de dirección estándar para el comercio de libros - Estados Unidos, Reino Unido, etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Centraal Boekhuis Relatie ID</xs:documentation>
+					<xs:documentation>Código identificador utilizado en los Países Bajos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Fondscode Boekenbank</xs:documentation>
+					<xs:documentation>Código de editorial flamenca.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Y-tunnus</xs:documentation>
+					<xs:documentation>Business Identity Code (Finlandia). Consulte http://www.ytj.fi/ (en finés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>ISNI</xs:documentation>
+					<xs:documentation>International Standard Name Identifier. Véase &quot;http://www.isni.org/&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>PND</xs:documentation>
+					<xs:documentation>Personennamendatei - archivo de la autoridad de los nombres de las personas utilizado por la Biblioteca Nacional de Alemania y en otros países de habla alemana. Véase http://www.d-nb.de/standardisierung/normdateien/pnd.htm (alemán) o http://www.d-nb.de/eng/standardisierung/normdateien/pnd.htm (inglés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>LCCN</xs:documentation>
+					<xs:documentation>Un número de control asignado al registro de nombres de autor de la Library of Congress.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Identificador editorial japonesa</xs:documentation>
+					<xs:documentation>Identificador editorial empleado por la Agencia Japonesa del ISBN.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>GKD</xs:documentation>
+					<xs:documentation>Gemeinsame Körperschaftsdatei - Corporate Body Authority File en los países germanófonos. Consulte http://www.d-nb.de/standardisierung/normdateien/gkd.htm (en alemán) o http://www.d-nb.de/eng/standardisierung/normdateien/gkd.htm (en inglés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>ORCID</xs:documentation>
+					<xs:documentation>Open Researcher and Contributor ID. Consulte http://www.orcid.org/.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Identificador editorial GAPP</xs:documentation>
+					<xs:documentation>Identificador editorial de la Agencia China del ISBN (GAPP).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Número de identificación fiscal</xs:documentation>
+					<xs:documentation>Identificador de una empresa a efectos del IVA, p. ej., dentro del sistema VIES de la UE. Visite http://ec.europa.eu/taxation_customs/vies/faqvies.do para más detalles sobre los identificadores de IVA en la UE, que varían según el país. Por lo general, estos consisten en un código de país de dos letras seguido de 8-12 dígitos del número de identificación fiscal nacional. Algunos países incluyen una o dos letras en su número de identificación fiscal. Visite http://en.wikipedia.org/wiki/VAT_identification_number para ver los países fuera de la Unión Europea que emplean identificadores similares. Se deben omitir los espacios, guiones, etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Identificador de Distribución JP</xs:documentation>
+					<xs:documentation>Identificador de cuatro dígitos de una organización empresarial controlado por la Asociación Japonesa de Publicaciones Mayoristas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List45">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 45">Código del rol editorial</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Editor</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Coeditorial</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Patrocinador</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Editorial de la versión en el idioma original</xs:documentation>
+					<xs:documentation>De una obra traducida.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Servidor/distribuidor de contenido electrónico</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Publicado por/en representación de</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Publicado en asociación con</xs:documentation>
+					<xs:documentation>Utilizar también para &quot;Publicado en cooperación con&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Publicado en representación de</xs:documentation>
+					<xs:documentation>OBSOLETO: utilice el código 06.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Editorial nueva o adquirente</xs:documentation>
+					<xs:documentation>Cuando la propiedad de un producto o título se transfiere de una editorial a otra.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Grupo editorial</xs:documentation>
+					<xs:documentation>El grupo al que pertenece el editor (rol de editor 01): se usa únicamente si el editor se identificó con el código de rol 01.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Editorial de la copia original</xs:documentation>
+					<xs:documentation>La editorial de la edición de la que el producto es una copia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Renovación de una edición preencuadernada</xs:documentation>
+					<xs:documentation>La renovación de una edición preencuadernada a la que se le asignó su propio identificador. (En EE. UU., una &quot;edición preencuadernada&quot; es un libro que ya había sido encuadernado previamente, por norma general en su edición en rústica, y que un proveedor distinto de la editorial original vuelve a encuadernar con tapa dura). Se requiere cuando el &lt;EditionType> tiene el código PRB. La editorial original debe figurar como &quot;la editorial&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Editorial anterior</xs:documentation>
+					<xs:documentation>Cuando la propiedad de un producto o título se transfiere de un editor a otro (complemento del código 09).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List46">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 46">Código de tipo de derechos de venta</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Derechos de venta desconocidos o no especificados por algún motivo</xs:documentation>
+					<xs:documentation>Solo puede utilizarse con el elemento &lt;ROWSalesRightsType> de ONIX 3.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Sin restricciones de venta con los derechos exclusivos en los países o territorios especificados</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Sin restricciones de venta con los derechos no exclusivos en los países o territorios especificados</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>No está en venta en los países o territorios especificados (no se especifica el motivo)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>No está en venta en los países especificados (pero la editorial tiene los derechos exclusivos en esos países o territorios)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>No está en venta en los países especificados (la editorial tiene los derechos no exclusivos en esos países o territorios)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>No está en venta en los países especificados (debido a que la editorial no tiene los derechos en esos países o territorios)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>En venta con los derechos exclusivos en los países o territorios especificados (se aplican las restricciones de venta)</xs:documentation>
+					<xs:documentation>Solo con ONIX 3.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>En venta con los derechos no exclusivos en los países o territorios especificados (se aplican las restricciones de venta)</xs:documentation>
+					<xs:documentation>Solo con ONIX 3.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List47">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 47">Derechos de región</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="000">
+				<xs:annotation>
+					<xs:documentation>De forma global</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="001">
+				<xs:annotation>
+					<xs:documentation>De forma global salvo si se especifica lo contrario en las declaraciones de derechos</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="002">
+				<xs:annotation>
+					<xs:documentation>Aeropuertos del Reino Unido</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="003">
+				<xs:annotation>
+					<xs:documentation>&quot;Libre mercado&quot; del Reino Unido</xs:documentation>
+					<xs:documentation>Se utiliza cuando una edición de libre mercado se publica con su propio ISBN.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List48">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 48">Código de tipo de medida</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Altura</xs:documentation>
+					<xs:documentation>Para un libro, la altura del dorso cuando está de pie en una estantería. Para un plano, la altura cuando está doblado. En general, la altura de un producto en la forma en la que se presenta o se empaqueta para su venta al por menor.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Anchura</xs:documentation>
+					<xs:documentation>Para un libro, la dimensión horizontal de la portada cuando está de pie. Para un plano, la anchura cuando está doblado. En general, la anchura de un producto en la forma en la que se presenta o se empaqueta para su venta al por menor.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Grosor</xs:documentation>
+					<xs:documentation>Para un libro, el grosor del lomo. Para un plano, el grosor cuando está doblado. En general, el grosor o corte de un producto en la forma en la que se presenta o se empaqueta para su venta al por menor.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Altura del corte de la página</xs:documentation>
+					<xs:documentation>No recomendada para uso general.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Anchura del corte de la página</xs:documentation>
+					<xs:documentation>No recomendada para uso general.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Unidad de peso</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Diámetro (esférico)</xs:documentation>
+					<xs:documentation>Por ejemplo, de un globo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Altura de la página desdoblada/desenrollada</xs:documentation>
+					<xs:documentation>La altura de una hoja de plano, un póster, etc., doblados o enrollados, al desplegarse.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Ancho de la hoja sin doblar/sin enrollar</xs:documentation>
+					<xs:documentation>El ancho de una hoja de plano, póster, etc. cuando están desdoblados.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Diámetro (tubo o cilindro)</xs:documentation>
+					<xs:documentation>El diámetro de la sección transversal de un tubo o cilindro, que generalmente contiene el producto en forma de hoja enrollada. Utilice &quot;altura&quot; 01 para la altura o longitud del tubo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Medida lateral de un paquete con una hoja enrollada</xs:documentation>
+					<xs:documentation>La longitud de un lado de la sección transversal de un paquete triangular o cuadrado, que generalmente contiene el producto en forma de hoja enrollada. Utilice &quot;altura&quot; 01 para la altura o longitud del paquete.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List49">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 49">Código de región</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AU-CT">
+				<xs:annotation>
+					<xs:documentation>Territorio de la Capital Australiana</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AU-NS">
+				<xs:annotation>
+					<xs:documentation>Nueva Gales del Sur</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AU-NT">
+				<xs:annotation>
+					<xs:documentation>Territorio del Norte</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AU-QL">
+				<xs:annotation>
+					<xs:documentation>Queensland</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AU-SA">
+				<xs:annotation>
+					<xs:documentation>Australia Meridional</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AU-TS">
+				<xs:annotation>
+					<xs:documentation>Tasmania</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AU-VI">
+				<xs:annotation>
+					<xs:documentation>Victoria</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AU-WA">
+				<xs:annotation>
+					<xs:documentation>Australia Occidental</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA-AB">
+				<xs:annotation>
+					<xs:documentation>Alberta</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA-BC">
+				<xs:annotation>
+					<xs:documentation>Columbia Británica</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA-MB">
+				<xs:annotation>
+					<xs:documentation>Manitoba</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA-NB">
+				<xs:annotation>
+					<xs:documentation>Nuevo Brunswick</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA-NL">
+				<xs:annotation>
+					<xs:documentation>Terranova y Labrador</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA-NS">
+				<xs:annotation>
+					<xs:documentation>Nueva Escocia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA-NT">
+				<xs:annotation>
+					<xs:documentation>Territorios del Noroeste</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA-NU">
+				<xs:annotation>
+					<xs:documentation>Nunavut</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA-ON">
+				<xs:annotation>
+					<xs:documentation>Ontario</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA-PE">
+				<xs:annotation>
+					<xs:documentation>Isla del Príncipe Eduardo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA-QC">
+				<xs:annotation>
+					<xs:documentation>Quebec</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA-SK">
+				<xs:annotation>
+					<xs:documentation>Saskatchewan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA-YT">
+				<xs:annotation>
+					<xs:documentation>Territorio del Yukón</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ES-CN">
+				<xs:annotation>
+					<xs:documentation>Islas Canarias</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GB-AIR">
+				<xs:annotation>
+					<xs:documentation>Zona de operaciones del Reino Unido</xs:documentation>
+					<xs:documentation>Puntos de venta solo en la zona de operaciones de los aeropuertos internacionales del Reino Unido.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GB-APS">
+				<xs:annotation>
+					<xs:documentation>Aeropuertos del Reino Unido</xs:documentation>
+					<xs:documentation>Todos los aeropuertos del Reino Unido, incluidos los de la zona de operaciones y otros puntos de venta.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GB-CHA">
+				<xs:annotation>
+					<xs:documentation>Islas del Canal</xs:documentation>
+					<xs:documentation>OBSOLETO, reemplazado por los códigos de países GG (Guernsey) y JE (Jersey).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GB-ENG">
+				<xs:annotation>
+					<xs:documentation>Inglaterra</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GB-EWS">
+				<xs:annotation>
+					<xs:documentation>Inglaterra, Gales y Escocia</xs:documentation>
+					<xs:documentation>El Reino Unido a excepción de Irlanda del Norte.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GB-IOM">
+				<xs:annotation>
+					<xs:documentation>Isla de Man</xs:documentation>
+					<xs:documentation>OBSOLETO, reemplazado por el código de país IM (Isla de Man).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GB-NIR">
+				<xs:annotation>
+					<xs:documentation>Irlanda del Norte</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GB-SCT">
+				<xs:annotation>
+					<xs:documentation>Escocia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GB-WLS">
+				<xs:annotation>
+					<xs:documentation>Gales</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-AK">
+				<xs:annotation>
+					<xs:documentation>Alaska</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-AL">
+				<xs:annotation>
+					<xs:documentation>Alabama</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-AR">
+				<xs:annotation>
+					<xs:documentation>Arkansas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-AZ">
+				<xs:annotation>
+					<xs:documentation>Arizona</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-CA">
+				<xs:annotation>
+					<xs:documentation>California</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-CO">
+				<xs:annotation>
+					<xs:documentation>Colorado</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-CT">
+				<xs:annotation>
+					<xs:documentation>Connecticut</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-DC">
+				<xs:annotation>
+					<xs:documentation>Washington D.C.</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-DE">
+				<xs:annotation>
+					<xs:documentation>Delaware</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-FL">
+				<xs:annotation>
+					<xs:documentation>Florida</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-GA">
+				<xs:annotation>
+					<xs:documentation>Georgia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-HI">
+				<xs:annotation>
+					<xs:documentation>Hawai</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-IA">
+				<xs:annotation>
+					<xs:documentation>Iowa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-ID">
+				<xs:annotation>
+					<xs:documentation>Idaho</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-IL">
+				<xs:annotation>
+					<xs:documentation>Illinois</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-IN">
+				<xs:annotation>
+					<xs:documentation>Indiana</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-KS">
+				<xs:annotation>
+					<xs:documentation>Kansas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-KY">
+				<xs:annotation>
+					<xs:documentation>Kentucky</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-LA">
+				<xs:annotation>
+					<xs:documentation>Luisiana</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-MA">
+				<xs:annotation>
+					<xs:documentation>Massachusetts</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-MD">
+				<xs:annotation>
+					<xs:documentation>Maryland</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-ME">
+				<xs:annotation>
+					<xs:documentation>Maine</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-MI">
+				<xs:annotation>
+					<xs:documentation>Michigan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-MN">
+				<xs:annotation>
+					<xs:documentation>Minnesota</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-MO">
+				<xs:annotation>
+					<xs:documentation>Misuri</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-MS">
+				<xs:annotation>
+					<xs:documentation>Misisipi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-MT">
+				<xs:annotation>
+					<xs:documentation>Montana</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-NC">
+				<xs:annotation>
+					<xs:documentation>Carolina del Norte</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-ND">
+				<xs:annotation>
+					<xs:documentation>Dakota del Norte</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-NE">
+				<xs:annotation>
+					<xs:documentation>Nebraska</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-NH">
+				<xs:annotation>
+					<xs:documentation>Nuevo Hampshire</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-NJ">
+				<xs:annotation>
+					<xs:documentation>Nueva Jersey</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-NM">
+				<xs:annotation>
+					<xs:documentation>Nuevo México</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-NV">
+				<xs:annotation>
+					<xs:documentation>Nevada</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-NY">
+				<xs:annotation>
+					<xs:documentation>Nueva York</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-OH">
+				<xs:annotation>
+					<xs:documentation>Ohio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-OK">
+				<xs:annotation>
+					<xs:documentation>Oklahoma</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-OR">
+				<xs:annotation>
+					<xs:documentation>Oregón</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-PA">
+				<xs:annotation>
+					<xs:documentation>Pensilvania</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-RI">
+				<xs:annotation>
+					<xs:documentation>Rhode Island</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-SC">
+				<xs:annotation>
+					<xs:documentation>Carolina del Sur</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-SD">
+				<xs:annotation>
+					<xs:documentation>Dakota del Sur</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-TN">
+				<xs:annotation>
+					<xs:documentation>Tennessee</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-TX">
+				<xs:annotation>
+					<xs:documentation>Texas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-UT">
+				<xs:annotation>
+					<xs:documentation>Utah</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-VA">
+				<xs:annotation>
+					<xs:documentation>Virginia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-VT">
+				<xs:annotation>
+					<xs:documentation>Vermont</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-WA">
+				<xs:annotation>
+					<xs:documentation>Washington</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-WI">
+				<xs:annotation>
+					<xs:documentation>Wisconsin</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-WV">
+				<xs:annotation>
+					<xs:documentation>Virginia Occidental</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US-WY">
+				<xs:annotation>
+					<xs:documentation>Wyoming</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ECZ">
+				<xs:annotation>
+					<xs:documentation>Eurozona</xs:documentation>
+					<xs:documentation>Los países que se encuentran en la zona continental de Europa y que tienen por moneda el Euro. En el momento de la redacción de este texto eran &quot;AT BE CY EE FI FR DE ES GR IE IT LU MT NL PT SI SK&quot; (los diecisiete países oficiales de la Eurozona) y &quot;AD MC SM VA ME&quot; (otros países cuya moneda es el Euro dentro de la Europa continental). Se han excluido de esta lista algunos países cuya moneda es el Euro, pero se sitúan fuera de la Europa continental. Pueden especificarse por separado. Solo es válido en ONIX 3 y únicamente dentro del Bloque 6.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ROW">
+				<xs:annotation>
+					<xs:documentation>Resto del mundo</xs:documentation>
+					<xs:documentation>De forma global a no ser que se especifique lo contrario. No se usa en ONIX 3.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WORLD">
+				<xs:annotation>
+					<xs:documentation>De forma global</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List50">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 50">Código de unidad de medida</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="cm">
+				<xs:annotation>
+					<xs:documentation>Centímetros</xs:documentation>
+					<xs:documentation>El milímetro es la unidad de longitud preferencial.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gr">
+				<xs:annotation>
+					<xs:documentation>Gramos</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="in">
+				<xs:annotation>
+					<xs:documentation>Pulgadas (US)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kg">
+				<xs:annotation>
+					<xs:documentation>Kilogramos</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lb">
+				<xs:annotation>
+					<xs:documentation>Libras (EE.UU.)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mm">
+				<xs:annotation>
+					<xs:documentation>Milímetros</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="oz">
+				<xs:annotation>
+					<xs:documentation>Onzas (EE.UU.)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="px">
+				<xs:annotation>
+					<xs:documentation>Píxeles</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List51">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 51">Código de relación del producto</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Sin especificar</xs:documentation>
+					<xs:documentation>&lt;Product> está relacionado con &lt;RelatedProduct> de tal forma que no se puede especificar con otro código de valor.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Incluye</xs:documentation>
+					<xs:documentation>&lt;Product> incluye &lt;RelatedProduct>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Es parte de</xs:documentation>
+					<xs:documentation>&lt;Product> es parte de &lt;RelatedProduct>: también para &quot;está disponible como parte de&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Reemplaza</xs:documentation>
+					<xs:documentation>&lt;Product> reemplaza, o es una nueva edición de &lt;RelatedProduct>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Reemplazado por</xs:documentation>
+					<xs:documentation>&lt;Product> está reemplazado por &lt;RelatedProduct>, o tiene una nueva edición (recíproco del código 03).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Formato alternativo</xs:documentation>
+					<xs:documentation>&lt;Product> está disponible en un formato alternativo como &lt;RelatedProduct>: indica un formato alternativo del mismo contenido que está o puede estar disponible.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Tiene un producto adicional</xs:documentation>
+					<xs:documentation>&lt;Product> tiene un producto adicional o suplementario, &lt;RelatedProduct>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Es adicional a</xs:documentation>
+					<xs:documentation>&lt;Product> es un producto adicional o suplementario de &lt;RelatedProduct>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Se liquida como</xs:documentation>
+					<xs:documentation>&lt;Product> se liquida como &lt;RelatedProduct>, cuando un mercado de liquidación asigna su propio identificador al producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Es un saldo de</xs:documentation>
+					<xs:documentation>&lt;Product> se vendía originalmente como &lt;RelatedProduct>, se indica el identificador original de la editorial para un título que se ofrece como un saldo bajo un identificador diferente (recíproco del código 09).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Es otra versión de idioma diferente de</xs:documentation>
+					<xs:documentation>&lt;Product> es otra versión de idioma diferente de &lt;RelatedProduct>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Alternativa sugerida por la editorial</xs:documentation>
+					<xs:documentation>&lt;Product> tiene una alternativa sugerida por la editorial, &lt;RelatedProduct>, pero no tiene el mismo contenido (cf 05 y 06).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Publicación digital basada en (producto impreso)</xs:documentation>
+					<xs:documentation>&lt;Product> es una publicación digital basada en el producto impreso &lt;RelatedProduct>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Publicación digital distribuida como</xs:documentation>
+					<xs:documentation>&lt;Product> es una publicación digital &quot;prestada&quot; como &lt;RelatedProduct>: se utiliza en ONIX 2.1 solo cuando el registro de &lt;Product> describe un paquete de contenido electrónico que está disponible en múltiples &quot;renders&quot; (código 000 en &lt;EpubTypeCode>): NO SE UTILIZA en ONIX 3.0.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>La publicación digital es un &quot;render&quot; de</xs:documentation>
+					<xs:documentation>&lt;Product> es un &quot;render&quot; de la publicación digital &lt;RelatedProduct>: se utiliza en ONIX 2.1 solo cuando el registro de &lt;Product> describe un &quot;render&quot; específico del paquete de contenido de una publicación digital, para identificar el paquete: NO SE UTILIZA en ONIX 3.0.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Versión imprimible bajo demanda sustituta de</xs:documentation>
+					<xs:documentation>&lt;Product> es una versión imprimible bajo demanda sustituta de &lt;RelatedProduct>. &lt;RelatedProduct> es un producto que está agotado y se sustituyó por una versión imprimible bajo demanda con un nuevo ISBN.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Se sustituyó por la versión imprimible bajo demanda.</xs:documentation>
+					<xs:documentation>&lt;Product> Se sustituyó por la versión imprimible bajo demanda &lt;RelatedProduct>. &lt;RelatedProduct> es un sustituto de la versión imprimible bajo demanda, con un nuevo ISBN, de &lt;Product>, que está agotado (recíproco del código 16).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Es una edición especial de</xs:documentation>
+					<xs:documentation>&lt;Product> es una edición especial de &lt;RelatedProduct>. Utilizado para una edición especial (en alemán: Sonderausgabe) con una portada, encuadernación, etc. diferentes (más que un formato alternativo) que puede estar disponible con una cantidad y durante un periodo de tiempo limitados.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Tiene una edición especial</xs:documentation>
+					<xs:documentation>&lt;Product> tiene una edición especial, &lt;RelatedProduct> (recíproco del código 18).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Es una edición preencuadernada de</xs:documentation>
+					<xs:documentation>&lt;Product> es una edición preencuadernada de &lt;RelatedProduct> (En EE.UU, una edición preencuadernada es un libro que ya había sido encuadernado previamente y que se volvió a encuadernar con tapa dura. En casi todos los casos, el libro en cuestión se había encuadernado en una versión en rústica originalmente).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>Es la edición original de la edición preencuadernada</xs:documentation>
+					<xs:documentation>&lt;Product> es la edición normal de la que &lt;RelatedProduct> es una edición preencuadernada.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Producto del mismo autor/a</xs:documentation>
+					<xs:documentation>&lt;Product> y &lt;RelatedProduct> tienen el mismo autor/a.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Producto similar</xs:documentation>
+					<xs:documentation>&lt;RelatedProduct> es un producto similar a &lt;Product> (&quot;si te gustó &lt;Product>, también te puede gustar &lt;RelatedProduct>&quot;).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Es una copia de</xs:documentation>
+					<xs:documentation>&lt;Product> es una copia de la edición de &lt;RelatedProduct>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Es el original de la copia</xs:documentation>
+					<xs:documentation>&lt;Product> es la edición original de la edición de copia &lt;RelatedProduct> (recíproco del código 25).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Es una licencia para</xs:documentation>
+					<xs:documentation>&lt;Product> es una licencia para el producto digital &lt;RelatedProduct>, que se comercia por separado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>Versión electrónica disponible como</xs:documentation>
+					<xs:documentation>&lt;RelatedProduct> es una versión electrónica del producto impreso &lt;Product> (recíproco del código 13).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>Versión mejorada disponible como</xs:documentation>
+					<xs:documentation>&lt;RelatedProduct> es una versión &quot;mejorada&quot; de &lt;Product>, con contenido adicional. Por norma general se emplea para relacionar un libro en línea mejorado con su original &quot;no mejorado&quot;, pero no se limita específicamente a libros digitales. Por ejemplo, puede utilizarse para relacionar libros impresos ilustrados y no ilustrados. &lt;Product> y &lt;RelatedProduct> comparten el mismo &lt;ProductForm>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="29">
+				<xs:annotation>
+					<xs:documentation>Versión básica disponible como</xs:documentation>
+					<xs:documentation>&lt;RelatedProduct> es una versión básica de &lt;Product> (recíproco del código 28). &lt;Product> y &lt;RelatedProduct> comparten el mismo &lt;ProductForm>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>Producto en la misma colección</xs:documentation>
+					<xs:documentation>&lt;RelatedProduct> y &lt;Product> forman parte de la misma serie (por ejemplo, dos productos en la misma serie o el mismo conjunto).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List52">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 52">Código de la región proveedora</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="004">
+				<xs:annotation>
+					<xs:documentation>&quot;Libre mercado&quot; del Reino Unido</xs:documentation>
+					<xs:documentation>Cuando se utiliza el mismo ISBN tanto para las ediciones de libre mercado como para las del Reino Unido.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List53">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 53">Tipo de código de condiciones de retorno</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Propietario</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Código de condiciones de devolución en el sector del libro francés</xs:documentation>
+					<xs:documentation>Mantenido por la Comisión Interprofesional del Libro (Commission Interprofessionnel du Livre, CLIL).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Código indicador de devolución BISAC</xs:documentation>
+					<xs:documentation>Mantenido por BISAC: consulte la Lista 66.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Código de condiciones de devolución en el sector del libro inglés</xs:documentation>
+					<xs:documentation>NO SE UTILIZA EN LA ACTUALIDAD: BIC ha decidido no mantener una lista de códigos a tal fin, puesto que por norma general las condiciones de devolución se basan al menos en parte en la relación de comercio.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List54">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 54">Código del estado de disponibilidad</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AB">
+				<xs:annotation>
+					<xs:documentation>Cancelado</xs:documentation>
+					<xs:documentation>Publicación cancelada después de haber sido anunciada.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AD">
+				<xs:annotation>
+					<xs:documentation>Disponibilidad solo de forma directa de la editorial</xs:documentation>
+					<xs:documentation>Directamente desde la editorial, elemento no disponible para el comercio.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CS">
+				<xs:annotation>
+					<xs:documentation>Disponibilidad imprecisa</xs:documentation>
+					<xs:documentation>Comprobar con el servicio al cliente.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EX">
+				<xs:annotation>
+					<xs:documentation>Ya no tenemos disponibilidad</xs:documentation>
+					<xs:documentation>Solo a través del proveedor o mayorista.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IP">
+				<xs:annotation>
+					<xs:documentation>Disponible</xs:documentation>
+					<xs:documentation>Disponible y en existencias.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MD">
+				<xs:annotation>
+					<xs:documentation>Fabricado bajo demanda</xs:documentation>
+					<xs:documentation>Puede estar acompañado de una estimación media del tiempo hasta suministro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NP">
+				<xs:annotation>
+					<xs:documentation>No ha sido publicado todavía</xs:documentation>
+					<xs:documentation>DEBE figurar la fecha prevista de disponibilidad.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NY">
+				<xs:annotation>
+					<xs:documentation>Novedad de catálogo, sin stock todavía</xs:documentation>
+					<xs:documentation>Solo utilizable por mayoristas u otros vendedores. DEBE ir acompañado de la fecha prevista de disponibilidad.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="OF">
+				<xs:annotation>
+					<xs:documentation>Disponible en otro formato</xs:documentation>
+					<xs:documentation>El formato está descatalogado, pero existe otro formato disponible: debe ir acompañado del identificador del producto alternativo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="OI">
+				<xs:annotation>
+					<xs:documentation>Agotado indefinidamente</xs:documentation>
+					<xs:documentation>Actualmente, no se prevén reimpresiones.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="OP">
+				<xs:annotation>
+					<xs:documentation>Descatalogado</xs:documentation>
+					<xs:documentation>Discontinuado, eliminado del catálogo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="OR">
+				<xs:annotation>
+					<xs:documentation>Sustituido por una nueva edición</xs:documentation>
+					<xs:documentation>La edición está descatalogada, pero se ha publicado o se publicará pronto una nueva edición: debe ir acompañado del identificador de la nueva edición.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PP">
+				<xs:annotation>
+					<xs:documentation>Publicación aplazada indefinidamente</xs:documentation>
+					<xs:documentation>La publicación se anunció y posteriormente se aplazó sin nueva fecha de publicación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RF">
+				<xs:annotation>
+					<xs:documentation>Ponerse en contacto con otro proveedor/a</xs:documentation>
+					<xs:documentation>El suministro del elemento pasó a otra editorial o distribuidor/a: debe ir acompañado del identificador del nuevo proveedor/a.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RM">
+				<xs:annotation>
+					<xs:documentation>Destinado al mercado de saldos de edición</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RP">
+				<xs:annotation>
+					<xs:documentation>En curso de reimpresión</xs:documentation>
+					<xs:documentation>DEBE figurar la fecha prevista de disponibilidad.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RU">
+				<xs:annotation>
+					<xs:documentation>En curso de reimpresión, sin fecha</xs:documentation>
+					<xs:documentation>Utilizar en lugar del código RP, únicamente si es realmente imposible indicar una fecha de disponibilidad prevista.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TO">
+				<xs:annotation>
+					<xs:documentation>Pedido especial</xs:documentation>
+					<xs:documentation>No se tienen existencias del producto y debe encargarse al proveedor/a mediante pedido especial (p. ej., en el caso de un producto importado sin stock local): puede ir acompañado de una fecha aproximada de suministro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TP">
+				<xs:annotation>
+					<xs:documentation>Temporalmente descatalogado porque la editorial no puede proveerlo</xs:documentation>
+					<xs:documentation>Solo a través del proveedor o mayorista.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TU">
+				<xs:annotation>
+					<xs:documentation>Temporalmente no disponible</xs:documentation>
+					<xs:documentation>DEBE figurar la fecha prevista de disponibilidad.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="UR">
+				<xs:annotation>
+					<xs:documentation>No disponible, pendiente de reedición</xs:documentation>
+					<xs:documentation>El producto está agotado, pero se reeditará con el mismo ISBN. DEBE ir acompañado de la fecha prevista de disponibilidad y de la fecha de reedición en el bloque &lt;Reissue>. Véase las notas en el bloque &lt;Reissue> para obtener más detalles acerca del estado de disponibilidad durante la reedición.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WR">
+				<xs:annotation>
+					<xs:documentation>Se destinará al mercado de saldos de edición a partir del (fecha)</xs:documentation>
+					<xs:documentation>DEBE ir acompañado de la fecha prevista de disponibilidad en el mercado de saldos de edición.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WS">
+				<xs:annotation>
+					<xs:documentation>Retirado de la venta</xs:documentation>
+					<xs:documentation>Por lo general, retirado de forma indefinida y por motivos legales.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List55">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 55">Formato de fecha</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>AAAAMMDD</xs:documentation>
+					<xs:documentation>Año, mes, día. Formato por defecto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>AAAAMM</xs:documentation>
+					<xs:documentation>Año, mes.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>AAAASS</xs:documentation>
+					<xs:documentation>Año, número de la semana.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>AAAAT</xs:documentation>
+					<xs:documentation>Año y trimestre (T = 1, 2, 3, 4).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>AAAAE</xs:documentation>
+					<xs:documentation>Año y estación (E = 1, 2, 3, 4, siendo 1 = primavera).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>AAAA</xs:documentation>
+					<xs:documentation>Año.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>AAAAMMDDAAAAMMDD</xs:documentation>
+					<xs:documentation>Intervalo de fechas exactas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>AAAAMMAAAAMM</xs:documentation>
+					<xs:documentation>Intervalo de meses.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>AAAASSAAAASS</xs:documentation>
+					<xs:documentation>Intervalo de semanas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>AAAATAAAAT</xs:documentation>
+					<xs:documentation>Intervalo de trimestres.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>AAAAEAAAAE</xs:documentation>
+					<xs:documentation>Intervalo de estaciones.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>AAAAAAAA</xs:documentation>
+					<xs:documentation>Intervalo de años.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Cadena de texto</xs:documentation>
+					<xs:documentation>Para fechas complejas, aproximadas o inciertas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>YYYYMMDDThhmm</xs:documentation>
+					<xs:documentation>Hora exacta. Utilizar SOLO cuando sea relevante la precisión de la hora y los minutos. Por defecto, se trata de la hora local del remitente. Alternativamente, se puede añadir el sufijo opcional &quot;Z&quot; para las horas UTC o el signo &quot;+&quot; o &quot;-&quot; y el desplazamiento de huso horario &quot;hhmm&quot; respecto al UTC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>YYYYMMDDThhmmss</xs:documentation>
+					<xs:documentation>Hora exacta. Utilizar SOLO cuando sea relevante la precisión de hora, minutos y segundos. Por defecto, se trata de la hora local del remitente. Alternativamente, se puede añadir el sufijo opcional &quot;Z&quot; para las horas UTC o el signo &quot;+&quot; o &quot;-&quot; y el desplazamiento de huso horario &quot;hhmm&quot; respecto al UTC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>YYYYMMDD (H)</xs:documentation>
+					<xs:documentation>Año, mes, día (calendario Hijri).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>YYYYMM (H)</xs:documentation>
+					<xs:documentation>Año, mes (calendario Hijri).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>YYYY (H)</xs:documentation>
+					<xs:documentation>Año (calendario Hijri).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>Cadena de texto (H)</xs:documentation>
+					<xs:documentation>Para fechas complejas, aproximadas o inciertas (calendario Hijri), el texto estará, generalmente, en escritura árabe.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List56">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 56">Marca de restricción del lector/a</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="R">
+				<xs:annotation>
+					<xs:documentation>Se aplican restricciones, véase la nota</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="X">
+				<xs:annotation>
+					<xs:documentation>Indiziert</xs:documentation>
+					<xs:documentation>Indexado para el mercado alemán - en Alemania se denomina &quot;indiziert&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List57">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 57">Código de tipo de elemento sin precio</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Gratuito</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Precio pendiente de comunicación</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>No se vende por separado</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Ponerse en contacto con el proveedor/a</xs:documentation>
+					<xs:documentation>Puede utilizarse para libros que no van acompañados de un precio recomendado de venta al público, cuando el registro ONIX &quot;se difunde públicamente&quot; y los archivos no se venden uno por uno a un socio comercial único; o para productos digitales ofrecidos en modalidad de suscripción o cuyo modelo de precios es demasiado complejo para especificarse en ONIX. </xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>No se vende en conjunto</xs:documentation>
+					<xs:documentation>Se debe utilizar cuando una colección que no se vende en conjunto tiene su propio registro ONIX.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List58">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 58">Código de tipo de precio</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>PVP recomendado sin impuestos</xs:documentation>
+					<xs:documentation>PVP recomendado sin ningún impuesto sobre las ventas o sobre el valor añadido.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>PVP recomendado, incluyendo impuestos</xs:documentation>
+					<xs:documentation>PVP recomendado incluyendo impuestos sobre las ventas o sobre el valor añadido, si procede.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Precio de venta fijo sin impuestos</xs:documentation>
+					<xs:documentation>En aquellos países en los que por ley es obligatorio un precio fijo para determinados productos. No es de aplicación en EE. UU.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Precio de venta fijo, incluyendo impuestos</xs:documentation>
+					<xs:documentation>En aquellos países en los que por ley es obligatorio un precio fijo para determinados productos. No es de aplicación en EE. UU.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Precio neto del proveedor/a sin impuestos</xs:documentation>
+					<xs:documentation>Precio unitario neto aplicado por el proveedor/a al revendedor/a final, sin impuestos sobre las ventas o sobre el valor añadido; aplicado a productos destinados a la venta al por menor.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Precio neto del proveedor/a sin impuestos; aplicado a productos destinados al alquiler</xs:documentation>
+					<xs:documentation>Precio unitario neto aplicado por el proveedor/a al revendedor/a o punto de alquiler final, sin impuestos sobre las ventas o sobre el valor añadido; aplicado a productos destinados al alquiler (vídeo o DVD).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Precio neto del proveedor/a, incluyendo impuestos</xs:documentation>
+					<xs:documentation>Precio unitario neto aplicado por el proveedor/a al revendedor/a final, incluyendo todos los impuestos sobre las ventas o sobre el valor añadido, si procede; aplicado a productos destinados a la venta al por menor.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Precio neto alternativo del proveedor/a sin impuestos</xs:documentation>
+					<xs:documentation>Precio unitario aplicado por el proveedor/a a una categoría determinada de revendedores/as, sin impuestos sobre las ventas o sobre el valor añadido; aplicado a productos destinados a la venta al por menor. El valor se usa solo en países como p. ej. Finlandia, donde la práctica comercial requiere que se fijen dos precios netos diferentes para las diferentes categorías de revendedores/as y donde las directrices nacionales especifican cómo debería usarse el código.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Precio neto alternativo del proveedor/a, incluyendo impuestos</xs:documentation>
+					<xs:documentation>Precio unitario aplicado por el proveedor/a a una categoría determinada de revendedores/as, incluyendo todos los impuestos sobre las ventas o sobre el valor añadido; aplicado a productos destinados a la venta al por menor. El valor se usa solo en países como p. ej. Finlandia, donde la práctica comercial requiere que se fijen dos precios netos diferentes para las diferentes categorías de revendedores/as y donde las directrices nacionales especifican cómo debería usarse el código.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>PVP de venta especial sin impuestos</xs:documentation>
+					<xs:documentation>PVP de venta especial sin impuestos sobre las ventas o sobre el valor añadido. Tenga en cuenta que las &quot;ventas especiales&quot; son ventas cuyos términos y condiciones son diferentes de las ventas comerciales normales cuando, por ejemplo, productos que normalmente se venden en una base de venta o devolución se venden con términos de venta en firme o cuando un producto determinado está diseñado para un punto de alquiler específico (a veces denominado como producto &quot;premium&quot;). Para más detalles sobre los términos y condiciones modificados véase &lt;PriceTypeDescription>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>PVP de venta especial, incluyendo impuestos</xs:documentation>
+					<xs:documentation>PVP de venta especial, incluyendo impuestos sobre las ventas o sobre el valor añadido, si procede.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Precio fijo de venta especial sin impuestos</xs:documentation>
+					<xs:documentation>En aquellos países en los que por ley es obligatorio un precio fijo para determinados productos. No es de aplicación en EE. UU.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Precio fijo de venta especial, incluyendo impuestos</xs:documentation>
+					<xs:documentation>En aquellos países en los que por ley es obligatorio un precio fijo para determinados productos. No es de aplicación en EE. UU.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Precio neto del proveedor/a para venta especial sin impuestos</xs:documentation>
+					<xs:documentation>Precio unitario cobrado al revendedor/a por el proveedor/a para venta especial sin impuestos sobre las ventas o sobre el valor añadido.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Precio unitario para venta especial, incluyendo impuestos</xs:documentation>
+					<xs:documentation>Precio unitario cobrado al revendedor/a por el proveedor/a para venta especial, incluyendo todos los impuestos sobre las ventas o sobre el valor añadido.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>PVP previo a la publicación sin impuestos</xs:documentation>
+					<xs:documentation>n</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>PVP previo a la publicación, incluyendo impuestos</xs:documentation>
+					<xs:documentation>PVP previo a la publicación, incluyendo impuestos sobre las ventas o sobre el valor añadido, si procede.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Precio fijo de venta al por menor previo a la publicación sin impuestos</xs:documentation>
+					<xs:documentation>En aquellos países en los que por ley es obligatorio un precio fijo para determinados productos. No es de aplicación en EE. UU.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Precio fijo de venta al por menor previo a la publicación, incluyendo impuestos</xs:documentation>
+					<xs:documentation>En aquellos países en los que por ley es obligatorio un precio fijo para determinados productos. No es de aplicación en EE. UU.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Precio neto del proveedor/a previo a la publicación sin impuestos</xs:documentation>
+					<xs:documentation>Precio unitario previo a la publicación cobrado al revendedor/a por el proveedor/a, sin impuestos sobre las ventas o sobre el valor añadido.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>Precio neto del proveedor/a previo a la publicación, incluyendo impuestos</xs:documentation>
+					<xs:documentation>Precio unitario previo a la publicación cobrado al revendedor/a por el proveedor/a, incluyendo todos los impuestos sobre las ventas o sobre el valor añadido.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>Precio &quot;freight-pass-through&quot;, sin impuestos</xs:documentation>
+					<xs:documentation>En EE. UU. los libros a veces se suministran con la fórmula &quot;freight-pass-through&quot;, cuando un precio distinto del PVP se usa como la base para calcular el precio aplicado por el proveedor/a al revendedor/a. Para que quede claro cuándo se invocan dichos términos, se usa el código 31 en lugar del código 01 para indicar el PVP. El código 32 se usa para el &quot;precio de facturación&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>Precio de facturación &quot;freight-pass-through&quot;, sin impuestos</xs:documentation>
+					<xs:documentation>Cuando se aplica la fórmula &quot;freight-pass-through&quot;, el precio sobre el cual se calcula el precio aplicado por el proveedor/a al revendedor/a, p. ej., el precio al cual se aplican términos de descuento. Véase también el código 31.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="41">
+				<xs:annotation>
+					<xs:documentation>Precio de venta al por menor de las editoriales sin impuestos</xs:documentation>
+					<xs:documentation>Para un producto suministrado en términos de agencias, el precio de venta se fija por la editorial, sin impuestos sobre las ventas o sobre el valor añadido.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="42">
+				<xs:annotation>
+					<xs:documentation>Precio de venta de las editoriales, incluyendo impuestos</xs:documentation>
+					<xs:documentation>Para un producto suministrado en términos de agencias, el precio de venta se fija por la editorial, incluyendo impuestos sobre las ventas o sobre el valor añadido, si procede.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List59">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 59">Calificador del tipo de precio</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Precio para miembro o suscriptor/a</xs:documentation>
+					<xs:documentation>El precio se aplica a una afiliación grupal determinada.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Precio de exportación</xs:documentation>
+					<xs:documentation>El precio se aplica a ventas que se realizan fuera del territorio en el cual está ubicado el proveedor/a.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Precio reducido que se aplica cuando el elemento se compra como parte de un conjunto (o serie o colección)</xs:documentation>
+					<xs:documentation>Usado en casos en los que no hay un precio combinado, pero se ofrece un precio más bajo para cada parte, si se compra el conjunto entero o la serie o colección entera (o a la vez, como parte de un compromiso continuo o en una compra individual). </xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Precio con bono de descuento</xs:documentation>
+					<xs:documentation>En los Países Bajos (o en cualquier otro mercado en el que se aplican acuerdos similares): un precio reducido fijo disponible durante un tiempo limitado, con la presentación de un bono o cupón publicado en un medio específico, p. ej., un periódico. Debe ir acompañado del código de tipo de precio 13 y detalles adicionales en &lt;PriceTypeDescription> y por fechas de validez en &lt;PriceEffectiveFrom> y &lt;PriceEffectiveUntil> (ONIX 2.1) o en el bloque &lt;PriceDate> (ONIX 3.0).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Precio al consumidor</xs:documentation>
+					<xs:documentation>Precio de venta solo para consumidores/as individuales.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Precio corporativo</xs:documentation>
+					<xs:documentation>Precio de venta a bibliotecas u otros clientes corporativos o institucionales.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Precio para pedidos de reserva</xs:documentation>
+					<xs:documentation>Precio válido para un período determinado previo a la publicación. Se garantiza que los pedidos realizados dentro de este período se entregarán al minorista antes de la fecha nominal de publicación. El precio puede o no ser diferente del precio &quot;normal&quot;, el cual no ofrece la misma garantía de entrega. Es necesario introducir una fecha &lt;PriceEffectiveUntil> (o el bloque equivalente &lt;PriceDate> en ONIX 3) y también un precio &quot;normal&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Precio promocional</xs:documentation>
+					<xs:documentation>Precio temporal de &quot;Oferta especial&quot;. Es necesario introducir las fechas &lt;PriceEffectiveFrom> y &lt;PriceEffectiveUntil> (o los bloques equivalentes &lt;PriceDate> en ONIX 3) y también puede ir acompañado de un precio &quot;normal&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List60">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 60">Unidad de facturación</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Por cada ejemplar del producto completo</xs:documentation>
+					<xs:documentation>Por defecto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Por página, solo para contenido imprimido en hojas sueltas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List61">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 61">Código de estado de precio</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Sin especificar</xs:documentation>
+					<xs:documentation>Por defecto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Provisional</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Firme</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List62">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 62">Código de tipo impositivo</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="H">
+				<xs:annotation>
+					<xs:documentation>Tipo superior</xs:documentation>
+					<xs:documentation>Especifica que los impuestos se aplican en un tipo superior al normal.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P">
+				<xs:annotation>
+					<xs:documentation>Impuestos pagados en origen (Italia)</xs:documentation>
+					<xs:documentation>Según la legislación fiscal de Italia, el IVA sobre los libros puede pagarse por la editorial en origen, así que las operaciones posteriores a través de la cadena de suministro están exentas de impuestos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="R">
+				<xs:annotation>
+					<xs:documentation>Tipo inferior</xs:documentation>
+					<xs:documentation>Especifica que los impuestos se aplican en un tipo inferior al normal.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="S">
+				<xs:annotation>
+					<xs:documentation>Tipo normal</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Z">
+				<xs:annotation>
+					<xs:documentation>Tipo cero</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List63">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 63">Disponibilidad del proveedor/a intermediario</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="List64">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 64">Estado de publicación</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Sin especificar</xs:documentation>
+					<xs:documentation>No se especifica el estado (a diferencia de desconocido): por defecto si el elemento &lt;PublishingStatus> no se envió. Destinado también para su uso en aplicaciones en las cuales el elemento se considera obligatorio, pero el remitente del mensaje ONIX elige no transmitir información de estado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Cancelado</xs:documentation>
+					<xs:documentation>El producto se anunció y posteriormente se abandonó; el elemento &lt;PublicationDate> no debe enviarse.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Próximo</xs:documentation>
+					<xs:documentation>Todavía no se publicó, debe ir acompañado de la fecha prevista en &lt;PublicationDate>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Aplazado indefinidamente</xs:documentation>
+					<xs:documentation>El producto se anunció y posteriormente se pospuso sin fecha de publicación prevista; el elemento &lt;Publication Date> (ONIX 2.1) o su bloque de fecha equivalente en ONIX 3.0 no deben enviarse.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Activo</xs:documentation>
+					<xs:documentation>El producto se publicó y sigue activo, lo que significa que la editorial aceptará pedidos, aunque se desconoce si estará o no disponible de manera inmediata. En este caso, véase &lt;SupplyDetail>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>El producto ya no nos pertenece</xs:documentation>
+					<xs:documentation>La propiedad del producto se transfirió a otra editorial (con los detalles de la editorial absorbente, si procede en PR.19 (ONIX 2.1) O P.19 (ONIX 3.0)).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Agotado indefinidamente</xs:documentation>
+					<xs:documentation>n Use este código para la opción &quot;se está considerando la reimpresión&quot;. El código 06 no especifica si todavía se aceptan o no devoluciones.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Descatalogado</xs:documentation>
+					<xs:documentation>El producto estaba activo pero ahora está permanentemente inactivo, lo que significa que a) la editorial no aceptará pedidos, aunque es posible que el producto esté disponible en otro lugar dentro de la cadena de suministro, y b) el producto no estará disponible otra vez con el mismo ISBN. El código 07 normalmente supone que la editorial no aceptará devoluciones a partir de una fecha determinada.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Inactivo</xs:documentation>
+					<xs:documentation>El producto estaba activo pero ahora se está permanentemente o indefinidamente inactivo, lo que significa que la editorial no aceptará pedidos, aunque es posible que el producto esté disponible en otro lugar dentro de la cadena de suministro. El código 08 cubre ambos códigos 06 y 07 y puede usarse cuando la distinción entre estos valores es innecesaria o sin sentido.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Desconocido</xs:documentation>
+					<xs:documentation>El remitente del registro ONIX no conoce el estado de publicación actual.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Destinado al mercado de saldos de edición</xs:documentation>
+					<xs:documentation>El producto ya no está disponible desde la editorial actual, con el ISBN actual o al precio actual. Puede estar disponible para la venta a través de otro canal. El código de estado de publicación 10 &quot;Destinado al mercado de saldos de edición&quot; generalmente, pero no en todos los casos, indica que la editorial ha decidido vender el exceso de inventario del libro. Las copias de los libros que constituyen un saldo de edición frecuentemente están disponibles en la cadena de suministro a un precio reducido. No obstante, dichos restos de edición frecuentemente se venden con un identificador de producto diferente al ISBN de la copia al precio completo del libro. El código de estado de publicación 10 &quot;Destinado al mercado de saldos de edición&quot; que figura en un registro de producto determinado puede o no estar seguido de el código de estado de publicación 06 &quot;Agotado indefinidamente&quot; 07 &quot;Descatalogado&quot;: la práctica varía de una editorial a otra. Algunas editoriales pueden volver al código de estado de publicación 04 &quot;Activo&quot; si posteriormente se alcanzó un nivel de inventario deseado del producto. No se debe deducir ningún cambio en los derechos de este (o cualquier otro) valor del código de estado de publicación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Retirado de la venta</xs:documentation>
+					<xs:documentation>Retirado, por lo general por razones legales o para evitar ofender a alguien.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Retirado</xs:documentation>
+					<xs:documentation>Retirado por razones de seguridad del consumidor/a. Obsoleto, usar en su lugar el código 15.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Retirado</xs:documentation>
+					<xs:documentation>Retirado por razones de seguridad del consumidor/a.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Retirado temporalmente de la venta</xs:documentation>
+					<xs:documentation>Retirado temporalmente, por lo general por razones técnicas o de calidad. En ONIX 3.0 debe aparecer la fecha de disponibilidad prevista con el código &quot;22&quot; dentro del bloque &lt;PublishingDate>, salvo en circunstancias excepcionales en las que se desconozca fecha.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List65">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 65">Disponibilidad del producto</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Cancelado</xs:documentation>
+					<xs:documentation>Cancelado: el producto se anunció y posteriormente se abandonó.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>No disponible todavía</xs:documentation>
+					<xs:documentation>No disponible todavía (es necesario introducir &lt;ExpectedShipDate>, salvo en circunstancias excepcionales en las que se desconozca la fecha).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Esperando más unidades</xs:documentation>
+					<xs:documentation>No disponible todavía, pero se encontrará en el almacén cuando esté disponible (es necesario introducir &lt;ExpectedShipDate>, salvo en circunstancias excepcionales en las que se desconozca la fecha). Se usa particularmente para importes que se publicaron en el país de origen, pero que aún no han llegado al país de importación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>No disponible todavía, se publicará como POD</xs:documentation>
+					<xs:documentation>No disponible todavía, se publicará solo como impresión bajo demanda (POD).  Puede aplicarse o a un sucesor POD de una edición convencional existente, cuando el sucesor se publicará con un ISBN diferente (por lo general porque se aplican diferentes términos comerciales); o a un título que se publica como un POD original.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Disponible</xs:documentation>
+					<xs:documentation>Disponible a través de nosotros (no se especifica el tipo de disponibilidad).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>Disponible en el almacén</xs:documentation>
+					<xs:documentation>Disponible a través de nosotros como posición de almacén.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Para pedir</xs:documentation>
+					<xs:documentation>Disponible a través de nosotros como posición no de almacén, disponible bajo pedido especial.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>POD</xs:documentation>
+					<xs:documentation>Disponible a través de nosotros como impresión bajo demanda (POD).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>Temporalmente no disponible</xs:documentation>
+					<xs:documentation>Temporalmente no disponible: temporalmente no disponible a través de nosotros (motivo no especificado). Es necesario introducir la fecha de disponibilidad prevista como &lt;ExpectedShipDate> (ONIX 2.1) o como &lt;SupplyDate> con &lt;SupplyDateRole> codificado como &quot;08&quot; (ONIX 3.0), salvo en circunstancias excepcionales en las que se desconozca la fecha.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>Agotado</xs:documentation>
+					<xs:documentation>Posición de almacén, temporalmente agotada (es necesario introducir la fecha de disponibilidad prevista como &lt;ExpectedShipDate> (ONIX 2.1) o como &lt;SupplyDate> con &lt;SupplyDateRole> codificado como &quot;08&quot; (ONIX 3.0), salvo en circunstancias excepcionales en las que se desconozca la fecha).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>En curso de reimpresión</xs:documentation>
+					<xs:documentation>Temporalmente no disponible, en proceso de reimpresión (es necesario introducir la fecha de disponibilidad prevista como &lt;ExpectedShipDate> (ONIX 2.1) o como &lt;SupplyDate> con &lt;SupplyDateRole> codificado como &quot;08&quot; (ONIX 3.0), salvo en circunstancias excepcionales en las que se desconozca la fecha).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>En proceso de reedición</xs:documentation>
+					<xs:documentation>Temporalmente no disponible, en proceso de reedición (es necesario introducir el bloque &lt;Reissue> y la fecha de disponibilidad prevista como &lt;ExpectedShipDate> (ONIX 2.1) o como &lt;SupplyDate> con &lt;SupplyDateRole> codificado como &quot;08&quot; (ONIX 3.0), salvo en circunstancias excepcionales en las que se desconozca la fecha).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>Retirado temporalmente de la venta</xs:documentation>
+					<xs:documentation>Puede ser debido a razones técnicas o de calidad. Es necesario introducir la fecha de disponibilidad prevista como &lt;ExpectedShipDate> (ONIX 2.1) o como &lt;SupplyDate> con &lt;SupplyDateRole> codificado como &quot;08&quot; (ONIX 3.0), salvo en circunstancias excepcionales en las que se desconozca la fecha.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="40">
+				<xs:annotation>
+					<xs:documentation>No disponible (motivo no especificado)</xs:documentation>
+					<xs:documentation>No disponible a través de nosotros (por cualquier motivo).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="41">
+				<xs:annotation>
+					<xs:documentation>No disponible, reemplazado por nuevo producto</xs:documentation>
+					<xs:documentation>El producto no está disponible, pero un sucesor del producto o de la edición estará disponible a través de nosotros (identificar sucesor en &lt;RelatedProduct>).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="42">
+				<xs:annotation>
+					<xs:documentation>No disponible, otro formato disponible</xs:documentation>
+					<xs:documentation>El producto no está disponible, pero el mismo contenido está o estará disponible a través de nosotros en un formato alternativo (identificar el producto de otro formato en &lt;RelatedProduct>).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="43">
+				<xs:annotation>
+					<xs:documentation>No se suministra más a través de nosotros</xs:documentation>
+					<xs:documentation>Identificar el nuevo proveedor/a en &lt;NewSupplier>, si procede.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="44">
+				<xs:annotation>
+					<xs:documentation>Solicitar directamente</xs:documentation>
+					<xs:documentation>No disponible para la venta, solicitar directamente a la editorial.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="45">
+				<xs:annotation>
+					<xs:documentation>No se vende por separado</xs:documentation>
+					<xs:documentation>Debe venderse como parte de un conjunto (identificar el conjunto en &lt;RelatedProduct>).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="46">
+				<xs:annotation>
+					<xs:documentation>Retirado de la venta</xs:documentation>
+					<xs:documentation>Puede ser debido a razones legales o para evitar ofender a alguien.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="47">
+				<xs:annotation>
+					<xs:documentation>Destinado al mercado de saldos de edición</xs:documentation>
+					<xs:documentation>Destinado al mercado de saldos de edición.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="48">
+				<xs:annotation>
+					<xs:documentation>No disponible, reemplazado por POD</xs:documentation>
+					<xs:documentation>Descatalogado, pero una edición de impresión bajo demanda está o estará disponible con un ISBN diferente. Use solo cuando el sucesor de POD tiene un ISBN diferente, normalmente porque se aplican diferentes términos comerciales.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="49">
+				<xs:annotation>
+					<xs:documentation>Retirado</xs:documentation>
+					<xs:documentation>Retirado por razones de seguridad del consumidor/a.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="50">
+				<xs:annotation>
+					<xs:documentation>No se vende en conjunto</xs:documentation>
+					<xs:documentation>Se debe utilizar cuando una colección que no se vende en conjunto tiene su propio registro ONIX.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="51">
+				<xs:annotation>
+					<xs:documentation>n</xs:documentation>
+					<xs:documentation>El producto no está disponible, no hay sucesor del producto o formato alternativo disponible o planificado. Use este código solo cuando la editorial haya indicado que el producto está descatalogado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="52">
+				<xs:annotation>
+					<xs:documentation>No disponible, la editorial ya no vende el producto en este mercado</xs:documentation>
+					<xs:documentation>El producto no está disponible en el mercado, no hay sucesor del producto o formato alternativo disponible o planificado. Use este código cuando la editorial ha indicado que el producto está permanentemente no disponible (en el mercado), mientras permanece disponible en otro lugar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="97">
+				<xs:annotation>
+					<xs:documentation>No se recibieron actualizaciones recientes</xs:documentation>
+					<xs:documentation>El remitente no recibió ninguna actualización reciente para este producto de la editorial/proveedor/a (para usarse cuando el remitente es agregador/a de datos): la definición como &quot;reciente&quot; debe especificarse por el agregador/a o en un acuerdo entre las partes interesadas en un intercambio.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="98">
+				<xs:annotation>
+					<xs:documentation>No se reciben más actualizaciones</xs:documentation>
+					<xs:documentation>El remitente no recibe más actualizaciones de la editorial/proveedor/a del producto (para usarse cuando el remitente es agregador/a de datos).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="99">
+				<xs:annotation>
+					<xs:documentation>Ponerse en contacto con el proveedor/a</xs:documentation>
+					<xs:documentation>El remitente desconoce la disponibilidad. </xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List66">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 66">Indicador de devoluciones BISAC.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="N">
+				<xs:annotation>
+					<xs:documentation>No, no se admite la devolución</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Y">
+				<xs:annotation>
+					<xs:documentation>Sí, se admite la devolución, solo para copias completas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="S">
+				<xs:annotation>
+					<xs:documentation>Sí, se admite la devolución, libro despojado de la portada</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="C">
+				<xs:annotation>
+					<xs:documentation>Condicional</xs:documentation>
+					<xs:documentation>Contactar con la editorial para los requisitos o la autorización.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List67">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 67">Rol de la fecha de mercado </xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Fecha de publicación</xs:documentation>
+					<xs:documentation>La fecha nominal de publicación en el mercado. Si se ha impuesto un embargo estricto a las ventas al por menor antes de la fecha prevista, este hecho debe especificarse por separado como fecha de embargo. </xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Fecha de embargo</xs:documentation>
+					<xs:documentation>Si existe una prohibición de venta al por menor (&quot;embargo&quot;) en este mercado antes de cierta fecha, la fecha a partir de la que se termina esta prohibición.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List68">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 68">Estado de publicación del mercado</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Sin especificar</xs:documentation>
+					<xs:documentation>No se especifica el estado (a diferencia de desconocido): por defecto si el elemento &lt;MarketPublishingStatus> no se envió.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Cancelado</xs:documentation>
+					<xs:documentation>Se anunció el producto para su publicación en el mercado y, posteriormente, se abandonó. </xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Próximo</xs:documentation>
+					<xs:documentation>Todavía no se publicó en el mercado, debe ir acompañado de la fecha de publicación local prevista.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Aplazado indefinidamente</xs:documentation>
+					<xs:documentation>Se anunció el producto para su publicación en el mercado y, posteriormente, se pospuso sin fecha de publicación local prevista.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Activo</xs:documentation>
+					<xs:documentation>El producto se publicó en el mercado y sigue activo, lo que significa que la editorial aceptará pedidos, aunque se desconoce si estará o no disponible de manera inmediata. En este caso, véase &lt;SupplyDetail>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>El producto ya no nos pertenece</xs:documentation>
+					<xs:documentation>La responsabilidad de este producto en este mercado se transfirió a otro lugar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Agotado indefinidamente</xs:documentation>
+					<xs:documentation>El producto estaba activo pero ahora no lo está, lo que significa que (a) no se espera que las unidades disponibles en el almacén salgan al mercado, aunque es posible que el producto esté disponible en otro lugar dentro de la cadena de suministro, y (b) actualmente, no se espera que lleguen más unidades al almacén.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Descatalogado</xs:documentation>
+					<xs:documentation>El producto estaba activo pero ahora se encuentra permanentemente inactivo, lo que significa que (a) no se espera que las unidades disponibles en el almacén salgan al mercado, aunque es posible que el producto esté disponible en otro lugar dentro de la cadena de suministro, y (b) el producto no estará disponible otra vez con el mismo ISBN.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Inactivo</xs:documentation>
+					<xs:documentation>El producto estaba activo pero ahora se encuentra permanente o indefinidamente inactivo, lo que significa que no se espera que las unidades disponibles en el almacén salgan al mercado, aunque es posible que el producto esté disponible en otro lugar dentro de la cadena de suministro. El código 08 cubre ambos códigos 06 y 07 y puede usarse cuando la distinción entre estos valores es innecesaria o sin sentido.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Desconocido</xs:documentation>
+					<xs:documentation>El remitente del registro ONIX no conoce el estado de publicación actual en el mercado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Destinado al mercado de saldos de edición</xs:documentation>
+					<xs:documentation>El producto ya no está disponible en el mercado desde la editorial local, con el ISBN actual, al precio actual. Puede estar disponible para la venta a través de otro canal, generalmente, a un precio reducido.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Retirado de la venta</xs:documentation>
+					<xs:documentation>Retirado de la venta en el mercado, por lo general, por razones legales.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>No disponible en el mercado</xs:documentation>
+					<xs:documentation>Por falta de derechos sobre el producto o por otras razones, la editorial ha decidido que el producto no esté disponible en el mercado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Activo, pero no se vende por separado</xs:documentation>
+					<xs:documentation>El producto está publicado en el mercado y activo pero, por decisión de la editorial, no se vende por separado (solo en conjunto o como parte de un paquete).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Activo, con restricciones de mercado</xs:documentation>
+					<xs:documentation>El producto está publicado en el mercado y activo, pero no está disponible para todo tipo de clientes, por lo general, porque el mercado está dividido entre agentes de ventas exclusivos para diferentes segmentos del mercado. En ONIX 2.1, debe aparecer una declaración de texto libre en &lt;MarketRestrictionDetail> que describa la naturaleza de la restricción. En ONIX 3.0, se debe usar el bloque &lt;SalesRestriction> en el grupo P.24.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Retirado</xs:documentation>
+					<xs:documentation>Retirado del mercado por razones de seguridad del consumidor/a.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Retirado temporalmente de la venta</xs:documentation>
+					<xs:documentation>Temporalmente retirado de la venta en el mercado, por lo general, por razones técnicas o de calidad. En ONIX 3.0, debe aparecer la fecha de disponibilidad prevista con el código &quot;22&quot; dentro del bloque &lt;MarketPublishingDate>, salvo en circunstancias excepcionales en las que se desconozca la fecha.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List69">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 69">Rol del agente</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Agente de ventas exclusivo</xs:documentation>
+					<xs:documentation>Agente de ventas exclusivo de la editorial en un territorio concreto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Agente de ventas no exclusivo</xs:documentation>
+					<xs:documentation>Agente de ventas no exclusivo de la editorial en un territorio concreto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Editorial local</xs:documentation>
+					<xs:documentation>Editorial para un territorio concreto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Agente de ventas</xs:documentation>
+					<xs:documentation>Agente de ventas de la editorial en un territorio concreto. Usar solo cuando el estado exclusivo/no exclusivo se desconozca. Elegir código 05 o 06, según el caso, cuando sea posible.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List70">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 70">Tipo de código de la cantidad de unidades disponibles en el almacén</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Propietario</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Código de la cantidad de unidades disponibles de APA </xs:documentation>
+					<xs:documentation>Sistema de códigos definido por la Asociación de Editores de Australia (APA).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List71">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 71">Código de tipo de la restricción de ventas</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>No especificado, véase texto</xs:documentation>
+					<xs:documentation>Es necesario describir la restricción en &lt;SalesRestrictionDetail> (ONIX 2.1) o en &lt;SalesRestrictionNote> (ONIX 3.0).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Marca exclusiva/propietaria del minorista</xs:documentation>
+					<xs:documentation>A la venta solo a través de minoristas designados. El minorista debe identificarse o poner su nombre en una instancia del bloque &lt;SalesOutlet>. Usar solo cuando no sea posible asignar los códigos más explícitos 04 o 05.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Edición de suministros de oficina</xs:documentation>
+					<xs:documentation>Solo para ediciones vendidas a través de mayoristas de suministros de oficina. El(los) minorista(s) o distribuidor(es) debe(n) identificarse o poner su nombre en una instancia del bloque &lt;SalesOutlet>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Solo para uso interno de la editorial: no añadir a la lista</xs:documentation>
+					<xs:documentation>Para un ISBN que está asignado para fines internos de la editorial.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Exclusivo del minorista</xs:documentation>
+					<xs:documentation>A la venta solo a través de minoristas designados, pero no bajo marca propia. El minorista debe identificarse o poner su nombre en una instancia del bloque &lt;SalesOutlet>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Marca propia del minorista</xs:documentation>
+					<xs:documentation>A la venta solo a través de minoristas designados bajo marca o sellos propios. El minorista debe identificarse o poner su nombre en una instancia del bloque &lt;SalesOutlet>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Edición para biblioteca</xs:documentation>
+					<xs:documentation>A la venta solo para bibliotecas, no para la venta al por menor.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Edición solo para centros de enseñanza</xs:documentation>
+					<xs:documentation>Solo para la venta directa a centros de enseñanza, no para la venta al por menor.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Indiziert</xs:documentation>
+					<xs:documentation>Indexado para el mercado alemán - en Alemania se denomina &quot;indiziert&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>No permitida su venta a bibliotecas</xs:documentation>
+					<xs:documentation>Aplicable, en particular, a productos digitales para la venta al consumidor/a cuando la editorial no permita que el producto se suministre a bibliotecas, las cuales cuentan con un servicio de préstamos de libros electrónicos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Edición de difusión de noticias</xs:documentation>
+					<xs:documentation>Para ediciones que se venden exclusivamente en quioscos o puestos de periódicos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List72">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 72">Código de tipo de tesis</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Habilitationsschrift</xs:documentation>
+					<xs:documentation>Disertación profesional (tesis para la capacitación para enseñanza postdoctoral).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Dissertationsschrift</xs:documentation>
+					<xs:documentation>Tesis doctoral.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Staatsexamensarbeit</xs:documentation>
+					<xs:documentation>Tesis para examen a nivel estatal.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Magisterarbeit</xs:documentation>
+					<xs:documentation>Tesis para graduación en máster.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Diplomarbeit</xs:documentation>
+					<xs:documentation>Tesis para diploma.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Bachelorarbeit</xs:documentation>
+					<xs:documentation>Tesis para licenciatura.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Masterarbeit</xs:documentation>
+					<xs:documentation>Tesis para máster.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List73">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 73">Rol del sitio web</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>No especificado, véase la descripción del sitio web</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Sitio web corporativo de la editorial</xs:documentation>
+					<xs:documentation>Véase también los códigos 17 y 18.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Sitio web de la editorial para un trabajo determinado</xs:documentation>
+					<xs:documentation>Una página web informativa o promocional de la editorial relacionada con un trabajo determinado (libro, revista, recurso en línea u otro tipo de publicación).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Página de inicio de servicio de alojamiento en línea</xs:documentation>
+					<xs:documentation>Una página web que da acceso al contenido del servicio de alojamiento en línea en su conjunto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Página de inicio de la revista</xs:documentation>
+					<xs:documentation>Una página web que ofrece información general sobre una serie, en formato impreso, digital o ambos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Recurso en línea de la página de &quot;contenido disponible&quot; </xs:documentation>
+					<xs:documentation>Una página web que da acceso al contenido que está disponible en línea para una versión del recurso determinada. Por lo general, se usa para el contenido disponible en línea bajo los términos de suscripción.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Sitio web propio del colaborador/a</xs:documentation>
+					<xs:documentation>Una página web mantenida por un autor/a u otro colaborador/a, la cual trata de sus publicaciones y antecedentes personales.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Sitio web de la editorial relacionado con un colaborador/a determinado</xs:documentation>
+					<xs:documentation>Una página web de la editorial dedicada a un autor/a determinado u otro colaborador/a.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Sitio web de otra editorial relacionado con un colaborador/a determinado</xs:documentation>
+					<xs:documentation>Una página web dedicada a un autor/a determinado u otro colaborador/a y mantenida por una editorial diferente a la editorial del elemento descrito en el registro ONIX.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Sito web de terceros relacionado con un colaborador/a determinado</xs:documentation>
+					<xs:documentation>Una página web dedicada a un autor/a determinado u otro colaborador/a y mantenida por terceros (p. ej., un sitio de seguidores/as).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Sitio web propio de un colaborador/a para un trabajo determinado.</xs:documentation>
+					<xs:documentation>Una página web mantenida por un autor/a u otro colaborador/a y específica para un trabajo individual.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Un sitio web de otra editorial relacionado con un trabajo determinado</xs:documentation>
+					<xs:documentation>Una página web dedicada a un trabajo individual y mantenida por una editorial diferente a la editorial del elemento descrito en el registro ONIX.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Un sitio web de terceros relacionado con un trabajo determinado</xs:documentation>
+					<xs:documentation>Una página web dedicada a un trabajo individual y mantenida por terceros (p. ej., un sitio de seguidores/as).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Sitio web propio de un colaborador/a para un grupo o una serie de trabajos</xs:documentation>
+					<xs:documentation>Una página web mantenida por un autor/a u otro colaborador/a y específica para un grupo o una serie de trabajos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Sitio web de la editorial relacionado con un grupo o una serie de trabajos</xs:documentation>
+					<xs:documentation>Una página web de la editorial dedicada a un grupo o una serie de trabajos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Sitio web de otra editorial relacionado con un grupo o una serie de trabajos</xs:documentation>
+					<xs:documentation>Una página web dedicada a un grupo o una serie de trabajos y mantenida por una editorial diferente a la editorial del elemento descrito en el registro ONIX.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Sitio web de terceros relacionado con un grupo o una serie de trabajos (p. ej., un sitio de seguidores/as)</xs:documentation>
+					<xs:documentation>Una página web dedicada a un grupo o una serie de trabajos y mantenida por terceros (p. ej., un sitio de seguidores/as).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Sitio web B2B de la editorial</xs:documentation>
+					<xs:documentation>Usar en lugar del código 01 para especificar un sitio web de una editorial para usuarios/as comerciales.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Sitio web B2C de la editorial</xs:documentation>
+					<xs:documentation>Usar en lugar del código 01 para especificar el sitio web de una editorial para clientes finales (consumidores/as).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Blog del autor/a</xs:documentation>
+					<xs:documentation>Por ejemplo, la URL de Blogger o Tumblr, la URL de un sitio web creado con Wordpress o de otro blog.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Página web para la presentación/comentarios de un autor/a</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Página web para la entrevista de un autor/a</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Página web para la lectura de un autor/a</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>Página web para el material de la cubierta</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>Página web para el contenido de la muestra</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="29">
+				<xs:annotation>
+					<xs:documentation>Página web para el contenido completo</xs:documentation>
+					<xs:documentation>Usar este valor en el bloque &lt;Website> en &lt;SupplyDetail> al enviar un enlace a la página web en el cual un producto digital se encuentra disponible para su descarga o el acceso en línea. </xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>Página web para otros comentarios/debate</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>URL de transferencia</xs:documentation>
+					<xs:documentation>La URL que necesita la Biblioteca Nacional de Alemania para el acceso directo, la recogida y el almacenaje de recursos electrónicos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>Enlace del sitio web DOI</xs:documentation>
+					<xs:documentation>Enlace necesario para los libros alemanes en formato impreso (VLB) para el registro DOI y la conversión de ONIX DOI.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>Sitio web corporativo de los proveedores/as</xs:documentation>
+					<xs:documentation>Un sitio web corporativo dirigido por un distribuidor/a u otro proveedor/a (diferente a la editorial).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>Sitio web B2B del proveedor/a</xs:documentation>
+					<xs:documentation>Un sitio web operado por un distribuidor/a u otro proveedor/a (diferente a la editorial) y dirigido a clientes comerciales. </xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="35">
+				<xs:annotation>
+					<xs:documentation>Sitio web B2C del proveedor/a</xs:documentation>
+					<xs:documentation>Un sitio web dirigido por un distribuidor/a u otro proveedor/a (diferente a la editorial) y dirigido a consumidores/as. </xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="36">
+				<xs:annotation>
+					<xs:documentation>Sitio web del proveedor/a para un trabajo determinado</xs:documentation>
+					<xs:documentation>La página web de un distribuidor/a o proveedor/a que describe un trabajo determinado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="37">
+				<xs:annotation>
+					<xs:documentation>Sitio web B2B del proveedor/a para un trabajo determinado</xs:documentation>
+					<xs:documentation>Una página web del distribuidor/a o proveedor/a que describe un trabajo determinado y que está dirigida a clientes comerciales.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="38">
+				<xs:annotation>
+					<xs:documentation>Sitio web B2C del proveedor/a para un trabajo determinado</xs:documentation>
+					<xs:documentation>La página web del distribuidor/a o proveedor/a que describe un trabajo determinado y que está dirigida a consumidores/as.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="39">
+				<xs:annotation>
+					<xs:documentation>Sitio web del proveedor/a para un grupo o una serie de trabajos</xs:documentation>
+					<xs:documentation>La página web del distribuidor/a o proveedor/a que describe un grupo o una serie de trabajos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="40">
+				<xs:annotation>
+					<xs:documentation>La URL de la descripción completa de los metadatos</xs:documentation>
+					<xs:documentation>Por ejemplo, un registro ONIX o MARC para el producto, disponible en línea.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="41">
+				<xs:annotation>
+					<xs:documentation>La URL de la red social para un trabajo determinado o un producto</xs:documentation>
+					<xs:documentation>Por ejemplo, una URL de Facebook, Google+ o Twitter para el producto o trabajo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="42">
+				<xs:annotation>
+					<xs:documentation>La URL de la red social del autor/a</xs:documentation>
+					<xs:documentation>Por ejemplo, una página de Facebook, Google+ o Twitter.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="43">
+				<xs:annotation>
+					<xs:documentation>La URL de la red social de la editorial</xs:documentation>
+					<xs:documentation>Por ejemplo, una página de Facebook, Google+ o Twitter.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="44">
+				<xs:annotation>
+					<xs:documentation>La URL de una red social para un artículo, capítulo o elemento de contenido determinado</xs:documentation>
+					<xs:documentation>Por ejemplo, una página de Facebook, Google+ o Twitter. Usar solo en el contexto de un elemento de contenido determinado (p. ej., dentro de &lt;ContentItem>). </xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List74">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 74">Código de idioma - ISO 639-2/B</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="aar">
+				<xs:annotation>
+					<xs:documentation>Afar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="abk">
+				<xs:annotation>
+					<xs:documentation>Abkhaz</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ace">
+				<xs:annotation>
+					<xs:documentation>Achinese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ach">
+				<xs:annotation>
+					<xs:documentation>Acoli</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ada">
+				<xs:annotation>
+					<xs:documentation>Adangme</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ady">
+				<xs:annotation>
+					<xs:documentation>Adygei</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="afa">
+				<xs:annotation>
+					<xs:documentation>Afroasiático (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="afh">
+				<xs:annotation>
+					<xs:documentation>Afrihili</xs:documentation>
+					<xs:documentation>Idioma artificial.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="afr">
+				<xs:annotation>
+					<xs:documentation>Afrikaans</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ain">
+				<xs:annotation>
+					<xs:documentation>Ainu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="aka">
+				<xs:annotation>
+					<xs:documentation>Akan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="akk">
+				<xs:annotation>
+					<xs:documentation>Akkadian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="alb">
+				<xs:annotation>
+					<xs:documentation>Albanés</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ale">
+				<xs:annotation>
+					<xs:documentation>Aleut</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="alg">
+				<xs:annotation>
+					<xs:documentation>Algonquin (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="alt">
+				<xs:annotation>
+					<xs:documentation>Southern Altai</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="amh">
+				<xs:annotation>
+					<xs:documentation>Amharic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ang">
+				<xs:annotation>
+					<xs:documentation>Inglés antiguo (ca. 450-1100)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="anp">
+				<xs:annotation>
+					<xs:documentation>Angika</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="apa">
+				<xs:annotation>
+					<xs:documentation>Lenguas Apache</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ara">
+				<xs:annotation>
+					<xs:documentation>Árabe</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="arc">
+				<xs:annotation>
+					<xs:documentation>Aramaic (700-300 a. C.)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="arg">
+				<xs:annotation>
+					<xs:documentation>Aragonés</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="arm">
+				<xs:annotation>
+					<xs:documentation>Armenio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="arn">
+				<xs:annotation>
+					<xs:documentation>Mapuche</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="arp">
+				<xs:annotation>
+					<xs:documentation>Arapaho</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="art">
+				<xs:annotation>
+					<xs:documentation>Artificial (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="arw">
+				<xs:annotation>
+					<xs:documentation>Arawak</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="asm">
+				<xs:annotation>
+					<xs:documentation>Assamese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ast">
+				<xs:annotation>
+					<xs:documentation>Bable</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ath">
+				<xs:annotation>
+					<xs:documentation>Athapascan (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="aus">
+				<xs:annotation>
+					<xs:documentation>Lenguas australianas</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ava">
+				<xs:annotation>
+					<xs:documentation>Avaric</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ave">
+				<xs:annotation>
+					<xs:documentation>Avestan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="awa">
+				<xs:annotation>
+					<xs:documentation>Awadhi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="aym">
+				<xs:annotation>
+					<xs:documentation>Aymara</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="aze">
+				<xs:annotation>
+					<xs:documentation>Azerbaijani</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bad">
+				<xs:annotation>
+					<xs:documentation>Banda</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bai">
+				<xs:annotation>
+					<xs:documentation>Lenguas Bamikele</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bak">
+				<xs:annotation>
+					<xs:documentation>Bashkir</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bal">
+				<xs:annotation>
+					<xs:documentation>Baluchi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bam">
+				<xs:annotation>
+					<xs:documentation>Bambara</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ban">
+				<xs:annotation>
+					<xs:documentation>Balinese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="baq">
+				<xs:annotation>
+					<xs:documentation>Vasco/Euskara</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bas">
+				<xs:annotation>
+					<xs:documentation>Basa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bat">
+				<xs:annotation>
+					<xs:documentation>Báltico (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bej">
+				<xs:annotation>
+					<xs:documentation>Beja</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bel">
+				<xs:annotation>
+					<xs:documentation>Bielorruso</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bem">
+				<xs:annotation>
+					<xs:documentation>Bemba</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ben">
+				<xs:annotation>
+					<xs:documentation>Bengalí</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ber">
+				<xs:annotation>
+					<xs:documentation>Bereber (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bho">
+				<xs:annotation>
+					<xs:documentation>Bhojpuri</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bih">
+				<xs:annotation>
+					<xs:documentation>Bihari</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bik">
+				<xs:annotation>
+					<xs:documentation>Bikol</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bin">
+				<xs:annotation>
+					<xs:documentation>Bini</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bis">
+				<xs:annotation>
+					<xs:documentation>Bislama</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bla">
+				<xs:annotation>
+					<xs:documentation>Siksika</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bnt">
+				<xs:annotation>
+					<xs:documentation>Bantu (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bos">
+				<xs:annotation>
+					<xs:documentation>Bosnio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bra">
+				<xs:annotation>
+					<xs:documentation>Braj</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bre">
+				<xs:annotation>
+					<xs:documentation>Bretón</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="btk">
+				<xs:annotation>
+					<xs:documentation>Batak</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bua">
+				<xs:annotation>
+					<xs:documentation>Buriat</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bug">
+				<xs:annotation>
+					<xs:documentation>Bugis</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bul">
+				<xs:annotation>
+					<xs:documentation>Búlgaro</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="bur">
+				<xs:annotation>
+					<xs:documentation>Birmano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="byn">
+				<xs:annotation>
+					<xs:documentation>Blin; Bilin</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cad">
+				<xs:annotation>
+					<xs:documentation>Caddo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cai">
+				<xs:annotation>
+					<xs:documentation>Indio centroamericano (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="car">
+				<xs:annotation>
+					<xs:documentation>Carib</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cat">
+				<xs:annotation>
+					<xs:documentation>Catalán</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cau">
+				<xs:annotation>
+					<xs:documentation>Caucásico (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ceb">
+				<xs:annotation>
+					<xs:documentation>Cebuano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cel">
+				<xs:annotation>
+					<xs:documentation>Celta (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cha">
+				<xs:annotation>
+					<xs:documentation>Chamorro</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="chb">
+				<xs:annotation>
+					<xs:documentation>Chibcha</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="che">
+				<xs:annotation>
+					<xs:documentation>Chechén</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="chg">
+				<xs:annotation>
+					<xs:documentation>Chagatai</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="chi">
+				<xs:annotation>
+					<xs:documentation>Chino</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="chk">
+				<xs:annotation>
+					<xs:documentation>Truk</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="chm">
+				<xs:annotation>
+					<xs:documentation>Mari</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="chn">
+				<xs:annotation>
+					<xs:documentation>Jerga Chinook</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cho">
+				<xs:annotation>
+					<xs:documentation>Choctaw</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="chp">
+				<xs:annotation>
+					<xs:documentation>Chipewyan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="chr">
+				<xs:annotation>
+					<xs:documentation>Cheroqui</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="chu">
+				<xs:annotation>
+					<xs:documentation>Church Slavic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="chv">
+				<xs:annotation>
+					<xs:documentation>Chuvash</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="chy">
+				<xs:annotation>
+					<xs:documentation>Cheyenne</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cmc">
+				<xs:annotation>
+					<xs:documentation>Lenguas chámicas</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cop">
+				<xs:annotation>
+					<xs:documentation>Cópco</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cor">
+				<xs:annotation>
+					<xs:documentation>Córnico</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cos">
+				<xs:annotation>
+					<xs:documentation>Corso</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cpe">
+				<xs:annotation>
+					<xs:documentation>Creoles y Pidgins, basados en el inglés (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cpf">
+				<xs:annotation>
+					<xs:documentation>Creoles y Pidgins, basados en el francés (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cpp">
+				<xs:annotation>
+					<xs:documentation>Creoles y Pidgins, basados en el portugués (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cre">
+				<xs:annotation>
+					<xs:documentation>Cree</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="crh">
+				<xs:annotation>
+					<xs:documentation>Turco y Tatar de Crimea</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="crp">
+				<xs:annotation>
+					<xs:documentation>Creoles y Pidgins (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="csb">
+				<xs:annotation>
+					<xs:documentation>Kashubian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cus">
+				<xs:annotation>
+					<xs:documentation>Cushitic (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="cze">
+				<xs:annotation>
+					<xs:documentation>Checo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="dak">
+				<xs:annotation>
+					<xs:documentation>Dakota</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="dan">
+				<xs:annotation>
+					<xs:documentation>Danés</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="dar">
+				<xs:annotation>
+					<xs:documentation>Dargwa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="day">
+				<xs:annotation>
+					<xs:documentation>Dayak</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="del">
+				<xs:annotation>
+					<xs:documentation>Delaware</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="den">
+				<xs:annotation>
+					<xs:documentation>Eslavo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="dgr">
+				<xs:annotation>
+					<xs:documentation>Dogrib</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="din">
+				<xs:annotation>
+					<xs:documentation>Dinka</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="div">
+				<xs:annotation>
+					<xs:documentation>Divehi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="doi">
+				<xs:annotation>
+					<xs:documentation>Dogri</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="dra">
+				<xs:annotation>
+					<xs:documentation>Dravidian (Otro)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="dsb">
+				<xs:annotation>
+					<xs:documentation>Lower Sorbian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="dua">
+				<xs:annotation>
+					<xs:documentation>Duala</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="dum">
+				<xs:annotation>
+					<xs:documentation>Neerlandés medio (ca. 1050-1350)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="dut">
+				<xs:annotation>
+					<xs:documentation>Neerlandés; Flamenco</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="dyu">
+				<xs:annotation>
+					<xs:documentation>Dyula</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="dzo">
+				<xs:annotation>
+					<xs:documentation>Dzongkha</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="efi">
+				<xs:annotation>
+					<xs:documentation>Efik</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="egy">
+				<xs:annotation>
+					<xs:documentation>Egipcio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="eka">
+				<xs:annotation>
+					<xs:documentation>Ekajuk</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="elx">
+				<xs:annotation>
+					<xs:documentation>Elamite</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="eng">
+				<xs:annotation>
+					<xs:documentation>(España)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="enm">
+				<xs:annotation>
+					<xs:documentation>Inglés medio (1100-1500)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="epo">
+				<xs:annotation>
+					<xs:documentation>Esperanto</xs:documentation>
+					<xs:documentation>Idioma artificial.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="est">
+				<xs:annotation>
+					<xs:documentation>Estonio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ewe">
+				<xs:annotation>
+					<xs:documentation>Ewe</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ewo">
+				<xs:annotation>
+					<xs:documentation>Ewondo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="fan">
+				<xs:annotation>
+					<xs:documentation>Fang</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="fao">
+				<xs:annotation>
+					<xs:documentation>Faroese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="fat">
+				<xs:annotation>
+					<xs:documentation>Fanti</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="fij">
+				<xs:annotation>
+					<xs:documentation>Fijian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="fil">
+				<xs:annotation>
+					<xs:documentation>Filipino; Pilipino</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="fin">
+				<xs:annotation>
+					<xs:documentation>Finlandés</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="fiu">
+				<xs:annotation>
+					<xs:documentation>Fino-Ungrian (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="fon">
+				<xs:annotation>
+					<xs:documentation>Fon</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="fre">
+				<xs:annotation>
+					<xs:documentation>Francés</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="frm">
+				<xs:annotation>
+					<xs:documentation>Francés medio (ca. 1400-1600)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="fro">
+				<xs:annotation>
+					<xs:documentation>Francés antiguo (ca. 842-1400)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="frr">
+				<xs:annotation>
+					<xs:documentation>Northern Frisian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="frs">
+				<xs:annotation>
+					<xs:documentation>Eastern Frisian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="fry">
+				<xs:annotation>
+					<xs:documentation>Western Frisian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ful">
+				<xs:annotation>
+					<xs:documentation>Fula</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="fur">
+				<xs:annotation>
+					<xs:documentation>Friulian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gaa">
+				<xs:annotation>
+					<xs:documentation>Gã</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gay">
+				<xs:annotation>
+					<xs:documentation>Gayo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gba">
+				<xs:annotation>
+					<xs:documentation>Gbaya</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gem">
+				<xs:annotation>
+					<xs:documentation>Germánicas (Otras)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="geo">
+				<xs:annotation>
+					<xs:documentation>Georgian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ger">
+				<xs:annotation>
+					<xs:documentation>Alemán</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gez">
+				<xs:annotation>
+					<xs:documentation>Etíope (Ge&apos;ez)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gil">
+				<xs:annotation>
+					<xs:documentation>Gilbertese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gla">
+				<xs:annotation>
+					<xs:documentation>Escocés, gaélico</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gle">
+				<xs:annotation>
+					<xs:documentation>Irlandés</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="glg">
+				<xs:annotation>
+					<xs:documentation>Gallego</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="glv">
+				<xs:annotation>
+					<xs:documentation>Manx</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gmh">
+				<xs:annotation>
+					<xs:documentation>Alto alemán medio (ca. 1050-1500)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="goh">
+				<xs:annotation>
+					<xs:documentation>Alto alemán antiguo (ca. 750-1050)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gon">
+				<xs:annotation>
+					<xs:documentation>Gondi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gor">
+				<xs:annotation>
+					<xs:documentation>Gorontalo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="got">
+				<xs:annotation>
+					<xs:documentation>Gothic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="grb">
+				<xs:annotation>
+					<xs:documentation>Grebo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="grc">
+				<xs:annotation>
+					<xs:documentation>Griego antiguo (hasta 1453)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gre">
+				<xs:annotation>
+					<xs:documentation>Griego moderno (1453-)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="grn">
+				<xs:annotation>
+					<xs:documentation>Guaraní</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gsw">
+				<xs:annotation>
+					<xs:documentation>Alemán Suizo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="guj">
+				<xs:annotation>
+					<xs:documentation>Gujarati</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gwi">
+				<xs:annotation>
+					<xs:documentation>Gwich&apos;in</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="hai">
+				<xs:annotation>
+					<xs:documentation>Haida</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="hat">
+				<xs:annotation>
+					<xs:documentation>Haitian French Creole</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="hau">
+				<xs:annotation>
+					<xs:documentation>Hausa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="haw">
+				<xs:annotation>
+					<xs:documentation>Hawaiano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="heb">
+				<xs:annotation>
+					<xs:documentation>Hebreo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="her">
+				<xs:annotation>
+					<xs:documentation>Herero</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="hil">
+				<xs:annotation>
+					<xs:documentation>Hiligaynon</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="him">
+				<xs:annotation>
+					<xs:documentation>Himachali</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="hin">
+				<xs:annotation>
+					<xs:documentation>Hindi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="hit">
+				<xs:annotation>
+					<xs:documentation>Hittite</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="hmn">
+				<xs:annotation>
+					<xs:documentation>Hmong</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="hmo">
+				<xs:annotation>
+					<xs:documentation>Hiri Motu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="hrv">
+				<xs:annotation>
+					<xs:documentation>Croata</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="hsb">
+				<xs:annotation>
+					<xs:documentation>Upper Sorbian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="hun">
+				<xs:annotation>
+					<xs:documentation>Húngaro</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="hup">
+				<xs:annotation>
+					<xs:documentation>Hupa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="iba">
+				<xs:annotation>
+					<xs:documentation>Iban</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ibo">
+				<xs:annotation>
+					<xs:documentation>Igbo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ice">
+				<xs:annotation>
+					<xs:documentation>Islandés</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ido">
+				<xs:annotation>
+					<xs:documentation>Ido</xs:documentation>
+					<xs:documentation>Idioma artificial.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="iii">
+				<xs:annotation>
+					<xs:documentation>Sichuan Yi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ijo">
+				<xs:annotation>
+					<xs:documentation>Ijo</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="iku">
+				<xs:annotation>
+					<xs:documentation>Inuktitut</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ile">
+				<xs:annotation>
+					<xs:documentation>Interlingue</xs:documentation>
+					<xs:documentation>Idioma artificial.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ilo">
+				<xs:annotation>
+					<xs:documentation>Iloko</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ina">
+				<xs:annotation>
+					<xs:documentation>Interlingua (International Auxiliary Language Association)</xs:documentation>
+					<xs:documentation>Idioma artificial.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="inc">
+				<xs:annotation>
+					<xs:documentation>Indic (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ind">
+				<xs:annotation>
+					<xs:documentation>Indonesio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ine">
+				<xs:annotation>
+					<xs:documentation>Indo-Europeo (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="inh">
+				<xs:annotation>
+					<xs:documentation>Ingush</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ipk">
+				<xs:annotation>
+					<xs:documentation>Inupiaq</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ira">
+				<xs:annotation>
+					<xs:documentation>Iraní (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="iro">
+				<xs:annotation>
+					<xs:documentation>Iroquoian (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ita">
+				<xs:annotation>
+					<xs:documentation>Italiano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="jav">
+				<xs:annotation>
+					<xs:documentation>Javanese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="jbo">
+				<xs:annotation>
+					<xs:documentation>Lojban</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="jpn">
+				<xs:annotation>
+					<xs:documentation>Japonés</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="jpr">
+				<xs:annotation>
+					<xs:documentation>Judeo-persa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="jrb">
+				<xs:annotation>
+					<xs:documentation>Judeo-árabe</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kaa">
+				<xs:annotation>
+					<xs:documentation>Kara-Kalpak</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kab">
+				<xs:annotation>
+					<xs:documentation>Kabyle</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kac">
+				<xs:annotation>
+					<xs:documentation>Kachin</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kal">
+				<xs:annotation>
+					<xs:documentation>Kalâtdlisut; Greenlandic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kam">
+				<xs:annotation>
+					<xs:documentation>Kamba</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kan">
+				<xs:annotation>
+					<xs:documentation>Kannada</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kar">
+				<xs:annotation>
+					<xs:documentation>Karen</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kas">
+				<xs:annotation>
+					<xs:documentation>Kashmiri</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kau">
+				<xs:annotation>
+					<xs:documentation>Kanuri</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kaw">
+				<xs:annotation>
+					<xs:documentation>Kawi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kaz">
+				<xs:annotation>
+					<xs:documentation>Kazajo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kbd">
+				<xs:annotation>
+					<xs:documentation>Kabardian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kha">
+				<xs:annotation>
+					<xs:documentation>Khasi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="khi">
+				<xs:annotation>
+					<xs:documentation>Khoisan (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="khm">
+				<xs:annotation>
+					<xs:documentation>Khmer</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kho">
+				<xs:annotation>
+					<xs:documentation>Khotanese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kik">
+				<xs:annotation>
+					<xs:documentation>Kikuyu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kin">
+				<xs:annotation>
+					<xs:documentation>Kinyarwanda</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kir">
+				<xs:annotation>
+					<xs:documentation>Kyrghiz</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kmb">
+				<xs:annotation>
+					<xs:documentation>Kimbundu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kok">
+				<xs:annotation>
+					<xs:documentation>Konkani</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kom">
+				<xs:annotation>
+					<xs:documentation>Komi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kon">
+				<xs:annotation>
+					<xs:documentation>Kongo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kor">
+				<xs:annotation>
+					<xs:documentation>Coreano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kos">
+				<xs:annotation>
+					<xs:documentation>Kusaie</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kpe">
+				<xs:annotation>
+					<xs:documentation>Kpelle</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="krc">
+				<xs:annotation>
+					<xs:documentation>Karachay-Balkar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="krl">
+				<xs:annotation>
+					<xs:documentation>Karellan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kro">
+				<xs:annotation>
+					<xs:documentation>Kru</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kru">
+				<xs:annotation>
+					<xs:documentation>Kurukh</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kua">
+				<xs:annotation>
+					<xs:documentation>Kuanyama</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kum">
+				<xs:annotation>
+					<xs:documentation>Kumyk</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kur">
+				<xs:annotation>
+					<xs:documentation>Kurdo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="kut">
+				<xs:annotation>
+					<xs:documentation>Kutenai</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lad">
+				<xs:annotation>
+					<xs:documentation>Ladino</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lah">
+				<xs:annotation>
+					<xs:documentation>Lahnda</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lam">
+				<xs:annotation>
+					<xs:documentation>Lamba</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lao">
+				<xs:annotation>
+					<xs:documentation>Lao</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lat">
+				<xs:annotation>
+					<xs:documentation>Latín</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lav">
+				<xs:annotation>
+					<xs:documentation>Letón</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lez">
+				<xs:annotation>
+					<xs:documentation>Lezgian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lim">
+				<xs:annotation>
+					<xs:documentation>Limburgish</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lin">
+				<xs:annotation>
+					<xs:documentation>Lingala</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lit">
+				<xs:annotation>
+					<xs:documentation>Lituano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lol">
+				<xs:annotation>
+					<xs:documentation>Mongo-Nkundu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="loz">
+				<xs:annotation>
+					<xs:documentation>Lozi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ltz">
+				<xs:annotation>
+					<xs:documentation>Letzeburgesch</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lua">
+				<xs:annotation>
+					<xs:documentation>Luba-Lulua</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lub">
+				<xs:annotation>
+					<xs:documentation>Luba-Katanga</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lug">
+				<xs:annotation>
+					<xs:documentation>Ganda</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lui">
+				<xs:annotation>
+					<xs:documentation>Luiseño</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lun">
+				<xs:annotation>
+					<xs:documentation>Lunda</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="luo">
+				<xs:annotation>
+					<xs:documentation>Luo (Kenya y Tanzania)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="lus">
+				<xs:annotation>
+					<xs:documentation>Lushai</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mac">
+				<xs:annotation>
+					<xs:documentation>Macedonio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mad">
+				<xs:annotation>
+					<xs:documentation>Madurese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mag">
+				<xs:annotation>
+					<xs:documentation>Magahi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mah">
+				<xs:annotation>
+					<xs:documentation>Marshall</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mai">
+				<xs:annotation>
+					<xs:documentation>Maithili</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mak">
+				<xs:annotation>
+					<xs:documentation>Makasar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mal">
+				<xs:annotation>
+					<xs:documentation>Malayalam</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="man">
+				<xs:annotation>
+					<xs:documentation>Mandingo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mao">
+				<xs:annotation>
+					<xs:documentation>Maori</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="map">
+				<xs:annotation>
+					<xs:documentation>Austronesian (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mar">
+				<xs:annotation>
+					<xs:documentation>Marathi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mas">
+				<xs:annotation>
+					<xs:documentation>Masai</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="may">
+				<xs:annotation>
+					<xs:documentation>Malay</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mdf">
+				<xs:annotation>
+					<xs:documentation>Moksha</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mdr">
+				<xs:annotation>
+					<xs:documentation>Mandar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="men">
+				<xs:annotation>
+					<xs:documentation>Mende</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mga">
+				<xs:annotation>
+					<xs:documentation>Irlandés medio (ca 1100-1550)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mic">
+				<xs:annotation>
+					<xs:documentation>Micmac</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="min">
+				<xs:annotation>
+					<xs:documentation>Minangkabau</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mis">
+				<xs:annotation>
+					<xs:documentation>Lenguas sin código específico</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mkh">
+				<xs:annotation>
+					<xs:documentation>Mon-Khmer (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mlg">
+				<xs:annotation>
+					<xs:documentation>Malagasy</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mlt">
+				<xs:annotation>
+					<xs:documentation>Maltese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mnc">
+				<xs:annotation>
+					<xs:documentation>Manchu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mni">
+				<xs:annotation>
+					<xs:documentation>Manipuri</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mno">
+				<xs:annotation>
+					<xs:documentation>Manobo languages</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="moh">
+				<xs:annotation>
+					<xs:documentation>Mohawk</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mol">
+				<xs:annotation>
+					<xs:documentation>Moldavo</xs:documentation>
+					<xs:documentation>OBSOLETO - usar rum.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mon">
+				<xs:annotation>
+					<xs:documentation>Mongolian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mos">
+				<xs:annotation>
+					<xs:documentation>Mooré; Mossi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mul">
+				<xs:annotation>
+					<xs:documentation>Lenguas múltiples</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mun">
+				<xs:annotation>
+					<xs:documentation>Munda (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mus">
+				<xs:annotation>
+					<xs:documentation>Creek</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mwl">
+				<xs:annotation>
+					<xs:documentation>Mirandese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mwr">
+				<xs:annotation>
+					<xs:documentation>Marwari</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="myn">
+				<xs:annotation>
+					<xs:documentation>Idiomas mayas</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="myv">
+				<xs:annotation>
+					<xs:documentation>Erzya</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nah">
+				<xs:annotation>
+					<xs:documentation>Nahuatl</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nai">
+				<xs:annotation>
+					<xs:documentation>Indio norteamericano (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nap">
+				<xs:annotation>
+					<xs:documentation>Italiano napolitano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nau">
+				<xs:annotation>
+					<xs:documentation>Nauru</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nav">
+				<xs:annotation>
+					<xs:documentation>Navajo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nbl">
+				<xs:annotation>
+					<xs:documentation>Ndebele (Sudáfrica)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nde">
+				<xs:annotation>
+					<xs:documentation>Ndebele (Zimbabwe)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ndo">
+				<xs:annotation>
+					<xs:documentation>Ndonga</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nds">
+				<xs:annotation>
+					<xs:documentation>Low German</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nep">
+				<xs:annotation>
+					<xs:documentation>Nepali</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="new">
+				<xs:annotation>
+					<xs:documentation>Newari</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nia">
+				<xs:annotation>
+					<xs:documentation>Nias</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nic">
+				<xs:annotation>
+					<xs:documentation>Niger-Kordofanian (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="niu">
+				<xs:annotation>
+					<xs:documentation>Niuean</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nno">
+				<xs:annotation>
+					<xs:documentation>Noruego nynorsk</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nob">
+				<xs:annotation>
+					<xs:documentation>Noruego Bokmål</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nog">
+				<xs:annotation>
+					<xs:documentation>Nogai</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="non">
+				<xs:annotation>
+					<xs:documentation>Nórdico antiguo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nor">
+				<xs:annotation>
+					<xs:documentation>Noruego</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nqo">
+				<xs:annotation>
+					<xs:documentation>N&apos;Ko</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nso">
+				<xs:annotation>
+					<xs:documentation>Northern Sotho</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nub">
+				<xs:annotation>
+					<xs:documentation>Nubian languages</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nwc">
+				<xs:annotation>
+					<xs:documentation>Classical Newari; Old Newari</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nya">
+				<xs:annotation>
+					<xs:documentation>Nyanja</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nym">
+				<xs:annotation>
+					<xs:documentation>Nyamwesi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nyn">
+				<xs:annotation>
+					<xs:documentation>Nyankole</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nyo">
+				<xs:annotation>
+					<xs:documentation>Nyoro</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="nzi">
+				<xs:annotation>
+					<xs:documentation>Nzima</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="oci">
+				<xs:annotation>
+					<xs:documentation>Occitano (post-1500)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="oji">
+				<xs:annotation>
+					<xs:documentation>Ojibwa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ori">
+				<xs:annotation>
+					<xs:documentation>Oriya</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="orm">
+				<xs:annotation>
+					<xs:documentation>Oromo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="osa">
+				<xs:annotation>
+					<xs:documentation>Osage</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="oss">
+				<xs:annotation>
+					<xs:documentation>Ossetic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ota">
+				<xs:annotation>
+					<xs:documentation>Turco, otomano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="oto">
+				<xs:annotation>
+					<xs:documentation>Otomian languages</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="paa">
+				<xs:annotation>
+					<xs:documentation>Papuan (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="pag">
+				<xs:annotation>
+					<xs:documentation>Pangasinan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="pal">
+				<xs:annotation>
+					<xs:documentation>Pahlavi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="pam">
+				<xs:annotation>
+					<xs:documentation>Pampanga</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="pan">
+				<xs:annotation>
+					<xs:documentation>Panjabi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="pap">
+				<xs:annotation>
+					<xs:documentation>Papiamento</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="pau">
+				<xs:annotation>
+					<xs:documentation>Palauan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="peo">
+				<xs:annotation>
+					<xs:documentation>Persa antiguo (ca. 600-400 a. C.)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="per">
+				<xs:annotation>
+					<xs:documentation>Persa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="phi">
+				<xs:annotation>
+					<xs:documentation>Filipino (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="phn">
+				<xs:annotation>
+					<xs:documentation>Fenicio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="pli">
+				<xs:annotation>
+					<xs:documentation>Pali</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="pol">
+				<xs:annotation>
+					<xs:documentation>Polaco</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="pon">
+				<xs:annotation>
+					<xs:documentation>Ponape</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="por">
+				<xs:annotation>
+					<xs:documentation>Portugués</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="pra">
+				<xs:annotation>
+					<xs:documentation>Prakrit languages</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="pro">
+				<xs:annotation>
+					<xs:documentation>Provençal, Old (to 1500); Occitan, Old (to 1500)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="pus">
+				<xs:annotation>
+					<xs:documentation>Pushto</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="qar">
+				<xs:annotation>
+					<xs:documentation>Aranés</xs:documentation>
+					<xs:documentation>Código local ONIX.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="qav">
+				<xs:annotation>
+					<xs:documentation>Valenciano</xs:documentation>
+					<xs:documentation>Código local ONIX.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="que">
+				<xs:annotation>
+					<xs:documentation>Quechua</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="raj">
+				<xs:annotation>
+					<xs:documentation>Rajasthani</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="rap">
+				<xs:annotation>
+					<xs:documentation>Rapanui</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="rar">
+				<xs:annotation>
+					<xs:documentation>Rarotongan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="roa">
+				<xs:annotation>
+					<xs:documentation>Romances (Otras)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="roh">
+				<xs:annotation>
+					<xs:documentation>Raeto-Romance</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="rom">
+				<xs:annotation>
+					<xs:documentation>Romany</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="rum">
+				<xs:annotation>
+					<xs:documentation>Rumano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="run">
+				<xs:annotation>
+					<xs:documentation>Rundi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="rup">
+				<xs:annotation>
+					<xs:documentation>Aromanian; Arumanian; Macedo-Romanian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="rus">
+				<xs:annotation>
+					<xs:documentation>Ruso</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sad">
+				<xs:annotation>
+					<xs:documentation>Sandawe</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sag">
+				<xs:annotation>
+					<xs:documentation>Sango</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sah">
+				<xs:annotation>
+					<xs:documentation>Yakut</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sai">
+				<xs:annotation>
+					<xs:documentation>Indio de sudamérica (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sal">
+				<xs:annotation>
+					<xs:documentation>Salishan languages</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sam">
+				<xs:annotation>
+					<xs:documentation>Samaritan Aramaic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="san">
+				<xs:annotation>
+					<xs:documentation>Sánscrito</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sas">
+				<xs:annotation>
+					<xs:documentation>Sasak</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sat">
+				<xs:annotation>
+					<xs:documentation>Santali</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="scc">
+				<xs:annotation>
+					<xs:documentation>Serbio</xs:documentation>
+					<xs:documentation>OBSOLETO - usar srp.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="scn">
+				<xs:annotation>
+					<xs:documentation>Siciliano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sco">
+				<xs:annotation>
+					<xs:documentation>Escocés</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="scr">
+				<xs:annotation>
+					<xs:documentation>Croata</xs:documentation>
+					<xs:documentation>OBSOLETO - usar hrv.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sel">
+				<xs:annotation>
+					<xs:documentation>Selkup</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sem">
+				<xs:annotation>
+					<xs:documentation>Semítico (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sga">
+				<xs:annotation>
+					<xs:documentation>Irlandés antiguo (hasta 1100)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sgn">
+				<xs:annotation>
+					<xs:documentation>Lenguas gestuales</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="shn">
+				<xs:annotation>
+					<xs:documentation>Shan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sid">
+				<xs:annotation>
+					<xs:documentation>Sidamo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sin">
+				<xs:annotation>
+					<xs:documentation>Sinhalese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sio">
+				<xs:annotation>
+					<xs:documentation>Siouan (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sit">
+				<xs:annotation>
+					<xs:documentation>Sino-Tibetan (Otros)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sla">
+				<xs:annotation>
+					<xs:documentation>Eslavas (Otras)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="slo">
+				<xs:annotation>
+					<xs:documentation>Eslovaco</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="slv">
+				<xs:annotation>
+					<xs:documentation>Esloveno</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sma">
+				<xs:annotation>
+					<xs:documentation>Southern Sami</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sme">
+				<xs:annotation>
+					<xs:documentation>Northern Sami</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="smi">
+				<xs:annotation>
+					<xs:documentation>Sami</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="smj">
+				<xs:annotation>
+					<xs:documentation>Lule Sami</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="smn">
+				<xs:annotation>
+					<xs:documentation>Inari Sami</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="smo">
+				<xs:annotation>
+					<xs:documentation>Samoan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sms">
+				<xs:annotation>
+					<xs:documentation>Skolt Sami</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sna">
+				<xs:annotation>
+					<xs:documentation>Shona</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="snd">
+				<xs:annotation>
+					<xs:documentation>Sindhi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="snk">
+				<xs:annotation>
+					<xs:documentation>Soninke</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sog">
+				<xs:annotation>
+					<xs:documentation>Sogdian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="som">
+				<xs:annotation>
+					<xs:documentation>Somali</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="son">
+				<xs:annotation>
+					<xs:documentation>Songhai</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sot">
+				<xs:annotation>
+					<xs:documentation>Sotho</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="spa">
+				<xs:annotation>
+					<xs:documentation>Español/Castellano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="srd">
+				<xs:annotation>
+					<xs:documentation>Sardo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="srn">
+				<xs:annotation>
+					<xs:documentation>Sranan Tongo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="srp">
+				<xs:annotation>
+					<xs:documentation>Serbio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="srr">
+				<xs:annotation>
+					<xs:documentation>Serer</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ssa">
+				<xs:annotation>
+					<xs:documentation>Nilo-Saharan (Other)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ssw">
+				<xs:annotation>
+					<xs:documentation>Swazi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="suk">
+				<xs:annotation>
+					<xs:documentation>Sukuma</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sun">
+				<xs:annotation>
+					<xs:documentation>Sundanese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sus">
+				<xs:annotation>
+					<xs:documentation>Susu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="sux">
+				<xs:annotation>
+					<xs:documentation>Sumerian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="swa">
+				<xs:annotation>
+					<xs:documentation>Swahili</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="swe">
+				<xs:annotation>
+					<xs:documentation>Sueco</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="syc">
+				<xs:annotation>
+					<xs:documentation>Sirio clásico</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="syr">
+				<xs:annotation>
+					<xs:documentation>Syriac</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tah">
+				<xs:annotation>
+					<xs:documentation>Tahitian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tai">
+				<xs:annotation>
+					<xs:documentation>Tai (Other)</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tam">
+				<xs:annotation>
+					<xs:documentation>Tamil</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tat">
+				<xs:annotation>
+					<xs:documentation>Tatar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tel">
+				<xs:annotation>
+					<xs:documentation>Telugu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tem">
+				<xs:annotation>
+					<xs:documentation>Temne</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ter">
+				<xs:annotation>
+					<xs:documentation>Terena</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tet">
+				<xs:annotation>
+					<xs:documentation>Tetum</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tgk">
+				<xs:annotation>
+					<xs:documentation>Tajiki</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tgl">
+				<xs:annotation>
+					<xs:documentation>Tagalog</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tha">
+				<xs:annotation>
+					<xs:documentation>Tailandés</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tib">
+				<xs:annotation>
+					<xs:documentation>Tibetano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tig">
+				<xs:annotation>
+					<xs:documentation>Tigré</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tir">
+				<xs:annotation>
+					<xs:documentation>Tigrinya</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tiv">
+				<xs:annotation>
+					<xs:documentation>Tiv</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tkl">
+				<xs:annotation>
+					<xs:documentation>Tokelauan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tlh">
+				<xs:annotation>
+					<xs:documentation>Klingon; tlhIngan-Hol</xs:documentation>
+					<xs:documentation>Idioma artificial.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tli">
+				<xs:annotation>
+					<xs:documentation>Tlingit</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tmh">
+				<xs:annotation>
+					<xs:documentation>Tamashek</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tog">
+				<xs:annotation>
+					<xs:documentation>Tonga (Nyasa)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ton">
+				<xs:annotation>
+					<xs:documentation>Tongan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tpi">
+				<xs:annotation>
+					<xs:documentation>Tok Pisin</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tsi">
+				<xs:annotation>
+					<xs:documentation>Tsimshian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tsn">
+				<xs:annotation>
+					<xs:documentation>Tswana</xs:documentation>
+					<xs:documentation>También conocido como Setswana.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tso">
+				<xs:annotation>
+					<xs:documentation>Tsonga</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tuk">
+				<xs:annotation>
+					<xs:documentation>Turkmen</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tum">
+				<xs:annotation>
+					<xs:documentation>Tumbuka</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tup">
+				<xs:annotation>
+					<xs:documentation>Tupi languages</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tur">
+				<xs:annotation>
+					<xs:documentation>Turco</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tut">
+				<xs:annotation>
+					<xs:documentation>Altaic (Otros)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tvl">
+				<xs:annotation>
+					<xs:documentation>Tuvaluan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="twi">
+				<xs:annotation>
+					<xs:documentation>Twi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="tyv">
+				<xs:annotation>
+					<xs:documentation>Tuvinian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="udm">
+				<xs:annotation>
+					<xs:documentation>Udmurt</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="uga">
+				<xs:annotation>
+					<xs:documentation>Ugaritic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="uig">
+				<xs:annotation>
+					<xs:documentation>Uighur</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ukr">
+				<xs:annotation>
+					<xs:documentation>Ucraniano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="umb">
+				<xs:annotation>
+					<xs:documentation>Umbundu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="und">
+				<xs:annotation>
+					<xs:documentation>No determinado</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="urd">
+				<xs:annotation>
+					<xs:documentation>Urdu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="uzb">
+				<xs:annotation>
+					<xs:documentation>Uzbek</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="vai">
+				<xs:annotation>
+					<xs:documentation>Vai</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ven">
+				<xs:annotation>
+					<xs:documentation>Venda</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="vie">
+				<xs:annotation>
+					<xs:documentation>Vietnamita</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="vol">
+				<xs:annotation>
+					<xs:documentation>Volapük</xs:documentation>
+					<xs:documentation>Idioma artificial.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="vot">
+				<xs:annotation>
+					<xs:documentation>Votic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="wak">
+				<xs:annotation>
+					<xs:documentation>Wakashan languages</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="wal">
+				<xs:annotation>
+					<xs:documentation>Walamo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="war">
+				<xs:annotation>
+					<xs:documentation>Waray</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="was">
+				<xs:annotation>
+					<xs:documentation>Washo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="wel">
+				<xs:annotation>
+					<xs:documentation>Galés</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="wen">
+				<xs:annotation>
+					<xs:documentation>Sorbian languages</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="wln">
+				<xs:annotation>
+					<xs:documentation>Walloon</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="wol">
+				<xs:annotation>
+					<xs:documentation>Wolof</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="xal">
+				<xs:annotation>
+					<xs:documentation>Kalmyk</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="xho">
+				<xs:annotation>
+					<xs:documentation>Xhosa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="yao">
+				<xs:annotation>
+					<xs:documentation>Yao</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="yap">
+				<xs:annotation>
+					<xs:documentation>Yapese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="yid">
+				<xs:annotation>
+					<xs:documentation>Yiddish</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="yor">
+				<xs:annotation>
+					<xs:documentation>Yoruba</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ypk">
+				<xs:annotation>
+					<xs:documentation>Yupik languages</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="zap">
+				<xs:annotation>
+					<xs:documentation>Zapotec</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="zbl">
+				<xs:annotation>
+					<xs:documentation>Blissymbols; Blissymbolics; Bliss</xs:documentation>
+					<xs:documentation>Idioma artificial.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="zen">
+				<xs:annotation>
+					<xs:documentation>Zenaga</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="zha">
+				<xs:annotation>
+					<xs:documentation>Zhuang</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="znd">
+				<xs:annotation>
+					<xs:documentation>Zande</xs:documentation>
+					<xs:documentation>Nombre colectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="zul">
+				<xs:annotation>
+					<xs:documentation>Zulu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="zun">
+				<xs:annotation>
+					<xs:documentation>Zuni</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="zxx">
+				<xs:annotation>
+					<xs:documentation>Sin contenido lingüístico</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="zza">
+				<xs:annotation>
+					<xs:documentation>Zaza; Dimili; Dimli; Kirdki; Kirmanjki; Zazaki</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List75">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 75">Función de fecha de persona</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="007">
+				<xs:annotation>
+					<xs:documentation>Fecha de nacimiento</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="008">
+				<xs:annotation>
+					<xs:documentation>Fecha de fallecimiento</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List76">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 76">Valor de característica de formato de producto - códigos de región para DVD</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="0">
+				<xs:annotation>
+					<xs:documentation>Todas las regiones</xs:documentation>
+					<xs:documentation>DVD o Blu-Ray.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="1">
+				<xs:annotation>
+					<xs:documentation>Región DVD 1</xs:documentation>
+					<xs:documentation>EE. UU., territorios de EE. UU., Canadá.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="2">
+				<xs:annotation>
+					<xs:documentation>Región DVD 2</xs:documentation>
+					<xs:documentation>Japón, Europa, Sudáfrica, Oriente Medio (incluido Egipto).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="3">
+				<xs:annotation>
+					<xs:documentation>Región DVD 3</xs:documentation>
+					<xs:documentation>Asia Oriental, Hong Kong, Macao, Corea del Sur y Taiwan.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="4">
+				<xs:annotation>
+					<xs:documentation>Región DVD 4</xs:documentation>
+					<xs:documentation>Australia, Nueva Zelanda, Islas del Pacífico, Centroamérica, México, Sudamérica y Caribe.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="5">
+				<xs:annotation>
+					<xs:documentation>Región DVD 5</xs:documentation>
+					<xs:documentation>Europa del Este (la antigua Unión Soviética), subcontinente indio, África, Corea del norte y Mongolia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="6">
+				<xs:annotation>
+					<xs:documentation>Región DVD 6</xs:documentation>
+					<xs:documentation>República Popular China (excepto Macao y Hong Kong).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="7">
+				<xs:annotation>
+					<xs:documentation>Región DVD 7</xs:documentation>
+					<xs:documentation>Reservado para uso futuro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="8">
+				<xs:annotation>
+					<xs:documentation>Región DVD 8</xs:documentation>
+					<xs:documentation>Lugares internacionales especiales: aviones, barcos, etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A">
+				<xs:annotation>
+					<xs:documentation>Región Blu-Ray A</xs:documentation>
+					<xs:documentation>América del Norte, América Central, Sudamérica, Japón, Taiwan, Corea del Norte, Corea del Sur, Hong Kong y Asia Sudoriental.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B">
+				<xs:annotation>
+					<xs:documentation>Región Blu-Ray B</xs:documentation>
+					<xs:documentation>La mayor parte de Europa, Groenlandia, territorios franceses de ultramar, Oriente Medio, África, Australia, Nueva Zelanda, más toda Oceanía.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="C">
+				<xs:annotation>
+					<xs:documentation>Región Blu-Ray C</xs:documentation>
+					<xs:documentation>India, Bangladesh, Nepal, China continental, Pakistán, Rusia, Ucrania, Bielorrusia, Asia Central y del Sur.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List77">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 77">Nivel educativo en EE. UU.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="P">
+				<xs:annotation>
+					<xs:documentation>Preschool</xs:documentation>
+					<xs:documentation>0-4 años.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="K">
+				<xs:annotation>
+					<xs:documentation>Kindergarten</xs:documentation>
+					<xs:documentation>5 años. </xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="1">
+				<xs:annotation>
+					<xs:documentation>First Grade</xs:documentation>
+					<xs:documentation>6 años.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="2">
+				<xs:annotation>
+					<xs:documentation>Second Grade</xs:documentation>
+					<xs:documentation>7 años. </xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="3">
+				<xs:annotation>
+					<xs:documentation>Third Grade</xs:documentation>
+					<xs:documentation>8 años.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="4">
+				<xs:annotation>
+					<xs:documentation>Fourth Grade</xs:documentation>
+					<xs:documentation>9 años.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="5">
+				<xs:annotation>
+					<xs:documentation>Fifth Grade</xs:documentation>
+					<xs:documentation>10 años.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="6">
+				<xs:annotation>
+					<xs:documentation>Sixth Grade</xs:documentation>
+					<xs:documentation>11 años.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="7">
+				<xs:annotation>
+					<xs:documentation>Seventh Grade</xs:documentation>
+					<xs:documentation>12 años.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="8">
+				<xs:annotation>
+					<xs:documentation>Eighth Grade</xs:documentation>
+					<xs:documentation>13 años.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="9">
+				<xs:annotation>
+					<xs:documentation>Ninth Grade</xs:documentation>
+					<xs:documentation>High School Freshman - 14 años.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Tenth Grade</xs:documentation>
+					<xs:documentation>High School Sophomore - 15 años.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Eleventh Grade</xs:documentation>
+					<xs:documentation>High School Junior - 16 años.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Twelfth Grade</xs:documentation>
+					<xs:documentation>High School Senior - 17 años.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>College Freshmand</xs:documentation>
+					<xs:documentation>18 años.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>College Sophomore</xs:documentation>
+					<xs:documentation>Por lo general, 19 años de edad.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>College Junior</xs:documentation>
+					<xs:documentation>20 años.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>College Senior</xs:documentation>
+					<xs:documentation>21 años.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>College Graduate Student</xs:documentation>
+					<xs:documentation>22 o más años.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List78">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 78">Detalle del formato del producto</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="A101">
+				<xs:annotation>
+					<xs:documentation>Formato CD audio estándar</xs:documentation>
+					<xs:documentation>Formato de CD &quot;red book&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A102">
+				<xs:annotation>
+					<xs:documentation>Formato SACD super audio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A103">
+				<xs:annotation>
+					<xs:documentation>Formato MP3</xs:documentation>
+					<xs:documentation>Archivo MPEG-1/2 Audio Layer III.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A104">
+				<xs:annotation>
+					<xs:documentation>Formato WAV</xs:documentation>
+					<xs:documentation>Archivo de audio Waveform.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A105">
+				<xs:annotation>
+					<xs:documentation>Formato Real Audio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A106">
+				<xs:annotation>
+					<xs:documentation>WMA</xs:documentation>
+					<xs:documentation>Formato Windows Media Audio.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A107">
+				<xs:annotation>
+					<xs:documentation>AAC</xs:documentation>
+					<xs:documentation>Formato Advanced Audio Coding.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A108">
+				<xs:annotation>
+					<xs:documentation>Ogg/Vorbis</xs:documentation>
+					<xs:documentation>Formato Vorbis audio en un contenedor Ogg.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A109">
+				<xs:annotation>
+					<xs:documentation>Audible</xs:documentation>
+					<xs:documentation>Formato de audio propio de Audible.com.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A110">
+				<xs:annotation>
+					<xs:documentation>FLAC</xs:documentation>
+					<xs:documentation>Free lossless audio codec.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A111">
+				<xs:annotation>
+					<xs:documentation>AIFF</xs:documentation>
+					<xs:documentation>Formato Audio Interchangeable File.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A112">
+				<xs:annotation>
+					<xs:documentation>ALAC</xs:documentation>
+					<xs:documentation>Apple Lossless Audio Codec.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A201">
+				<xs:annotation>
+					<xs:documentation>DAISY 2: audio completo solo con título (sin navegación)</xs:documentation>
+					<xs:documentation>Obsoleto, no cumple el estándar DAISY 2. Utilice códigos de audiolibro convencionales en su lugar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A202">
+				<xs:annotation>
+					<xs:documentation>DAISY 2: audio completo con navegación (sin texto)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A203">
+				<xs:annotation>
+					<xs:documentation>DAISY 2: audio completo con navegación y texto parcial</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A204">
+				<xs:annotation>
+					<xs:documentation>DAISY 2: audio completo con navegación y texto completo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A205">
+				<xs:annotation>
+					<xs:documentation>DAISY 2: texto completo con navegación y audio parcial</xs:documentation>
+					<xs:documentation>Algunos sistemas de lectura pueden ofrecer audio completo mediante síntesis de voz.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A206">
+				<xs:annotation>
+					<xs:documentation>DAISY 2: texto completo con navegación, pero sin audio</xs:documentation>
+					<xs:documentation>Algunos sistemas de lectura pueden ofrecer audio completo mediante síntesis de voz.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A207">
+				<xs:annotation>
+					<xs:documentation>DAISY 3: audio completo solo con título (sin navegación)</xs:documentation>
+					<xs:documentation>Obsoleto, no cumple el estándar DAISY 3. Utilice códigos de audiolibro convencionales en su lugar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A208">
+				<xs:annotation>
+					<xs:documentation>DAISY 3: audio completo con navegación (sin texto)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A209">
+				<xs:annotation>
+					<xs:documentation>DAISY 3: audio completo con navegación y texto parcial</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A210">
+				<xs:annotation>
+					<xs:documentation>DAISY 3: audio completo con navegación y texto completo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A211">
+				<xs:annotation>
+					<xs:documentation>DAISY 3: texto completo con navegación y audio parcial</xs:documentation>
+					<xs:documentation>Algunos sistemas de lectura pueden ofrecer audio completo mediante síntesis de voz.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A212">
+				<xs:annotation>
+					<xs:documentation>DAISY 3: texto completo con navegación (sin audio)</xs:documentation>
+					<xs:documentation>Algunos sistemas de lectura pueden ofrecer audio completo mediante síntesis de voz.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A301">
+				<xs:annotation>
+					<xs:documentation>Audio autónomo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A302">
+				<xs:annotation>
+					<xs:documentation>Audio para lectura acompañada</xs:documentation>
+					<xs:documentation>Audio cuya finalidad exclusiva es ser utilizado junto con la versión impresa de un libro. Un producto para el público infantil en la mayoría de los casos. Habitualmente contiene instrucciones como &quot;pasa la página ahora&quot; y otras referencias al producto impreso. Se suele vender empaquetado junto con la copia impresa.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A303">
+				<xs:annotation>
+					<xs:documentation>Audio de acompañamiento</xs:documentation>
+					<xs:documentation>Audio destinado al acompañamiento musical, p. ej. &quot;Music minus one&quot;, etc., a menudo para aprender música. Incluye audio para acompañamiento vocal para aprender música o para actividades tipo karaoke.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A304">
+				<xs:annotation>
+					<xs:documentation>Audio para hablar al mismo tiempo</xs:documentation>
+					<xs:documentation>Audio destinado al aprendizaje de idiomas, incluye discursos con silencios que el oyente debe rellenar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B101">
+				<xs:annotation>
+					<xs:documentation>Mass market (rack) paperback</xs:documentation>
+					<xs:documentation>En Norteamérica, un tipo de libro en rústica caracterizada parcialmente por el tamaño de página (típicamente 4¼ x 7 1/8 pulgadas) y parcialmente por el mercado objetivo y las condiciones de comercio. El elemento Product Form debe tener el valor BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B102">
+				<xs:annotation>
+					<xs:documentation>Trade paperback (EE. UU.)</xs:documentation>
+					<xs:documentation>En Norteamérica, un tipo de libro en rústica caracterizado parcialmente por el tamaño de página y por el mercado objetivo y las condiciones de comercio. También conocido como &quot;libro en rústica de calidad&quot;, incluye libros de texto. La mayoría de los libros en rústica vendidos en Norteamérica salvo &quot;mass market&quot; (B101) y &quot;tall rack&quot; (B107) se describen correctamente con este código. El elemento Product Form debe tener el valor BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B103">
+				<xs:annotation>
+					<xs:documentation>Digest format paperback</xs:documentation>
+					<xs:documentation>En Norteamérica, un tipo de libro en rústica caracterizado por el tamaño de página, generalmente utilizado para libros infantiles. El elemento Product Form debe tener el valor BC. Nota: se mostraba erróneamente como B102 (entrada duplicada) en la Edición 3.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B104">
+				<xs:annotation>
+					<xs:documentation>Libro en rústica en formato A</xs:documentation>
+					<xs:documentation>En el Reino Unido, un tipo de libro en rústica caracterizado por el tamaño de página (normalmente 178 x 111 mm aprox.). El elemento Product Form debe tener el valor BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B105">
+				<xs:annotation>
+					<xs:documentation>Libro en rústica en formato B</xs:documentation>
+					<xs:documentation>En el Reino Unido, un tipo de libro en rústica caracterizado por el tamaño de página (normalmente 198 x 129 mm aprox.). El elemento Product Form debe tener el valor BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B106">
+				<xs:annotation>
+					<xs:documentation>Trade paperback (Reino Unido)</xs:documentation>
+					<xs:documentation>En el Reino Unido, un tipo de libro en rústica caracterizado parcialmente por su tamaño (habitualmente con las dimensiones de un libro de tapa dura tradicional), y a menudo utilizado para originales en rústica. El elemento Product Form debe tener el valor BC (reemplaza el &quot;formato-C&quot; de la anterior Lista 8).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B107">
+				<xs:annotation>
+					<xs:documentation>Tall rack paperback (EE. UU.)</xs:documentation>
+					<xs:documentation>En Norteamérica, un tipo de libro en rústica caracterizado parcialmente por el tamaño de página y parcialmente por el mercado objetivo y las condiciones de comercio. El elemento Product Form debe tener el valor BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B108">
+				<xs:annotation>
+					<xs:documentation>A5:Tankobon</xs:documentation>
+					<xs:documentation>210 x 148 mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B109">
+				<xs:annotation>
+					<xs:documentation>JIS B5:Tankobon</xs:documentation>
+					<xs:documentation>Tamaño de serie B japonés, 257 x 182 mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B110">
+				<xs:annotation>
+					<xs:documentation>JIS B6:Tankobon</xs:documentation>
+					<xs:documentation>Tamaño de serie B japonés, 182 x 128 mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B111">
+				<xs:annotation>
+					<xs:documentation>A6:Bunko</xs:documentation>
+					<xs:documentation>148 x 105 mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B112">
+				<xs:annotation>
+					<xs:documentation>B40-dori Shinsho</xs:documentation>
+					<xs:documentation>Formato japonés, 182 x 103 mm o 173 x 105 mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B113">
+				<xs:annotation>
+					<xs:documentation>Pocket (Suecia)</xs:documentation>
+					<xs:documentation>Formato en rústica específico en Suecia. El elemento Product Form debe tener el valor BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B114">
+				<xs:annotation>
+					<xs:documentation>Storpocket (Suecia)</xs:documentation>
+					<xs:documentation>Formato en rústica específico en Suecia. El elemento Product Form debe tener el valor BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B115">
+				<xs:annotation>
+					<xs:documentation>Kartonnage (Suecia)</xs:documentation>
+					<xs:documentation>Formato de tapa dura específico en Suecia. El elemento Product Form debe tener el valor BB.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B116">
+				<xs:annotation>
+					<xs:documentation>Flexband (Suecia)</xs:documentation>
+					<xs:documentation>Formato en rústica específico en Suecia. El elemento Product Form debe tener el valor BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B117">
+				<xs:annotation>
+					<xs:documentation>Mook</xs:documentation>
+					<xs:documentation>En Japón, un libro en rústica con el formato de una revista pero que se vende como un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B118">
+				<xs:annotation>
+					<xs:documentation>Dwarsligger</xs:documentation>
+					<xs:documentation>Conocido en España como &quot;Librino&quot;. Libro en rústica en un formato propio particularmente compacto con páginas en impresión apaisada en papel muy fino y con encuadernación horizontal (vea www.dwarsligger.com).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B119">
+				<xs:annotation>
+					<xs:documentation>Tamaño 46</xs:documentation>
+					<xs:documentation>Formato japonés: 188 x 127 mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B120">
+				<xs:annotation>
+					<xs:documentation>Tamaño 46-Henkei</xs:documentation>
+					<xs:documentation>Formato japonés.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B121">
+				<xs:annotation>
+					<xs:documentation>A4</xs:documentation>
+					<xs:documentation>297 x 210 mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B122">
+				<xs:annotation>
+					<xs:documentation>Tamaño A4-Henkei</xs:documentation>
+					<xs:documentation>Formato japonés.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B123">
+				<xs:annotation>
+					<xs:documentation>Tamaño A5-Henkei</xs:documentation>
+					<xs:documentation>Formato japonés.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B124">
+				<xs:annotation>
+					<xs:documentation>Tamaño B5-Henkei</xs:documentation>
+					<xs:documentation>Formato japonés.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B125">
+				<xs:annotation>
+					<xs:documentation>Tamaño B6-Henkei</xs:documentation>
+					<xs:documentation>Formato japonés.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B126">
+				<xs:annotation>
+					<xs:documentation>Tamaño AB</xs:documentation>
+					<xs:documentation>257 x 210 mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B127">
+				<xs:annotation>
+					<xs:documentation>Tamaño JIS B7</xs:documentation>
+					<xs:documentation>Tamaño de serie B japonesa, 128 x 91 mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B128">
+				<xs:annotation>
+					<xs:documentation>Tamaño Kiku</xs:documentation>
+					<xs:documentation>Formato japonés, 218 x 152 mm o 227 x 152 mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B129">
+				<xs:annotation>
+					<xs:documentation>Tamaño Kiku-Henkei</xs:documentation>
+					<xs:documentation>Formato japonés.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B130">
+				<xs:annotation>
+					<xs:documentation>Tamaño JIS B4</xs:documentation>
+					<xs:documentation>Tamaño japonés serie B, 364 x 257 mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B201">
+				<xs:annotation>
+					<xs:documentation>Libro para colorear o unir puntos</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B202">
+				<xs:annotation>
+					<xs:documentation>Libro con desplegables</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B203">
+				<xs:annotation>
+					<xs:documentation>Libro infantil para pensar</xs:documentation>
+					<xs:documentation>OBSOLETO por ambigüedad. Utilizar B210, B214 o B215 según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B204">
+				<xs:annotation>
+					<xs:documentation>Minilibro</xs:documentation>
+					<xs:documentation>Nota: mostrado de forma incorrecta como B203 (entrada duplicada) en el número 3.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B205">
+				<xs:annotation>
+					<xs:documentation>Libro con imágenes en movimiento o folioscopio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B206">
+				<xs:annotation>
+					<xs:documentation>Libro tridimensional</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B207">
+				<xs:annotation>
+					<xs:documentation>Libro perfumado o con olores</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B208">
+				<xs:annotation>
+					<xs:documentation>Libro con sonidos o ruidos</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B209">
+				<xs:annotation>
+					<xs:documentation>Libro de pegatinas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B210">
+				<xs:annotation>
+					<xs:documentation>Libro con texturas</xs:documentation>
+					<xs:documentation>Libro cuyas páginas presentan una variedad de texturas diseñadas para estimular la exploración táctil: vea también B214 y B215.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B211">
+				<xs:annotation>
+					<xs:documentation>Libro juguete o troquelado</xs:documentation>
+					<xs:documentation>OBSOLETO. Usar B212 o B213 según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B212">
+				<xs:annotation>
+					<xs:documentation>Libro troquelado</xs:documentation>
+					<xs:documentation>Libro que está recortado en una forma distintiva no lineal o en el que se han recortado agujeros o formas en el interior. &quot;Troquelado&quot; se usa aquí como una taquigrafía conveniente y no implica una limitación estricta a un proceso determinado de producción.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B213">
+				<xs:annotation>
+					<xs:documentation>Libro juguete</xs:documentation>
+					<xs:documentation>Libro que es también un juguete o que incorpora un juguete como parte fundamental. Sin embargo, no utilizar B213 para un producto con múltiples objetos que incluya un libro y un juguete como objetos separados.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B214">
+				<xs:annotation>
+					<xs:documentation>Libro de tacto suave</xs:documentation>
+					<xs:documentation>Libro cuya cubierta tiene un acabado con una textura suave, normalmente en la anterior.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B215">
+				<xs:annotation>
+					<xs:documentation>Libro con recortables de fieltro</xs:documentation>
+					<xs:documentation>Libro con piezas de fieltro desmontables y páginas con texturas donde pueden añadirse estas piezas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B221">
+				<xs:annotation>
+					<xs:documentation>Libro de imágenes</xs:documentation>
+					<xs:documentation>Libro de imágenes para niños: utilizar con el código de formulario de producto pertinente.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B222">
+				<xs:annotation>
+					<xs:documentation>Libro &quot;Carousel&quot;</xs:documentation>
+					<xs:documentation>(también llamado libro &quot;Star&quot;). El tratamiento fiscal de los productos puede variar con respecto a productos con códigos similares, como el libro juguete o el libro tridimensional).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B301">
+				<xs:annotation>
+					<xs:documentation>Hojas intercambiables: hojas y archivador</xs:documentation>
+					<xs:documentation>Usar con el código BD de formulario de producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B302">
+				<xs:annotation>
+					<xs:documentation>Hojas intercambiables: solo el archivador</xs:documentation>
+					<xs:documentation>Usar con el código BD de formulario de producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B303">
+				<xs:annotation>
+					<xs:documentation>Hojas intercambiables: solo las hojas</xs:documentation>
+					<xs:documentation>Usar con el código BD de formulario de producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B304">
+				<xs:annotation>
+					<xs:documentation>Cosido</xs:documentation>
+					<xs:documentation>También llamado suturado; para ver &quot;cosido con hilo&quot;, vea el código B310.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B305">
+				<xs:annotation>
+					<xs:documentation>No cosido o con encuadernado arráfica</xs:documentation>
+					<xs:documentation>Incluye &quot;encuadernado perfecto&quot;, &quot;con pegamento&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B306">
+				<xs:annotation>
+					<xs:documentation>Encuadernación de biblioteca</xs:documentation>
+					<xs:documentation>Encuadernación reforzada para bibliotecas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B307">
+				<xs:annotation>
+					<xs:documentation>Encuadernación reforzada</xs:documentation>
+					<xs:documentation>Encuadernación reforzada, no necesariamente para bibliotecas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B308">
+				<xs:annotation>
+					<xs:documentation>Media encuadernación</xs:documentation>
+					<xs:documentation>Debe ir acompañado por un código que especifique un material, p.ej. &quot;media encuadernación en piel auténtica&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B309">
+				<xs:annotation>
+					<xs:documentation>Encuadernación en cuarto</xs:documentation>
+					<xs:documentation>Debe ir acompañado por un código que especifique un material &quot;encuadernación en cuarto en piel auténtica&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B310">
+				<xs:annotation>
+					<xs:documentation>Cosido</xs:documentation>
+					<xs:documentation>También llamado &quot;grapado&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B311">
+				<xs:annotation>
+					<xs:documentation>Encuadernación con peine</xs:documentation>
+					<xs:documentation>Formas redondas u ovaladas de plástico configuradas en forma de pinza: utilizar con el código de formulario de producto BE.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B312">
+				<xs:annotation>
+					<xs:documentation>Wire-O</xs:documentation>
+					<xs:documentation>Doble espiral metálica: utilizar con el código de formulario de producto BE.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B313">
+				<xs:annotation>
+					<xs:documentation>Alambre oculto</xs:documentation>
+					<xs:documentation>Encuadernación Wire-O recubierta: utilizar con el código de formulario de producto BE.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B401">
+				<xs:annotation>
+					<xs:documentation>Tela sobre cubiertas</xs:documentation>
+					<xs:documentation>También llamado tejido o lino sobre cubiertas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B402">
+				<xs:annotation>
+					<xs:documentation>Papel sobre las tapas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B403">
+				<xs:annotation>
+					<xs:documentation>Piel auténtica</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B404">
+				<xs:annotation>
+					<xs:documentation>Piel imitación</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B405">
+				<xs:annotation>
+					<xs:documentation>Cuero regenerado</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B406">
+				<xs:annotation>
+					<xs:documentation>Vitela</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B407">
+				<xs:annotation>
+					<xs:documentation>Plástico</xs:documentation>
+					<xs:documentation>OBSOLETO. Utilizar B412 o B413 nuevo según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B408">
+				<xs:annotation>
+					<xs:documentation>Vinilo</xs:documentation>
+					<xs:documentation>OBSOLETO. Utilizar B412 o B414 nuevo según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B409">
+				<xs:annotation>
+					<xs:documentation>Tela</xs:documentation>
+					<xs:documentation>Tela, no necesariamente sobre las cubiertas; vea B401.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B410">
+				<xs:annotation>
+					<xs:documentation>Tela de imitación</xs:documentation>
+					<xs:documentation>Símil-tela español.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B411">
+				<xs:annotation>
+					<xs:documentation>Terciopelo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B412">
+				<xs:annotation>
+					<xs:documentation>Portada flexible de plástico o vinilo</xs:documentation>
+					<xs:documentation>También llamado &quot;flexibound&quot;: utilizar con el código de formulario de producto BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B413">
+				<xs:annotation>
+					<xs:documentation>Cubierta de plástico</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B414">
+				<xs:annotation>
+					<xs:documentation>Cubierta de vinilo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B415">
+				<xs:annotation>
+					<xs:documentation>Cubierta laminada</xs:documentation>
+					<xs:documentation>Libro, material de laminado no especificado: utilizar L101 para &quot;todo el producto laminado&quot;, p.ej., una página de mapa o póster laminados.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B501">
+				<xs:annotation>
+					<xs:documentation>Con sobrecubierta</xs:documentation>
+					<xs:documentation>Tipo no especificado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B502">
+				<xs:annotation>
+					<xs:documentation>Con sobrecubierta impresa</xs:documentation>
+					<xs:documentation>Usado para distinguir de B503.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B503">
+				<xs:annotation>
+					<xs:documentation>Con sobrecubierta translúcida</xs:documentation>
+					<xs:documentation>Con cubierta protectora translúcida de papel o plástico.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B504">
+				<xs:annotation>
+					<xs:documentation>Con solapas</xs:documentation>
+					<xs:documentation>Para libros en rústica con solapas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B505">
+				<xs:annotation>
+					<xs:documentation>Con índice de pestañas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B506">
+				<xs:annotation>
+					<xs:documentation>Con cinta(s) marcapáginas</xs:documentation>
+					<xs:documentation>Si el número de marcapáginas es relevante, se puede exponer como texto libre en &lt;ProductFormDescription>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B507">
+				<xs:annotation>
+					<xs:documentation>Con cremallera</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B508">
+				<xs:annotation>
+					<xs:documentation>Con cierre de botón a presión</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B509">
+				<xs:annotation>
+					<xs:documentation>Encuadernación a la holandesa</xs:documentation>
+					<xs:documentation>También conocido como bodes de encuadernación flexible.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B510">
+				<xs:annotation>
+					<xs:documentation>Canto rugoso</xs:documentation>
+					<xs:documentation>Con los bordes cortados de forma desigual, sin cuidado y de forma irregular. También conocido como borde intonso o borde con barbas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B601">
+				<xs:annotation>
+					<xs:documentation>Libro para dar la vuelta</xs:documentation>
+					<xs:documentation>Libro en el cual la mitad del contenido está impreso de forma inversa para leerse al revés.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B602">
+				<xs:annotation>
+					<xs:documentation>Formato manga sin adaptación de lectura</xs:documentation>
+					<xs:documentation>Manga con páginas y secuencias ordenadas según el original japonés, pero con texto occidental.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B701">
+				<xs:annotation>
+					<xs:documentation>Braille no contraído de Reino Unido</xs:documentation>
+					<xs:documentation>Solo letras sueltas. Se ha identificado anteriormente como Braille de Reino Unido de grado 1.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B702">
+				<xs:annotation>
+					<xs:documentation>Braille contraído de Reino Unido</xs:documentation>
+					<xs:documentation>Con algunas combinaciones de letras. Antes se identificaba como braille del Reino Unido de grado 2.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B703">
+				<xs:annotation>
+					<xs:documentation>Braille de EEUU</xs:documentation>
+					<xs:documentation>OBSOLETO. Utilizar B704 o B705 según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B704">
+				<xs:annotation>
+					<xs:documentation>Braille no contraído de EE.UU.</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B705">
+				<xs:annotation>
+					<xs:documentation>Braille contraído de EE.UU.</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B706">
+				<xs:annotation>
+					<xs:documentation>Braille inglés unificado</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B707">
+				<xs:annotation>
+					<xs:documentation>Alfabeto Moon</xs:documentation>
+					<xs:documentation>Alfabeto en relieve Moon, usado por lectores con deficiencias visuales y con dificultades con el Braille.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D101">
+				<xs:annotation>
+					<xs:documentation>Formato Real Video</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D102">
+				<xs:annotation>
+					<xs:documentation>Formato Quicktime</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D103">
+				<xs:annotation>
+					<xs:documentation>Formato AVI</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D104">
+				<xs:annotation>
+					<xs:documentation>Formato Windows Media Video</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D105">
+				<xs:annotation>
+					<xs:documentation>MPEG-4</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D201">
+				<xs:annotation>
+					<xs:documentation>MS-DOS</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto D* pertinente. Tenga en cuenta que se puede dar más detalle de los requisitos del sistema en un compuesto de características de formulario de producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D202">
+				<xs:annotation>
+					<xs:documentation>Windows</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto D* pertinente; vea la nota en D201.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D203">
+				<xs:annotation>
+					<xs:documentation>Macintosh</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto D* pertinente; vea la nota en D201.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D204">
+				<xs:annotation>
+					<xs:documentation>UNIX / LINUX</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto D* pertinente; vea la nota en D201.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D205">
+				<xs:annotation>
+					<xs:documentation>Otros sistemas operativos</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto D* pertinente; vea la nota en D201.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D206">
+				<xs:annotation>
+					<xs:documentation>Palm OS</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto D* pertinente; vea la nota en D201.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D207">
+				<xs:annotation>
+					<xs:documentation>Windows Mobile</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto D* pertinente; vea la nota en D201.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D301">
+				<xs:annotation>
+					<xs:documentation>Microsoft XBox</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto DE o DB según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D302">
+				<xs:annotation>
+					<xs:documentation>Nintendo Gameboy Color</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto DE o DB según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D303">
+				<xs:annotation>
+					<xs:documentation>Nintendo Gameboy Advanced</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto DE o DB según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D304">
+				<xs:annotation>
+					<xs:documentation>Nintendo Gameboy</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto DE o DB según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D305">
+				<xs:annotation>
+					<xs:documentation>Nintendo Gamecube</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto DE o DB según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D306">
+				<xs:annotation>
+					<xs:documentation>Nintendo 64</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto DE o DB según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D307">
+				<xs:annotation>
+					<xs:documentation>Sega Dreamcast</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto DE o DB según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D308">
+				<xs:annotation>
+					<xs:documentation>Sega Genesis/Megadrive</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto DE o DB según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D309">
+				<xs:annotation>
+					<xs:documentation>Sega Saturn</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto DE o DB según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D310">
+				<xs:annotation>
+					<xs:documentation>Sony PlayStation 1</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto DE o DB según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D311">
+				<xs:annotation>
+					<xs:documentation>Sony PlayStation 2</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto DE o DB según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D312">
+				<xs:annotation>
+					<xs:documentation>Nintendo Dual Screen</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D313">
+				<xs:annotation>
+					<xs:documentation>Sony PlayStation 3</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D314">
+				<xs:annotation>
+					<xs:documentation>Xbox 360</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D315">
+				<xs:annotation>
+					<xs:documentation>Nintendo Wii</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D316">
+				<xs:annotation>
+					<xs:documentation>Sony PlayStation Portable (PSP)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E200">
+				<xs:annotation>
+					<xs:documentation>Ajustable</xs:documentation>
+					<xs:documentation>Utilizar cuando un tipo particular de publicación electrónica (especificado en &lt;EpubType>) tenga variantes tanto ajustables como de formato fijo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E201">
+				<xs:annotation>
+					<xs:documentation>Formato fijo</xs:documentation>
+					<xs:documentation>Utilizar cuando un tipo particular de publicación electrónica (especificado en &lt;EpubType>) tenga variantes tanto ajustables como de formato fijo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E202">
+				<xs:annotation>
+					<xs:documentation>Disponible sin conexión</xs:documentation>
+					<xs:documentation>Todos los recursos de publicaciones electrónicas se incluyen en el paquete de publicaciones electrónicas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E203">
+				<xs:annotation>
+					<xs:documentation>Se requiere conexión a una red</xs:documentation>
+					<xs:documentation>Las publicaciones electrónicas requieren conexión a una red para acceder a algunos recursos (p.ej., un libro electrónico mejorado donde los clips de vídeo no se guardan dentro del &quot;paquete&quot; de publicaciones electrónicas en sí, sino que se distribuyen a través de la conexión a Internet).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="L101">
+				<xs:annotation>
+					<xs:documentation>Laminado</xs:documentation>
+					<xs:documentation>Producto entero laminado (p.ej., mapa laminado, gráfica desplegable, póster, etc.): utilizar B415 para libros con la portada laminada.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P101">
+				<xs:annotation>
+					<xs:documentation>Calendario de escritorio</xs:documentation>
+					<xs:documentation>Utilizar con el código de formulario de producto PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P102">
+				<xs:annotation>
+					<xs:documentation>Minicalendario</xs:documentation>
+					<xs:documentation>Utilizar con el código de formulario de producto PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P103">
+				<xs:annotation>
+					<xs:documentation>Agenda de citas</xs:documentation>
+					<xs:documentation>Utilizar con el código de formulario de producto PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P104">
+				<xs:annotation>
+					<xs:documentation>Calendario diario</xs:documentation>
+					<xs:documentation>Utilizar con el código de formulario de producto PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P105">
+				<xs:annotation>
+					<xs:documentation>Calendario en forma de póster</xs:documentation>
+					<xs:documentation>Utilizar con el código de formulario de producto PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P106">
+				<xs:annotation>
+					<xs:documentation>Calendario de pared</xs:documentation>
+					<xs:documentation>Utilizar con el código de formulario de producto PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P107">
+				<xs:annotation>
+					<xs:documentation>Calendario perpetuo</xs:documentation>
+					<xs:documentation>Utilizar con el código de formulario de producto PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P108">
+				<xs:annotation>
+					<xs:documentation>Calendario de Adviento</xs:documentation>
+					<xs:documentation>Utilizar con el código de formulario de producto PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P109">
+				<xs:annotation>
+					<xs:documentation>Calendario marcapáginas</xs:documentation>
+					<xs:documentation>Utilizar con el código de formulario de producto PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P110">
+				<xs:annotation>
+					<xs:documentation>Calendario escolarl</xs:documentation>
+					<xs:documentation>Utilizar con el código de formulario de producto PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P111">
+				<xs:annotation>
+					<xs:documentation>Calendario para proyectos</xs:documentation>
+					<xs:documentation>Utilizar con el código de formulario de producto PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P112">
+				<xs:annotation>
+					<xs:documentation>Almanaque</xs:documentation>
+					<xs:documentation>Utilizar con el código de formulario de producto PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P113">
+				<xs:annotation>
+					<xs:documentation>Otro tipo de calendario</xs:documentation>
+					<xs:documentation>Calendario que no es ninguno de los tipos especificados: utilizar con el código del formulario de producto PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P114">
+				<xs:annotation>
+					<xs:documentation>Otro tipo de producto para calendarios o agendas</xs:documentation>
+					<xs:documentation>Producto que está asociado o bien es un accesorio de un calendario o agenda, p.ej., un soporte para un calendario, o bien un encaje para un organizador: utilizar con el código de formulario de producto PC o PS.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P201">
+				<xs:annotation>
+					<xs:documentation>Tapa dura (artículos de papelería)</xs:documentation>
+					<xs:documentation>Artículos de papelería en formato de libro de tapa dura.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P202">
+				<xs:annotation>
+					<xs:documentation>Encuadernación rústica (artículos de papelería)</xs:documentation>
+					<xs:documentation>Artículo de papelería en formato de libro con encuadernación rústica.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P203">
+				<xs:annotation>
+					<xs:documentation>Encuadernación en espiral (artículo de papelería)</xs:documentation>
+					<xs:documentation>Artículo de papelería en formato de libro con encuadernación en espiral.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P204">
+				<xs:annotation>
+					<xs:documentation>Encuadernación en piel o de lujo (artículo de papelería)</xs:documentation>
+					<xs:documentation>Artículo de papelería en formato de libro con encuadernación en piel o de lujo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="V201">
+				<xs:annotation>
+					<xs:documentation>PAL</xs:documentation>
+					<xs:documentation>Estándar de televisión para vídeo y DVD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="V202">
+				<xs:annotation>
+					<xs:documentation>NTSC</xs:documentation>
+					<xs:documentation>Estándar de televisión para vídeo y DVD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="V203">
+				<xs:annotation>
+					<xs:documentation>SECAM</xs:documentation>
+					<xs:documentation>Estándar de televisión para vídeo y DVD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List79">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 79">Característica de formato del producto</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Color de la cubierta</xs:documentation>
+					<xs:documentation>Para ver los valores de las características de formato del producto vea la lista de códigos 98.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Color del borde de la página</xs:documentation>
+					<xs:documentation>Para ver los valores de las características de formato del producto vea la lista de códigos 98.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Fuente del texto</xs:documentation>
+					<xs:documentation>La fuente principal usada en el cuerpo del texto, cuando hay un aspecto significante de una descripción del producto, p. ej, para algunas Biblias e impresiones grandes. La descripción de las características de formato del producto es un texto que especifica el tamaño de la fuente y, si lo desea, la tipografía.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Material de portada especial</xs:documentation>
+					<xs:documentation>Para ver los valores de las características de formulario de producto vaya a la lista de códigos 99.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Región de DVD</xs:documentation>
+					<xs:documentation>Para ver los valores de las características de formulario de producto vaya a la lista de códigos 76.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Requisitos del sistema operativo</xs:documentation>
+					<xs:documentation>Sistema operativo de un ordenador o un dispositivo portátil necesario para un producto digital, que incluya detalles de la versión si procede. El valor de la característica de formulario de producto acompañante es un código de la lista 176. Los detalles de la versión, en caso que procedan, se realizan en la descripción de característica de formulario de producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Otros requisitos del sistema</xs:documentation>
+					<xs:documentation>Otros requisitos de sistema para un producto digital, descrito por texto libre en la descripción de característica de formulario de producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Compatibilidad con el dispositivo &quot;señala y escucha&quot;</xs:documentation>
+					<xs:documentation>Indica compatibilidad con el dispositivo patentado &quot;señala y escucha&quot; como Ting Pen (http://www.ting.eu) o el iSmart Touch y Read Pen. Estos dispositivos escanean códigos invisibles especialmente impresos en las páginas para identificar el libro y la posición de la palabra y se la leen. Debería darse el nombre de un dispositivo compatible (o rango de dispositivos) en &lt;ProductFormFeatureDescription>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Detalle de la accesibilidad de la publicación electrónica</xs:documentation>
+					<xs:documentation>Para los códigos &lt;ProductFormFeatureValue>, vea la lista de códigos 196.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Versión de formato de la publicación electrónica</xs:documentation>
+					<xs:documentation>Para formato de archivo de libro electrónico versionados (o en algunos casos, dispositivo), p. ej., EPUB 2 y EPUB 3. &lt;ProductFormFeatureValue> debería contener un número de versión. Utilizar solo con ONIX 3.0; en cambio, en ONIX 2.1, utilizar &lt;EpubTypeVersion>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Advertencia de peligro de ahogamiento CPSIA</xs:documentation>
+					<xs:documentation>OBSOLETO. Utilizar el código 12 y la lista 143.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Advertencia de peligro de ahogamiento CPSIA</xs:documentation>
+					<xs:documentation>Advertencia por peligro por asfixia necesaria según la Ley estadounidense de Mejora para la Seguridad de Productos de Consumo (CPSIA) de 2008. Necesario, si procede, para productos vendidos en EE.UU. El valor de característica de formulario del producto es un código de la lista 143. Más información puede darse en la descripción de características del formulario del producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Advertencia de peligro en la seguridad del juguete de la UE</xs:documentation>
+					<xs:documentation>El producto incluye la advertencia de peligro necesaria según la directiva de seguridad de los juguetes de la UE. El valor de características del formulario del producto es un código de la lista 184 y (para algunos de los códigos) la expresión exacta de la advertencia puede darse en la descripción de características de formulario del producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>FSC o PEFC no certificado</xs:documentation>
+					<xs:documentation>El producto no tiene ningún logo FSC o PEFC. Los elementos de la descripción y valor de las características de formulario del productos no se utilizan. Sin embargo, puede que el producto contenga una reclamación de contenido (introduzca el código 37) de sobrante pre y postconsumo (PWC) en un compuesto de característica de formulario de producto repetido.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>Certificado FSC; puro</xs:documentation>
+					<xs:documentation>El producto tiene el logo FSC (Puro, 100%). &lt;ProductFormFeatureValue> es el número de certificado, es decir, o bien en número de la cadena de custodia (COC) o bien el número de licencia de registro, que irá impreso en el libro. Formato: El número de la cadena de custodia consiste en de dos a cinco letras, COC, seis dígitos (los dígitos pueden empezar por ceros si fuera necesario) p.ej., &quot;AB-COC-001234&quot; o &quot;ABCDE-COC-123456&quot;; El número de licencia de registro es una C seguida de seis dígitos, p.ej., &quot;C005678&quot; (normalmente se mostrara con el prefijo &quot;FSC®&quot;). Por definición, el producto certificado como Puro, no contiene sobrantes ni pre ni postconsumo (PCW), así que el código tipo 31 solo puede tener lugar por sí mismo. Se pueden comprobar los números de certificado en &apos;http://info.fsc.org/&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>Certificado FSC; varias fuentes</xs:documentation>
+					<xs:documentation>El producto tiene el logo FSC (Fuentes varias, Mix). &lt;ProductFormFeatureValue> es el número de certificado, es decir, o bien en número de la cadena de custodia (COC) o bien el número de licencia de registro, que irá impreso en el libro. Formato: El número de la cadena de custodia consiste en de dos a cinco letras, COC, seis dígitos (los dígitos pueden empezar por ceros si fuera necesario) p.ej., &quot;AB-COC-001234&quot; o &quot;ABCDE-COC-123456&quot;; El número de licencia de registro es una C seguida de seis dígitos, p.ej., &quot;C005678&quot; (normalmente se mostrara con el prefijo &quot;FSC®&quot;). Puede ir acompañado de un valor de porcentaje del sobrante pre y postconsumo (PCW), que puede reportarse en otra instacia de &lt;ProductFormFeature> con el código tipo 36. Los números de certificado se pueden comprobar en http://info.fsc.org/</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>Certificado FSC; reciclado</xs:documentation>
+					<xs:documentation>El producto tiene el logo FSC (Reciclado). &lt;ProductFormFeatureValue> es el número de certificado, es decir, o bien en número de la cadena de custodia (COC) o bien el número de licencia de registro, que irá impreso en el libro. Formato: El número de la cadena de custodia consiste en de dos a cinco letras, COC, seis dígitos (los dígitos pueden empezar por ceros si fuera necesario) p.ej., &quot;AB-COC-001234&quot; o &quot;ABCDE-COC-123456&quot;; El número de licencia de registro es una C seguida de seis dígitos, p.ej., &quot;C005678&quot; (normalmente se mostrara con el prefijo &quot;FSC®&quot;). Debe ir acompañado de un valor de porcentaje del sobrante pre y postconsumo (PCW), que puede reportarse en otra instacia de &lt;ProductFormFeature> con el código tipo 36. Se pueden comprobar los números de certificado en http://info.fsc.org/&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>Certificado PEFC</xs:documentation>
+					<xs:documentation>El producto tiene el logo PEFC (certificado). &lt;ProductFormFeatureValue> es el número de cadena de custodia (COC) impreso en el libro. Puede ir acompañado de un valor de porcentaje del sobrante pre y postconsumo (PCW), que puede reportarse en otra instancia de &lt;ProductFormFeature> con el código tipo 36.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="35">
+				<xs:annotation>
+					<xs:documentation>PEFC reciclado</xs:documentation>
+					<xs:documentation>El producto tiene el logo PEFC (reciclado). &lt;ProductFormFeatureValue> es el número de cadena de custodia (COC) impreso en el libro. Debe ir acompañado de un valor de porcentaje del sobrante pre y postconsumo (PCW), que puede reportarse en otra instancia de &lt;ProductFormFeature> con el código tipo 36.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="36">
+				<xs:annotation>
+					<xs:documentation>Porcenjate de sobrante pre y postconsumo certificado por FSC o PEFC</xs:documentation>
+					<xs:documentation>Porcentaje de sobrante pre y postconsumo reciclado usado en un producto cuya composición está certificada por FSC o PEFC. &lt;ProductFormFeatureValue> es un número entero. Puede ocurrir junto con el tipo de código 32, 33, 34 ó 35.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="37">
+				<xs:annotation>
+					<xs:documentation>Porcentaje de sobrante pre y postconsumo declarado</xs:documentation>
+					<xs:documentation>Porcentaje de sobrante pre y postconsumo reciclado declarado para ser usado en un producto cuya composición no está certificada por FSC o PEFC. &lt;Product FormFeatureValue> es un número entero. &lt;ProductFormFeatureDescription> puede contener texto libre para respaldar la demanda. Debe estar acompañado por el tipo de código 30.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="40">
+				<xs:annotation>
+					<xs:documentation>Papel producido por tecnología ecológica</xs:documentation>
+					<xs:documentation>Producto hecho del papel producido por tecnología que respeta el medio ambiente. &lt;ProductFormFeatureDescription> puede contener texto libre con una declaración más detallada.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List80">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 80">Tipo de embalaje del producto</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Sin embalajes externos</xs:documentation>
+					<xs:documentation>Sin embalajes o los elementos más pequeños colocados dentro del más grande.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Funda deslizante</xs:documentation>
+					<xs:documentation>Funda fina de cartón, mucho menos rígida que un estuche deslizante.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Clamshell o envase tipo almeja</xs:documentation>
+					<xs:documentation>Embalaje hecho de plástico y sellado por todos los lados del producto. No se debe confundir con el blíster de una cara.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Caja de DVD</xs:documentation>
+					<xs:documentation>Embalaje típico de DVD, a veces conocido como estuche &quot;Amaray&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Caja transparente</xs:documentation>
+					<xs:documentation>Embalaje típico de CD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Caja cerrada</xs:documentation>
+					<xs:documentation>Elemento individual, elementos o set en una caja de cartón con tapa separada o abatible: no confundir con la comúnmente utilizada &quot;set de cajas&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Estuche deslizante</xs:documentation>
+					<xs:documentation>Estuche deslizanta para un solo elemento: en alemán &quot;Schuber&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Set de estuche deslizante</xs:documentation>
+					<xs:documentation>Estuche deslizante para set de varios volúmenes: en alemán &quot;Kassette&quot;; comúnmente conocido también como &quot;set de cajas&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Tubo</xs:documentation>
+					<xs:documentation>Enrollado en un tubo o cilindro: por ejemplo un mapa o un póster.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Archivador</xs:documentation>
+					<xs:documentation>Utilizar en diversos elementos como diapositivas o microfichas cuando se presenten en un archivador.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>En una cartera o carpeta</xs:documentation>
+					<xs:documentation>Utilizar en diversos elementos como diapositivas o microfichas cuando se presenten en una cartera o en una carpeta.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Embalaje triangular y alargado</xs:documentation>
+					<xs:documentation>Embalaje alargado con una sección transversal triangular utilizada para enrollar mapas, pósteres, etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Embalaje cuadrangular y alargado</xs:documentation>
+					<xs:documentation>Embalaje alargado con una sección transversal cuadrangular para enrollar mapas, pósteres, etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Caja blanda (de DVD)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Bolsa</xs:documentation>
+					<xs:documentation>En la bolsa, por ejemplo materiales didácticos en una bolsa de plástico o bolso.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Estuche de plástico rígido</xs:documentation>
+					<xs:documentation>En duroplástico u otro estuche de plástico rígido, por ejemplo para un set de clase.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Estuche de cartón</xs:documentation>
+					<xs:documentation>En un estuche de cartón, por ejemplo para un set de clase.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>Embalaje de plástico retráctil</xs:documentation>
+					<xs:documentation>Utilizar en productos o paquetes suministrados por los minoristas en embalaje de plástico retráctil. Para los lotes de embalaje de plástico retráctil de múltiples productos solo para el suministro de comercios, vea el código XL en la Lista 7.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Lote de blíster</xs:documentation>
+					<xs:documentation>Lote que conste de un plástico blíster ya formado y una carta impresa con una cubierta de sellado en caliente.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Funda de transporte</xs:documentation>
+					<xs:documentation>Estuche con asa de transporta, normalmente para un set de libros o materiales educativos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List81">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 81">Tipo de contenido del producto</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Texto (legible)</xs:documentation>
+					<xs:documentation>Texto legible del trabajo principal: se necesita este valor, junto con los valores pertinentes &lt;ProductForm> y &lt;ProductFormDetail>, para designar un libro electrónico u otro producto digital cuyo contenido principal sea texto legible.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Enlaces extensos en el contenido interno.</xs:documentation>
+					<xs:documentation>La publicación electrónica se mejoró con un número significativo de referencias cruzadas procesables, notas con hipervínculos y anotaciones o con otros enlaces en los elementos textuales de gran tamaño (p.ej., preguntas de examénes o tests, &quot;elige tu propio final&quot;, etc).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Enlaces extensos a contenido externo.</xs:documentation>
+					<xs:documentation>La publicación electrónica se mejoró con un número significativo de enlaces a páginas web procesables (cliqueable).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Texto legible adicional que no forma parte del trabajo principal.</xs:documentation>
+					<xs:documentation>La publicación electrónica se mejoró con contenido textual adicional como una entrevista, un artículo de fondo, un ensayo, una bibliografía, un examen o test u otro materiales de referencia o texto que no esté incluido en una versión inicial o &quot;mejorada&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Texto promocional para otro tipo de libro</xs:documentation>
+					<xs:documentation>p.ej., capítulo de avance.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Notación musical</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Imágenes o gráficos estáticos</xs:documentation>
+					<xs:documentation>Utilizar solo cuando no se disponga una especificación más detallada.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Fotografías</xs:documentation>
+					<xs:documentation>Ya sea o no en una lámina.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Figuras, diagramas, tablas, gráficos</xs:documentation>
+					<xs:documentation>Lo que incluye otras ilustraciones &quot;mecánicas&quot; (p.ej., no fotográficas).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Imágenes o gráficos adicionales que no forman parte del trabajo principal</xs:documentation>
+					<xs:documentation>La publicación electrónica se mejora con contenido adicional de imágenes o gráficos como fotografías suplementarias que no se incluyen en una versión inicial o &quot;no mejorada&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Mapas u otro contenido cartográfico</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Audiolibro</xs:documentation>
+					<xs:documentation>Grabación de audio de una lectura de un libro o de otro texto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Representación: palabra hablada</xs:documentation>
+					<xs:documentation>Grabación de audio de un drama o de otra representación de palabra hablada.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Otro contenido de discurso</xs:documentation>
+					<xs:documentation>p.ej., una entrevista, no una &quot;lectura&quot; o &quot;representación&quot;).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Grabación de música</xs:documentation>
+					<xs:documentation>Grabación de audio de una representación de música, incluyendo drama musical y ópera.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Otro audio</xs:documentation>
+					<xs:documentation>Grabación de audio de otro sonido, p.ej., canto de ave.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>Representación parcial: palabra hablada</xs:documentation>
+					<xs:documentation>Grabación de audio de una lectura, representación o dramatización de una parte del trabajo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Contenido de audio adicional que no forma parte del trabajo principal</xs:documentation>
+					<xs:documentation>El producto se mejoró con una grabación de audio de una lectura completa o parcial, representaciones, dramatizaciones, entrevistas, documentales de fondo u otros contenidos de audios que no están incluidos en una versión inicial o &quot;no mejorada&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Audio promocional para otro tipo de libro</xs:documentation>
+					<xs:documentation>p.ej., lectura del capítulo de avance.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Vídeo</xs:documentation>
+					<xs:documentation>Incluye película, vídeo, animación, etc. Utilizar solo cuando no se disponga una especificación más detallada. Anteriormente &quot;Imágenes en movimiento&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Grabación de vídeo de una lectura</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>Representación: visual</xs:documentation>
+					<xs:documentation>Grabación de vídeo de un drama u otra representación, incluyendo representación musical.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Ilustraciones animadas o interactivas</xs:documentation>
+					<xs:documentation>p.ej., diagramas animados, tablas, gráficos u otras ilustraciones.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Animación narrativa</xs:documentation>
+					<xs:documentation>Por ejemplo, dibujos animados, animático o animación CGI.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>Otro vídeo</xs:documentation>
+					<xs:documentation>Otro tipo de contenido de vídeo, por ejemplo una entrevista, no una lectura o representación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="29">
+				<xs:annotation>
+					<xs:documentation>Representación parcial: vídeo</xs:documentation>
+					<xs:documentation>Grabación de vídeo de una lectura, representación o dramatización de una parte del trabajo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="30">
+				<xs:annotation>
+					<xs:documentation>Contenido de vídeo adicional que no forma parte del trabajo principal</xs:documentation>
+					<xs:documentation>La publicación en línea se mejora con una grabación de vídeo de una lectura completa o parcial, una representación, una dramatización, una entrevista, un documental de fondo u otro contenido de audios que no están incluidos en una versión inicial o &quot;no mejorada&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="31">
+				<xs:annotation>
+					<xs:documentation>Vídeo promocional para otro tipo de libro</xs:documentation>
+					<xs:documentation>Por ejemplo tráiler de libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Juego o Puzzle</xs:documentation>
+					<xs:documentation>Sin funcionalidad multiusuario. Anteriormente solo &quot;Juego&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="32">
+				<xs:annotation>
+					<xs:documentation>Competición</xs:documentation>
+					<xs:documentation>Incluye cierto grado de funcionalidad multiusuario.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Software</xs:documentation>
+					<xs:documentation>Principalmente sin contenido.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Datos</xs:documentation>
+					<xs:documentation>Datos de archivos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="33">
+				<xs:annotation>
+					<xs:documentation>Conjuntos de datos además de software</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="34">
+				<xs:annotation>
+					<xs:documentation>Páginas en blanco</xs:documentation>
+					<xs:documentation>Destinadas a ser rellenadas por el lector.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="35">
+				<xs:annotation>
+					<xs:documentation>Contenido publicitario</xs:documentation>
+					<xs:documentation>Usar solo donde el tipo de contenido publicitario no se encuentre especificado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="37">
+				<xs:annotation>
+					<xs:documentation>Publicidad: primera parte</xs:documentation>
+					<xs:documentation>&quot;Anuncios de fondo&quot;: páginas promocionales para otros libros (que no incluyen contenido de ejemplo, vea códigos 17, 23).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="36">
+				<xs:annotation>
+					<xs:documentation>Publicidad: cupones</xs:documentation>
+					<xs:documentation>Por ejemplo, para obtener descuentos en otros productos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="38">
+				<xs:annotation>
+					<xs:documentation>Publicidad: exhibición de la tercera parte</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="39">
+				<xs:annotation>
+					<xs:documentation>Publicidad: tercera parte textual</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List82">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 82">Contenidos bíblicos</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AP">
+				<xs:annotation>
+					<xs:documentation>Apócrifos (canon católico)</xs:documentation>
+					<xs:documentation>Las siete secciones de los libros apócrifos añadidos al canon católico en el Consejo de Trent en 1546: Tobit; Judith; Sabiduría de Salomón; Sira (Eclesiástico); Baruc, en el que se incluye la Carta de Jeremías; Macabeos I y II; secciones extra de Ester y Daniel (Incorporaciones a Ester; la Oración de Azarías; Canción de los Tres Judíos; Susana; Bel y el Dragón). Estos no están incluidos normalmente en el canon protestante.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AQ">
+				<xs:annotation>
+					<xs:documentation>Apócrifos (canon no especificado)</xs:documentation>
+					<xs:documentation>Una colección de textos apócrifos cuyo canon no está especificado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AX">
+				<xs:annotation>
+					<xs:documentation>Textos Apócrifos Adicionales: Canon Ortodoxo Griego</xs:documentation>
+					<xs:documentation>Esdras I; Salmo 151; Macabeos III.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AY">
+				<xs:annotation>
+					<xs:documentation>Textos Apócrifos Adicionales: Canon Ortodoxo Eslavo</xs:documentation>
+					<xs:documentation>Esdras I y II; Oración de Manasés; Salmo 151; Macabeos III y IV.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AZ">
+				<xs:annotation>
+					<xs:documentation>Textos apócrifos adicionales</xs:documentation>
+					<xs:documentation>Textos Apócrifos Adicionales incluidos en algunas versiones de la Biblia: Esdras I y II; Oración de Manasés.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GA">
+				<xs:annotation>
+					<xs:documentation>Canon general con libros apócrifos (canon católico)</xs:documentation>
+					<xs:documentation>Los 66 libros incluidos en los cánones protestante, católico y ortodoxo, además de las siete secciones de los siete libros apócrifos incluidos en el canon católico.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GC">
+				<xs:annotation>
+					<xs:documentation>Canon general con textos apócrifos (canon no especificado)</xs:documentation>
+					<xs:documentation>Los 66 libros incluidos en los cánones protestante, católico y ortodoxo, además de los textos apócrifos cuyo canon no está especificado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GE">
+				<xs:annotation>
+					<xs:documentation>Canon general</xs:documentation>
+					<xs:documentation>Los 66 libros incluidos en los cánones protestante, católico y ortodoxo, los 39 del Antiguo Testamento y los 27 del Nuevo Testamento. La secuencia de libros puede diferenciarse en distintos cánones.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GS">
+				<xs:annotation>
+					<xs:documentation>Evangelios</xs:documentation>
+					<xs:documentation>Los libros de Mateo, Marcos, Lucas y Juan.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="OT">
+				<xs:annotation>
+					<xs:documentation>Antiguo Testamento</xs:documentation>
+					<xs:documentation>Los 39 libros que se incluyeron en el canon judío por la academia rabínica establecida en Jamma en el año 90 d.C. También conocidos como las Escrituras judías o hebreas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NT">
+				<xs:annotation>
+					<xs:documentation>Nuevo Testamento</xs:documentation>
+					<xs:documentation>Los 27 libros incluidos en el canon cristiano a través de la Carta pascual de Atanasio, obispo de Alejandría y también por el consejo general de la Iglesia cristiana que tuvo lugar a finales del siglo IV d.C.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NP">
+				<xs:annotation>
+					<xs:documentation>Nuevo Testamento con Salmos y Proverbios</xs:documentation>
+					<xs:documentation>Incluye los 27 libros del Nuevo Testamento además de los Salmos y Proverbios del Antiguo Testamento.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PE">
+				<xs:annotation>
+					<xs:documentation>Epístolas paulinas</xs:documentation>
+					<xs:documentation>Los libros que contienen las cartas de San Pablo a las primeras comunidades cristianas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PP">
+				<xs:annotation>
+					<xs:documentation>Salmos y Proverbios</xs:documentation>
+					<xs:documentation>El libro de los Salmos y el libro de Proverbios combinados.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PS">
+				<xs:annotation>
+					<xs:documentation>Salmos</xs:documentation>
+					<xs:documentation>El libro de los Salmos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PT">
+				<xs:annotation>
+					<xs:documentation>El Pentateuco</xs:documentation>
+					<xs:documentation>Los cinco primeros libros de la Biblia: Génesis, Éxodo, Números, Levítico y Deuteronomio. También aplicado a la Torá.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZZ">
+				<xs:annotation>
+					<xs:documentation>Otros libros</xs:documentation>
+					<xs:documentation>Libros seleccionados del Antiguo o Nuevo Testamento a menos que se indique lo contrario.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List83">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 83">Versiones de la Biblia</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ALV">
+				<xs:annotation>
+					<xs:documentation>Alberto Vaccari</xs:documentation>
+					<xs:documentation>Alberto Vaccari; Pontificio Istituto Biblico.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AMP">
+				<xs:annotation>
+					<xs:documentation>Amplificada</xs:documentation>
+					<xs:documentation>Una traducción basada en la Versión Estándar Americana con múltiples opciones para la traducción de textos antiguos. Publicada por completo en 1965. Patrocinada por la Fundación Lockman.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ANM">
+				<xs:annotation>
+					<xs:documentation>Antonio Martini</xs:documentation>
+					<xs:documentation>La traducción de la Biblia católica más popular en italiano anterior a la traducción de la CEI en 1971.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ASV">
+				<xs:annotation>
+					<xs:documentation>Versión Estándar Americana</xs:documentation>
+					<xs:documentation>Traducción de 1901 que utiliza técnicas de equivalencia verbal con el objetivo de americanizar la versión inglesa revisada.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CEI">
+				<xs:annotation>
+					<xs:documentation>Conferenza Episcopale Italiana</xs:documentation>
+					<xs:documentation>Traducción de la Conferencia Episcopal Italiana de 1971 adecuada para la liturgia católica italiana. (Incluye algunas revisiones de 1974).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CEN">
+				<xs:annotation>
+					<xs:documentation>Conferenza Episcopale Italiana 2008</xs:documentation>
+					<xs:documentation>Nueva traducción de la CEI Se publicó por primera vez en 2008 y es la versión más extendida en la Iglesia católica italiana.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CEV">
+				<xs:annotation>
+					<xs:documentation>Versión en inglés contemporáneo</xs:documentation>
+					<xs:documentation>Traducción completada en 1995 y patrocinada por la Sociedad Americana de la Biblia bajo la dirección de Barclay Newman.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CNC">
+				<xs:annotation>
+					<xs:documentation>Concordata</xs:documentation>
+					<xs:documentation>1968 Versión interconfesional promovida por la Sociedad Italiana de la Biblia. Posee el impremátur católico, a pesar de que su enfoque ecuménico tiene el apoyo judío, protestante y cristiano ortodoxo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DDI">
+				<xs:annotation>
+					<xs:documentation>Diodati</xs:documentation>
+					<xs:documentation>Versión basada en los documentos originales, editados por Giovanni Diodati en 1607, revisada por Diodati en 1641 y en 1894. Es la versión de referencia para muchos italianos protestantes.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DDN">
+				<xs:annotation>
+					<xs:documentation>Nuova Diodati</xs:documentation>
+					<xs:documentation>Revisión de la Biblia de Diodati datada de los años 1990 y pretende ser lo más fiel posible a los textos originales en griego antiguo (Nuevo Testamento) y a los textos originales en hebreo (Antiguo Testamento).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DOU">
+				<xs:annotation>
+					<xs:documentation>Douay-Rheims</xs:documentation>
+					<xs:documentation>Traducción antigua inglesa (1580-1609) del latín vulgar diseñada para católicos y llevada a cabo por George Martin.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EIN">
+				<xs:annotation>
+					<xs:documentation>Einheitsübersetzung</xs:documentation>
+					<xs:documentation>Traducción alemana de la Biblia para uso en iglesias católicas romanas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ESV">
+				<xs:annotation>
+					<xs:documentation>Versión estándar en inglés</xs:documentation>
+					<xs:documentation>Actualización de la Versión Estándar Revisada que hace un uso &quot;modesto&quot; del lenguaje no sexista.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FBB">
+				<xs:annotation>
+					<xs:documentation>Biblia (1776)</xs:documentation>
+					<xs:documentation>Traducción finesa de la Biblia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FRA">
+				<xs:annotation>
+					<xs:documentation>Raamattu (1933/1938)</xs:documentation>
+					<xs:documentation>Traducción finesa de la Biblia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FRK">
+				<xs:annotation>
+					<xs:documentation>Raamattu kansalle</xs:documentation>
+					<xs:documentation>Traducción finesa de la Biblia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FRM">
+				<xs:annotation>
+					<xs:documentation>Raamattu (1992)</xs:documentation>
+					<xs:documentation>Traducción finesa de la Biblia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GDW">
+				<xs:annotation>
+					<xs:documentation>La palabra de Dios</xs:documentation>
+					<xs:documentation>Traducción de 1995 de World Bible Publishing Company que utiliza la lengua inglesa de tal manera que sea comprensible para los americanos de finales del siglo XX.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GEN">
+				<xs:annotation>
+					<xs:documentation>Ginebra</xs:documentation>
+					<xs:documentation>Versión antigua (1560) de la Biblia traducida por Willian Whittingham con fuertes inclinaciones protestantes.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GNB">
+				<xs:annotation>
+					<xs:documentation>Versión de las Buenas Nuevas.</xs:documentation>
+					<xs:documentation>Traducción patrocinada por la Sociedad Americana de la Biblia. El Nuevo Testamento se publicó por primera vez (como la Versión Actual en Inglés) en 1966. El Antiguo Testamento se completó en 1976 y la versión completa se publicó como La Biblia de las Buenas Nuevas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GPR">
+				<xs:annotation>
+					<xs:documentation>Galbiati, Penna, Rossano - UTET</xs:documentation>
+					<xs:documentation>Versión editada por E. Galbiati, A. Penna y P. Rossano, y publicada por UTET. En esta versión, que está basada en textos originales, abundan las notas y se usó como base para la traducción de la CEI.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GRK">
+				<xs:annotation>
+					<xs:documentation>Original en griego</xs:documentation>
+					<xs:documentation>El Nuevo Testamento en versión original en griego.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GRM">
+				<xs:annotation>
+					<xs:documentation>Garofano, Rinaldi - Marietti</xs:documentation>
+					<xs:documentation>Versión de 1963 con anotaciones editada por S. Garofano y S. Rinaldi y publicada por Marietti.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HBR">
+				<xs:annotation>
+					<xs:documentation>Original en hebreo</xs:documentation>
+					<xs:documentation>El Antiguo Testamento en versión original en hebreo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HCS">
+				<xs:annotation>
+					<xs:documentation>Versión Estándar Cristiana de Holman</xs:documentation>
+					<xs:documentation>Publicada por Broadman y Holman, esta traducción rechaza todas las formas de redacción de lenguaje no sexista y está escrita con grandes influencias de la perspectiva Bautista del Sur de estudios bíblicos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ICB">
+				<xs:annotation>
+					<xs:documentation>Versión internacional para niños</xs:documentation>
+					<xs:documentation>Traducción completada en 1986 orientada a niños de 8 ó 9 años de los Estados Unidos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ILC">
+				<xs:annotation>
+					<xs:documentation>Traduzione Interconfessionale in Lingua Corrente</xs:documentation>
+					<xs:documentation>Traducción Interconfesional que resultó del esfuerzo de eruditos católicos y protestantes en 1985 con el objetivo de difundir un mensaje más fácil de entender.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="JER">
+				<xs:annotation>
+					<xs:documentation>Jerusalén</xs:documentation>
+					<xs:documentation>Una traducción diseñada para católicos angloparlantes basada en las lenguas originales. Está basada en textos franceses y antiguos y se publicó por primera vez en 1966.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KJV">
+				<xs:annotation>
+					<xs:documentation>Versión del Rey Jacobo</xs:documentation>
+					<xs:documentation>Traducción encargada por el Rey Jacobo I de Inglaterra y publicada por primera vez en 1611.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KJT">
+				<xs:annotation>
+					<xs:documentation>Versión del Rey Jacobo del siglo XXI</xs:documentation>
+					<xs:documentation>Traducción verbal llevada a cabo por William Prindele. Publicada en 1994, se diseñó para modernizar el lenguaje de la versión del Rey Jacobo basada en el Nuevo Diccionario Internacional de Webster, 2ª edición en versión completa.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LVB">
+				<xs:annotation>
+					<xs:documentation>La Biblia Viviente</xs:documentation>
+					<xs:documentation>Traducción parafraseada por Kenneth N Taylor y publicada por primera vez en 1972.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LZZ">
+				<xs:annotation>
+					<xs:documentation>Luzzi</xs:documentation>
+					<xs:documentation>Traducción de 1924 por Giovanni Luzzi, profesor de la Facultad Valdense de Teología de Roma, quien revisó la versión del siglo XVII de Diodati.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MSG">
+				<xs:annotation>
+					<xs:documentation>El Mensaje de la Biblia</xs:documentation>
+					<xs:documentation>Traducción parafraseada del Nuevo Testamento por Eugene Peterson publicada por primera vez en 1993.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NAB">
+				<xs:annotation>
+					<xs:documentation>Nueva Versión Americana</xs:documentation>
+					<xs:documentation>Traducción dirigida a lectores católicos publicada por primera vez en su totalidad en 1970. Nuevo Testamento revisado se publicó en 1986 como la segunda edición. La tercera edición se publicó en 1991 con revisiones en los Salmos. La cuarta edición, también conocida como la Edición Revisada de la Nueva Biblia Americana, se publicó en 2011 incorporando así nuevas revisiones en el Nuevo Testamento.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NAS">
+				<xs:annotation>
+					<xs:documentation>Nueva Versión Estándar Americana</xs:documentation>
+					<xs:documentation>Traducción encargada por la Fundación Lockman. El Nuevo Testamento se publicó en 1960 y la Biblia completa en 1971.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NAU">
+				<xs:annotation>
+					<xs:documentation>Nueva Versión Estándar Americana Actualizada</xs:documentation>
+					<xs:documentation>Traducción de 1995 que utiliza un lenguaje más moderno que la versión Estándar Americana de la Biblia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NBA">
+				<xs:annotation>
+					<xs:documentation>Bibelen 1895</xs:documentation>
+					<xs:documentation>Traducción noruega de la Biblia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NBB">
+				<xs:annotation>
+					<xs:documentation>Bibelen 1930</xs:documentation>
+					<xs:documentation>Traducción noruega de la Biblia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NBC">
+				<xs:annotation>
+					<xs:documentation>Bibelen 1938</xs:documentation>
+					<xs:documentation>Traducción noruega de la Biblia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NBD">
+				<xs:annotation>
+					<xs:documentation>Bibelen 1978-85</xs:documentation>
+					<xs:documentation>Traducción noruega de la Biblia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NBE">
+				<xs:annotation>
+					<xs:documentation>Bibelen 1978</xs:documentation>
+					<xs:documentation>Traducción noruega de la Biblia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NBF">
+				<xs:annotation>
+					<xs:documentation>Bibelen 1985</xs:documentation>
+					<xs:documentation>Traducción noruega de la Biblia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NBG">
+				<xs:annotation>
+					<xs:documentation>Bibelen 1988</xs:documentation>
+					<xs:documentation>Traducción noruega de la Biblia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NBH">
+				<xs:annotation>
+					<xs:documentation>Bibelen 1978-85/rev. 2005</xs:documentation>
+					<xs:documentation>Traducción noruega de la Biblia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NBI">
+				<xs:annotation>
+					<xs:documentation>Bibelen 2011</xs:documentation>
+					<xs:documentation>Traducción noruega de la Biblia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NCV">
+				<xs:annotation>
+					<xs:documentation>Nuevo Siglo</xs:documentation>
+					<xs:documentation>Una traducción inspirada por la Versión Internacional Para Niños. Publicada por primera vez por World Publishing en 1991.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NEB">
+				<xs:annotation>
+					<xs:documentation>Inglés moderno</xs:documentation>
+					<xs:documentation>Una traducción publicada en 1961 (Nuevo Testamento) y en 1970 (Biblia completa) como resultado de una propuesta durante la Asamblea General de la Iglesia de Escocia de 1946.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NGO">
+				<xs:annotation>
+					<xs:documentation>Bibelen Guds ord</xs:documentation>
+					<xs:documentation>Traducción noruega de la Biblia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NIV">
+				<xs:annotation>
+					<xs:documentation>Nueva Versión Internacional</xs:documentation>
+					<xs:documentation>Una traducción financiada por Biblica (antiguamente conocida como Sociedad Bíblica Internacional y, anteriormente, como la Sociedad Neoyorquina de la Biblia). El Nuevo Testamento se publicó en 1973 y la Biblia completa en 1978. La Nueva Versión Internacional se revisó primero en 1984 y luego en 2011.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NIR">
+				<xs:annotation>
+					<xs:documentation>Nuevo Lector Internacional de la Biblia</xs:documentation>
+					<xs:documentation>Una traducción de 1996 diseñada para lectores con conocimientos limitados de inglés y basada en la Nueva Versión Internacional.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NJB">
+				<xs:annotation>
+					<xs:documentation>Nueva Biblia de Jerusalén</xs:documentation>
+					<xs:documentation>Una revisión de la Biblia de Jerusalén. Se publicó por primera vez en 1986.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NKJ">
+				<xs:annotation>
+					<xs:documentation>Nueva Biblia del Rey Jacobo</xs:documentation>
+					<xs:documentation>Una versión publicada por Thomas Nelson Publishers en 1982-1983 diseñada para actualizar el idioma de la versión de la Biblia del Rey Jacobo, que mantenía la redacción y el ritmo, y utilizaba las mismas fuentes que su predecesor.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NNK">
+				<xs:annotation>
+					<xs:documentation>Bibelen, nynorsk</xs:documentation>
+					<xs:documentation>Traducción noruega &quot;nynorsk&quot; de la Biblia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NLV">
+				<xs:annotation>
+					<xs:documentation>Nueva Traducción Viviente</xs:documentation>
+					<xs:documentation>Una traducción patrocinada por Tyndale House y publicada por primera vez en 1996. Se considera como una versión revisada y actualizada de la Traducción Viviente.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NRS">
+				<xs:annotation>
+					<xs:documentation>Nueva Versión Estándar Revisada</xs:documentation>
+					<xs:documentation>Una revisión de la Versión Estándar Revisada basada en los textos antiguos pero actualizada de acuerdo al lenguaje estadounidense de los años 80.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NTV">
+				<xs:annotation>
+					<xs:documentation>Nueva Traducción Viviente</xs:documentation>
+					<xs:documentation>La traducción al español del griego y del hebreo original, patrocinada por Tyndale House.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NVB">
+				<xs:annotation>
+					<xs:documentation>Novissima Versione della Bibbia</xs:documentation>
+					<xs:documentation>Nuovissima version - una traducción orientada al catolicismo en italiano moderno, editada por un equipo que incluye a Carlo Martini, Gianfranco Ravasi y Ugo Vanni. Fue publicada por primera vez por Edizioni San Paolo en 48 volúmenes entre 1967 y 1980.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NVD">
+				<xs:annotation>
+					<xs:documentation>Nueva Biblia al Día</xs:documentation>
+					<xs:documentation>Una traducción al español de los textos originales en griego y hebreo, patrocinada por la International Bible Society / Sociedad Bíblica Internacional.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NVI">
+				<xs:annotation>
+					<xs:documentation>Nueva Versión Internacional</xs:documentation>
+					<xs:documentation>Una traducción al español financiada por la Sociedad Bíblica Internacional.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PHP">
+				<xs:annotation>
+					<xs:documentation>El Nuevo Testamento en inglés moderno (Phillips)</xs:documentation>
+					<xs:documentation>Una traducción idiomática por J B Phillips, completada en 1966.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="REB">
+				<xs:annotation>
+					<xs:documentation>Versión revisada de la Biblia</xs:documentation>
+					<xs:documentation>Una revisión de 1989 de la Nueva Biblia Inglesa. Se realizó un esfuerzo significativo por suprimir la influencia del inglés británico en la versión de la Nueva Biblia Inglesa.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="REV">
+				<xs:annotation>
+					<xs:documentation>Versión revisada</xs:documentation>
+					<xs:documentation>Es la primera revisión importante de la Versión del Rey Jacobo e incorpora reflexiones inspiradas en antiguos manuscritos descubiertos entre 1611 y 1870. Además, corrige algunas lecturas que se hicieron en la Versión del Rey Jacobo que fueron consideradas como erróneas por los académicos del siglo XIX. El Nuevo Testamento fue publicado en 1881, el Antiguo Testamento en 1885, y los textos apócrifos en 1895.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RSV">
+				<xs:annotation>
+					<xs:documentation>Versión Estándar Revisada</xs:documentation>
+					<xs:documentation>Una traducción autorizada por el Consejo Nacional de Iglesias de Cristo en Estados Unidos. El Nuevo Testamento se publicó en 1946 seguido por un canon completo protestante en 1951.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RVL">
+				<xs:annotation>
+					<xs:documentation>Reina Valera</xs:documentation>
+					<xs:documentation>Una traducción al español basada en los textos originales.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SBB">
+				<xs:annotation>
+					<xs:documentation>Bibel 2000</xs:documentation>
+					<xs:documentation>Traducción sueca de la Biblia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SMK">
+				<xs:annotation>
+					<xs:documentation>Bibelen, samisk</xs:documentation>
+					<xs:documentation>Traducción de la Biblia noruega &apos;samisk&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TEV">
+				<xs:annotation>
+					<xs:documentation>La Versión Inglesa Actual</xs:documentation>
+					<xs:documentation>Una traducción del Nuevo Testamento patrocinada por la Sociedad Bíblica Americana y publicada por primera vez en 1966. Fue incorporada en la Biblia &quot;Las Buenas Nuevas&quot; en 1976.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TNI">
+				<xs:annotation>
+					<xs:documentation>Nueva Versión Internacional Actual</xs:documentation>
+					<xs:documentation>Una actualización de la Nueva Versión Internacional. El Nuevo Testamento fue publicado en 2002 y la Biblia completa en 2005. Fue sustituida por la actualización de la Nueva Versión Internacional en el 2011.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZZZ">
+				<xs:annotation>
+					<xs:documentation>Otro</xs:documentation>
+					<xs:documentation>Otras traducciones no anotadas de otra forma.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List84">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 84">Tipo de Biblia para estudio</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CAM">
+				<xs:annotation>
+					<xs:documentation>Cambridge Comentado</xs:documentation>
+					<xs:documentation>Contiene el trabajo de Howard Clark Kee e incluye un resumen del desarrollo del canon, una introducción a los libros, notas y referencias cruzadas. Publicada por primera vez en 1993, Nueva Versión Estándar Revisada.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LIF">
+				<xs:annotation>
+					<xs:documentation>Biblia de estudio: Diario vivir</xs:documentation>
+					<xs:documentation>Un proyecto de Tyndale House Publishers y Zondervan con la intención de ayudar a los lectores a aplicar los principios de la Biblia en la vida cotidiana. Nueva Traducción Viviente, Versión del Rey Jacobo, Nueva Versión Internacional, Nueva Versión Estándar Americana.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MAC">
+				<xs:annotation>
+					<xs:documentation>Macarthur</xs:documentation>
+					<xs:documentation>Una versión de la Biblia de estudio del Rey Jacobo con notas de James Macarthur publicada por primera vez en 1997.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="OXF">
+				<xs:annotation>
+					<xs:documentation>Oxford Comentado</xs:documentation>
+					<xs:documentation>Una Biblia de estudio publicada por primera vez en los años 60 y basada en la VER / NVER.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NNT">
+				<xs:annotation>
+					<xs:documentation>Studiebibel, Det Nye testamentet</xs:documentation>
+					<xs:documentation>Biblia de estudio noruega, Nuevo Testamento.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NOX">
+				<xs:annotation>
+					<xs:documentation>Nuevo Oxford Comentado</xs:documentation>
+					<xs:documentation>Publicado en 1991 y basado en la Nueva Versión Estándar Revisada.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NSB">
+				<xs:annotation>
+					<xs:documentation>Norsk studiebibel</xs:documentation>
+					<xs:documentation>Biblia de estudio noruega.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RYR">
+				<xs:annotation>
+					<xs:documentation>Ryrie</xs:documentation>
+					<xs:documentation>Basada en el trabajo de Charles C. Ryrie. King James, NI, NASB.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SCO">
+				<xs:annotation>
+					<xs:documentation>Scofield</xs:documentation>
+					<xs:documentation>Una Biblia de estudio basada en el trabajo de C.I. de principios del siglo XX. Scofield. Basada en la versión revisada del Rey Jacobo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SPR">
+				<xs:annotation>
+					<xs:documentation>Biblia Plenitud</xs:documentation>
+					<xs:documentation>Una Biblia de estudio transdenominacional para personas con tradiciones pentecostales/carismáticas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List85">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 85">Propósito de la Biblia</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AW">
+				<xs:annotation>
+					<xs:documentation>Premio</xs:documentation>
+					<xs:documentation>Una Biblia (o un texto bíblico) diseñada para la presentación de una organización religiosa.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BB">
+				<xs:annotation>
+					<xs:documentation>Bebé</xs:documentation>
+					<xs:documentation>Una Biblia (o un texto bíblico seleccionado) diseñada para conmemorar el nacimiento de un niño.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BR">
+				<xs:annotation>
+					<xs:documentation>Novia</xs:documentation>
+					<xs:documentation>Una Biblia especial de regalo (o un texto bíblico seleccionado) diseñada para la novia en el día de su boda. Normalmente blanco.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CF">
+				<xs:annotation>
+					<xs:documentation>Confirmación</xs:documentation>
+					<xs:documentation>Una Biblia (o un texto bíblico seleccionado) diseñada para usar en la lectura de confirmación o para regalar a los confirmados.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CH">
+				<xs:annotation>
+					<xs:documentation>Niños</xs:documentation>
+					<xs:documentation>Una Biblia sin remisiones ni notas (o un texto bíblico seleccionado) diseñado para presentaciones y para ser leído por los niños.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CM">
+				<xs:annotation>
+					<xs:documentation>Compacta</xs:documentation>
+					<xs:documentation>Una Biblia pequeña (o un texto bíblico seleccionado) con una altura inferior a 12 centímetros.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CR">
+				<xs:annotation>
+					<xs:documentation>Referencias cruzadas</xs:documentation>
+					<xs:documentation>Una Biblia (o un texto bíblico seleccionado) que incluye texto con referencias cruzadas a otros pasajes de la Biblia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DR">
+				<xs:annotation>
+					<xs:documentation>Lecturas diarias</xs:documentation>
+					<xs:documentation>Una Biblia (o un texto bíblico seleccionado) diseñada para proporcionar lecturas breves para cada día del año.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DV">
+				<xs:annotation>
+					<xs:documentation>Devoción</xs:documentation>
+					<xs:documentation>Una Biblia (o un texto bíblico seleccionado) con contenido devoto junto a las Escrituras.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FM">
+				<xs:annotation>
+					<xs:documentation>Familia</xs:documentation>
+					<xs:documentation>Una Biblia (o un texto bíblico seleccionado) que contiene textos relacionados con la familia y/o contenido adicional de estudio para la devoción en las familias.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GT">
+				<xs:annotation>
+					<xs:documentation>General/Texto</xs:documentation>
+					<xs:documentation>Una Biblia estándar (o un texto bíblico seleccionado) de cualquier versión que no contenga características específicas además del texto religioso.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GF">
+				<xs:annotation>
+					<xs:documentation>Regalo</xs:documentation>
+					<xs:documentation>Una Biblia (o un texto bíblico seleccionado) diseñada para un regalo o para una presentación, por lo general incluye una página de presentación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LP">
+				<xs:annotation>
+					<xs:documentation>Atril/Púlpito</xs:documentation>
+					<xs:documentation>Una Biblia grande (o un texto bíblico seleccionado) con letra grande diseñada para leer en público durante el culto, desde un atril o un púlpito.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MN">
+				<xs:annotation>
+					<xs:documentation>Para el hombre</xs:documentation>
+					<xs:documentation>Una Biblia (o un texto bíblico seleccionado) especialmente diseñada con notas y guías de estudio orientadas al hombre adulto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PS">
+				<xs:annotation>
+					<xs:documentation>Escuela primaria</xs:documentation>
+					<xs:documentation>Una Biblia (o un texto bíblico seleccionado) diseñada para usarse en la escuela primaria.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PW">
+				<xs:annotation>
+					<xs:documentation>Bancos de iglesia</xs:documentation>
+					<xs:documentation>Una Biblia (o un texto bíblico seleccionado) por lo general barata pero robusta, diseñada para usarse en los bancos de la iglesia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SC">
+				<xs:annotation>
+					<xs:documentation>Académica</xs:documentation>
+					<xs:documentation>Una Biblia (o un texto bíblico seleccionado) que incluye textos en griego y/o en hebreo y diseñada para el estudio académico.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SL">
+				<xs:annotation>
+					<xs:documentation>Delgado</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ST">
+				<xs:annotation>
+					<xs:documentation>Estudiante</xs:documentation>
+					<xs:documentation>Una Biblia (o un texto bíblico seleccionado) con artículos de estudio y notas diseñadas especialmente para su uso en el aula.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SU">
+				<xs:annotation>
+					<xs:documentation>Estudio</xs:documentation>
+					<xs:documentation>Una Biblia (o un texto bíblico seleccionado) con muchas características adicionales, p. ej., introducciones, diccionarios, concordancias, referencias, mapas, etc., para ayudar a los lectores a entender mejor las escrituras.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WG">
+				<xs:annotation>
+					<xs:documentation>Regalo de bodas</xs:documentation>
+					<xs:documentation>Una Biblia especial de regalo (o un texto bíblico seleccionado) diseñada para regalar a los novios en su boda.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WM">
+				<xs:annotation>
+					<xs:documentation>Para la mujer</xs:documentation>
+					<xs:documentation>Una Biblia de estudio o devoción (o un texto bíblico seleccionado) con ayuda, orientada a la mujer adulta.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="YT">
+				<xs:annotation>
+					<xs:documentation>Juventud</xs:documentation>
+					<xs:documentation>Una Biblia (o texto bíblico seleccionado) que contiene ayuda especial para el estudio o devoción, diseñadas específicamente para las necesidades de los adolescentes.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List86">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 86">Organización de los textos en la Biblia</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CHR">
+				<xs:annotation>
+					<xs:documentation>Cronológica</xs:documentation>
+					<xs:documentation>Una Biblia cuyo texto está organizado en el orden en el que se cree que acontecieron los eventos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CHA">
+				<xs:annotation>
+					<xs:documentation>Referencias en cadena</xs:documentation>
+					<xs:documentation>Una Biblia que explora temas o palabras clave haciendo referencia a textos anteriores o posteriores.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="INT">
+				<xs:annotation>
+					<xs:documentation>Interlineal</xs:documentation>
+					<xs:documentation>Una Biblia, u otros textos, en los cuales se presentan las diferentes versiones impresas, unas encima de las otras, de manera que las diferencias entre las versiones se puedan detectar con facilidad.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PAR">
+				<xs:annotation>
+					<xs:documentation>Paralelo</xs:documentation>
+					<xs:documentation>Una Biblia con dos o más versiones impresas una al lado de la otra.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="STN">
+				<xs:annotation>
+					<xs:documentation>Estándar</xs:documentation>
+					<xs:documentation>Una Biblia en la que el texto está presentado en el orden tradicional.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List87">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 87">Posición de las referencias bíblicas</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="CCL">
+				<xs:annotation>
+					<xs:documentation>Columna central</xs:documentation>
+					<xs:documentation>Se imprimen las referencias en una columna estrecha en el centro de la página, entre dos columnas de texto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PGE">
+				<xs:annotation>
+					<xs:documentation>Final de la página</xs:documentation>
+					<xs:documentation>Se imprimen las referencias al pie de página.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SID">
+				<xs:annotation>
+					<xs:documentation>Columna lateral</xs:documentation>
+					<xs:documentation>Se imprimen las referencias en una columna a un lado de las Escrituras.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VER">
+				<xs:annotation>
+					<xs:documentation>Final del verso</xs:documentation>
+					<xs:documentation>Se imprimen las referencias al final de los versos correspondientes.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="UNK">
+				<xs:annotation>
+					<xs:documentation>Desconocido</xs:documentation>
+					<xs:documentation>La persona que crea el registro ONIX no sabe dónde están ubicadas las referencias.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZZZ">
+				<xs:annotation>
+					<xs:documentation>Otro</xs:documentation>
+					<xs:documentation>Otras ubicaciones no identificadas de otra forma.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List88">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 88">Identificador de textos religiosos</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="List89">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 89">Tipo de característica de texto religioso</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Fecha o actividad litúrgica</xs:documentation>
+					<xs:documentation>Una fecha o  actividad litúrgicas a las que está destinado el texto religioso.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List90">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 90">Código de característica de texto religioso</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Año académico</xs:documentation>
+					<xs:documentation>Úselo con código 01 en &lt;ReligiousTextFeatureType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Año catequístico</xs:documentation>
+					<xs:documentation>Úselo con código 01 en &lt;ReligiousTextFeatureType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Año litúrgico</xs:documentation>
+					<xs:documentation>Úselo con código 01 en &lt;ReligiousTextFeatureType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Adviento y Navidad</xs:documentation>
+					<xs:documentation>Úselo con código 01 en &lt;ReligiousTextFeatureType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Bendiciones</xs:documentation>
+					<xs:documentation>Úselo con código 01 en &lt;ReligiousTextFeatureType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Ciclos académicos</xs:documentation>
+					<xs:documentation>Úselo con código 01 en &lt;ReligiousTextFeatureType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Confirmación y Primera Comunión</xs:documentation>
+					<xs:documentation>Úselo con código 01 en &lt;ReligiousTextFeatureType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Actividades de verano</xs:documentation>
+					<xs:documentation>Por ejemplo, campamentos de verano y otras actividades recreativas para jóvenes: úselo con código 01 en &lt;ReligiousTextFeatureType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Semana Santa</xs:documentation>
+					<xs:documentation>Úselo con código 01 en &lt;ReligiousTextFeatureType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Cuaresma</xs:documentation>
+					<xs:documentation>Úselo con código 01 en &lt;ReligiousTextFeatureType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Advocación mariana</xs:documentation>
+					<xs:documentation>Úselo con código 01 en &lt;ReligiousTextFeatureType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List91">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 91">Código de país - ISO 3166-1</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AD">
+				<xs:annotation>
+					<xs:documentation>Andorra</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AE">
+				<xs:annotation>
+					<xs:documentation>Emiratos Árabes Unidos</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AF">
+				<xs:annotation>
+					<xs:documentation>Afganistán</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AG">
+				<xs:annotation>
+					<xs:documentation>Antigua y Barbuda</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AI">
+				<xs:annotation>
+					<xs:documentation>Anguila</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AL">
+				<xs:annotation>
+					<xs:documentation>Albania</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AM">
+				<xs:annotation>
+					<xs:documentation>Armenia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AN">
+				<xs:annotation>
+					<xs:documentation>Antillas Neerlandesas</xs:documentation>
+					<xs:documentation>Obsoleto - use BQ, CW o SX según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AO">
+				<xs:annotation>
+					<xs:documentation>Angola</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AQ">
+				<xs:annotation>
+					<xs:documentation>Antártida</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AR">
+				<xs:annotation>
+					<xs:documentation>Argentina</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AS">
+				<xs:annotation>
+					<xs:documentation>Samoa Americana</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AT">
+				<xs:annotation>
+					<xs:documentation>Austria</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AU">
+				<xs:annotation>
+					<xs:documentation>Australia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AW">
+				<xs:annotation>
+					<xs:documentation>Aruba</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AX">
+				<xs:annotation>
+					<xs:documentation>Islas Åland</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AZ">
+				<xs:annotation>
+					<xs:documentation>Azerbaiyán</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BA">
+				<xs:annotation>
+					<xs:documentation>Bosnia y Herzegovina</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BB">
+				<xs:annotation>
+					<xs:documentation>Barbados</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BD">
+				<xs:annotation>
+					<xs:documentation>Bangladés</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BE">
+				<xs:annotation>
+					<xs:documentation>Bélgica</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BF">
+				<xs:annotation>
+					<xs:documentation>Burkina Faso</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BG">
+				<xs:annotation>
+					<xs:documentation>Bulgaria</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BH">
+				<xs:annotation>
+					<xs:documentation>Baréin</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BI">
+				<xs:annotation>
+					<xs:documentation>Burundi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BJ">
+				<xs:annotation>
+					<xs:documentation>Benín</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BL">
+				<xs:annotation>
+					<xs:documentation>San Bartolomé</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BM">
+				<xs:annotation>
+					<xs:documentation>Bermudas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BN">
+				<xs:annotation>
+					<xs:documentation>Brunéi Darussalam</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BO">
+				<xs:annotation>
+					<xs:documentation>Bolivia, Estado Plurinacional de</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BQ">
+				<xs:annotation>
+					<xs:documentation>Bonaire, San Eustaquio y Saba</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BR">
+				<xs:annotation>
+					<xs:documentation>Brasil</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BS">
+				<xs:annotation>
+					<xs:documentation>Bahamas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BT">
+				<xs:annotation>
+					<xs:documentation>Bután</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BV">
+				<xs:annotation>
+					<xs:documentation>Isla Bouvet</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BW">
+				<xs:annotation>
+					<xs:documentation>Botsuana</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BY">
+				<xs:annotation>
+					<xs:documentation>Bielorrusia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BZ">
+				<xs:annotation>
+					<xs:documentation>Belice</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA">
+				<xs:annotation>
+					<xs:documentation>Canadá</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CC">
+				<xs:annotation>
+					<xs:documentation>Islas Cocos (Keeling)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CD">
+				<xs:annotation>
+					<xs:documentation>Congo, República Democrática del</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CF">
+				<xs:annotation>
+					<xs:documentation>República Centroafricana</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CG">
+				<xs:annotation>
+					<xs:documentation>Congo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CH">
+				<xs:annotation>
+					<xs:documentation>Suiza</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CI">
+				<xs:annotation>
+					<xs:documentation>Costa de Marfil</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CK">
+				<xs:annotation>
+					<xs:documentation>Islas Cook</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CL">
+				<xs:annotation>
+					<xs:documentation>Chile</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CM">
+				<xs:annotation>
+					<xs:documentation>Camerún</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CN">
+				<xs:annotation>
+					<xs:documentation>China</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CO">
+				<xs:annotation>
+					<xs:documentation>Colombia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CR">
+				<xs:annotation>
+					<xs:documentation>Costa Rica</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CS">
+				<xs:annotation>
+					<xs:documentation>Serbia y Montenegro</xs:documentation>
+					<xs:documentation>OBSOLETO - Reemplazada por ME - Montenegro y RS - Serbia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CU">
+				<xs:annotation>
+					<xs:documentation>Cuba</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CV">
+				<xs:annotation>
+					<xs:documentation>Cabo Verde</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CW">
+				<xs:annotation>
+					<xs:documentation>Curazao</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CX">
+				<xs:annotation>
+					<xs:documentation>Isla de Navidad</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CY">
+				<xs:annotation>
+					<xs:documentation>Chipre</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CZ">
+				<xs:annotation>
+					<xs:documentation>República Checa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DE">
+				<xs:annotation>
+					<xs:documentation>Alemania</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DJ">
+				<xs:annotation>
+					<xs:documentation>Yibuti</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DK">
+				<xs:annotation>
+					<xs:documentation>Dinamarca</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DM">
+				<xs:annotation>
+					<xs:documentation>Dominica</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DO">
+				<xs:annotation>
+					<xs:documentation>República Dominicana</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DZ">
+				<xs:annotation>
+					<xs:documentation>Argelia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EC">
+				<xs:annotation>
+					<xs:documentation>Ecuador</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EE">
+				<xs:annotation>
+					<xs:documentation>Estonia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EG">
+				<xs:annotation>
+					<xs:documentation>Egipto</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EH">
+				<xs:annotation>
+					<xs:documentation>Sáhara Occidental</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ER">
+				<xs:annotation>
+					<xs:documentation>Eritrea</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ES">
+				<xs:annotation>
+					<xs:documentation>España</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ET">
+				<xs:annotation>
+					<xs:documentation>Etiopía</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FI">
+				<xs:annotation>
+					<xs:documentation>Finlandia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FJ">
+				<xs:annotation>
+					<xs:documentation>Fiyi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FK">
+				<xs:annotation>
+					<xs:documentation>Islas Malvinas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FM">
+				<xs:annotation>
+					<xs:documentation>Micronesia, Los Estados Federados de</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FO">
+				<xs:annotation>
+					<xs:documentation>Islas Feroe</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FR">
+				<xs:annotation>
+					<xs:documentation>Francia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GA">
+				<xs:annotation>
+					<xs:documentation>Gabón</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GB">
+				<xs:annotation>
+					<xs:documentation>Reino Unido</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GD">
+				<xs:annotation>
+					<xs:documentation>Granada</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GE">
+				<xs:annotation>
+					<xs:documentation>Georgia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GF">
+				<xs:annotation>
+					<xs:documentation>Guayana Francesa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GG">
+				<xs:annotation>
+					<xs:documentation>Guernsey</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GH">
+				<xs:annotation>
+					<xs:documentation>Ghana</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GI">
+				<xs:annotation>
+					<xs:documentation>Gibraltar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GL">
+				<xs:annotation>
+					<xs:documentation>Groenlandia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GM">
+				<xs:annotation>
+					<xs:documentation>Gambia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GN">
+				<xs:annotation>
+					<xs:documentation>Guinea</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GP">
+				<xs:annotation>
+					<xs:documentation>Guadalupe</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GQ">
+				<xs:annotation>
+					<xs:documentation>Guinea Ecuatorial</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GR">
+				<xs:annotation>
+					<xs:documentation>Grecia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GS">
+				<xs:annotation>
+					<xs:documentation>Islas Georgias del Sur y Sandwich del Sur</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GT">
+				<xs:annotation>
+					<xs:documentation>Guatemala</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GU">
+				<xs:annotation>
+					<xs:documentation>Guam</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GW">
+				<xs:annotation>
+					<xs:documentation>Guinea-Bisáu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GY">
+				<xs:annotation>
+					<xs:documentation>Guyana</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HK">
+				<xs:annotation>
+					<xs:documentation>Hong Kong</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HM">
+				<xs:annotation>
+					<xs:documentation>Islas Heard y McDonald</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HN">
+				<xs:annotation>
+					<xs:documentation>Honduras</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HR">
+				<xs:annotation>
+					<xs:documentation>Croacia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HT">
+				<xs:annotation>
+					<xs:documentation>Haití</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HU">
+				<xs:annotation>
+					<xs:documentation>Hungría</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ID">
+				<xs:annotation>
+					<xs:documentation>Indonesia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IE">
+				<xs:annotation>
+					<xs:documentation>Irlanda</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IL">
+				<xs:annotation>
+					<xs:documentation>Israel</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IM">
+				<xs:annotation>
+					<xs:documentation>Isla de Man</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IN">
+				<xs:annotation>
+					<xs:documentation>India</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IO">
+				<xs:annotation>
+					<xs:documentation>Territorio Británico del Océano Índico</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IQ">
+				<xs:annotation>
+					<xs:documentation>Irak</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IR">
+				<xs:annotation>
+					<xs:documentation>Irán, República Islámica de</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IS">
+				<xs:annotation>
+					<xs:documentation>Islandia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IT">
+				<xs:annotation>
+					<xs:documentation>Italia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="JE">
+				<xs:annotation>
+					<xs:documentation>Jersey</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="JM">
+				<xs:annotation>
+					<xs:documentation>Jamaica</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="JO">
+				<xs:annotation>
+					<xs:documentation>Jordania</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="JP">
+				<xs:annotation>
+					<xs:documentation>Japón</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KE">
+				<xs:annotation>
+					<xs:documentation>Kenia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KG">
+				<xs:annotation>
+					<xs:documentation>Kirguistán</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KH">
+				<xs:annotation>
+					<xs:documentation>Camboya</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KI">
+				<xs:annotation>
+					<xs:documentation>Kiribati</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KM">
+				<xs:annotation>
+					<xs:documentation>Comores</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KN">
+				<xs:annotation>
+					<xs:documentation>San Cristóbal y Nieves</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KP">
+				<xs:annotation>
+					<xs:documentation>Corea, República Democrática Popular de</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KR">
+				<xs:annotation>
+					<xs:documentation>República de Corea</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KW">
+				<xs:annotation>
+					<xs:documentation>Kuwait</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KY">
+				<xs:annotation>
+					<xs:documentation>Islas Caimán</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KZ">
+				<xs:annotation>
+					<xs:documentation>Kazajistán</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LA">
+				<xs:annotation>
+					<xs:documentation>República Democrática Popular Lao</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LB">
+				<xs:annotation>
+					<xs:documentation>Líbano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LC">
+				<xs:annotation>
+					<xs:documentation>Santa Lucía</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LI">
+				<xs:annotation>
+					<xs:documentation>Liechtenstein</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LK">
+				<xs:annotation>
+					<xs:documentation>Sri Lanka</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LR">
+				<xs:annotation>
+					<xs:documentation>Liberia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LS">
+				<xs:annotation>
+					<xs:documentation>Lesoto</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LT">
+				<xs:annotation>
+					<xs:documentation>Lituania</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LU">
+				<xs:annotation>
+					<xs:documentation>Luxemburgo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LV">
+				<xs:annotation>
+					<xs:documentation>Letonia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LY">
+				<xs:annotation>
+					<xs:documentation>Libia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MA">
+				<xs:annotation>
+					<xs:documentation>Marruecos</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MC">
+				<xs:annotation>
+					<xs:documentation>Mónaco</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MD">
+				<xs:annotation>
+					<xs:documentation>Moldavia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ME">
+				<xs:annotation>
+					<xs:documentation>Montenegro</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MF">
+				<xs:annotation>
+					<xs:documentation>San Martín, parte francesa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MG">
+				<xs:annotation>
+					<xs:documentation>Madagascar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MH">
+				<xs:annotation>
+					<xs:documentation>Islas Marshall</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MK">
+				<xs:annotation>
+					<xs:documentation>Macedonia, Antigua República Yugoslava de</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ML">
+				<xs:annotation>
+					<xs:documentation>Mali</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MM">
+				<xs:annotation>
+					<xs:documentation>Birmania</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MN">
+				<xs:annotation>
+					<xs:documentation>Mongolia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MO">
+				<xs:annotation>
+					<xs:documentation>Macao</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MP">
+				<xs:annotation>
+					<xs:documentation>Islas Marianas del Norte</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MQ">
+				<xs:annotation>
+					<xs:documentation>Martinica</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MR">
+				<xs:annotation>
+					<xs:documentation>Mauritania</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MS">
+				<xs:annotation>
+					<xs:documentation>Montserrat</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MT">
+				<xs:annotation>
+					<xs:documentation>Malta</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MU">
+				<xs:annotation>
+					<xs:documentation>Mauricio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MV">
+				<xs:annotation>
+					<xs:documentation>Maldivas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MW">
+				<xs:annotation>
+					<xs:documentation>Malawi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MX">
+				<xs:annotation>
+					<xs:documentation>México</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MY">
+				<xs:annotation>
+					<xs:documentation>Malasia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MZ">
+				<xs:annotation>
+					<xs:documentation>Mozambique</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NA">
+				<xs:annotation>
+					<xs:documentation>Namibia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NC">
+				<xs:annotation>
+					<xs:documentation>Nueva Caledonia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NE">
+				<xs:annotation>
+					<xs:documentation>Níger</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NF">
+				<xs:annotation>
+					<xs:documentation>Isla Norfolk</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NG">
+				<xs:annotation>
+					<xs:documentation>Nigeria</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NI">
+				<xs:annotation>
+					<xs:documentation>Nicaragua</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NL">
+				<xs:annotation>
+					<xs:documentation>Países Bajos</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NO">
+				<xs:annotation>
+					<xs:documentation>Noruega</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NP">
+				<xs:annotation>
+					<xs:documentation>Nepal</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NR">
+				<xs:annotation>
+					<xs:documentation>Nauru</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NU">
+				<xs:annotation>
+					<xs:documentation>Niue</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NZ">
+				<xs:annotation>
+					<xs:documentation>Nueva Zelanda</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="OM">
+				<xs:annotation>
+					<xs:documentation>Omán</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PA">
+				<xs:annotation>
+					<xs:documentation>Panamá</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PE">
+				<xs:annotation>
+					<xs:documentation>Perú</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PF">
+				<xs:annotation>
+					<xs:documentation>Polinesia Francesa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PG">
+				<xs:annotation>
+					<xs:documentation>Papúa Nueva Guinea</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PH">
+				<xs:annotation>
+					<xs:documentation>Filipinas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PK">
+				<xs:annotation>
+					<xs:documentation>Pakistán</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PL">
+				<xs:annotation>
+					<xs:documentation>Polonia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PM">
+				<xs:annotation>
+					<xs:documentation>San Pedro y Miquelón</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PN">
+				<xs:annotation>
+					<xs:documentation>Islas Pitcairn</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PR">
+				<xs:annotation>
+					<xs:documentation>Puerto Rico</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PS">
+				<xs:annotation>
+					<xs:documentation>Territorios Palestinos</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PT">
+				<xs:annotation>
+					<xs:documentation>Portugal</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PW">
+				<xs:annotation>
+					<xs:documentation>Palaos</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PY">
+				<xs:annotation>
+					<xs:documentation>Paraguay</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="QA">
+				<xs:annotation>
+					<xs:documentation>Catar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RE">
+				<xs:annotation>
+					<xs:documentation>Reunión</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RO">
+				<xs:annotation>
+					<xs:documentation>Rumanía</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RS">
+				<xs:annotation>
+					<xs:documentation>Serbia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RU">
+				<xs:annotation>
+					<xs:documentation>Federación de Rusia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RW">
+				<xs:annotation>
+					<xs:documentation>Ruanda</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SA">
+				<xs:annotation>
+					<xs:documentation>Arabia Saudí</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SB">
+				<xs:annotation>
+					<xs:documentation>Islas Salomón</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SC">
+				<xs:annotation>
+					<xs:documentation>Las Seychelles</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SD">
+				<xs:annotation>
+					<xs:documentation>Sudán</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SE">
+				<xs:annotation>
+					<xs:documentation>Suecia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SG">
+				<xs:annotation>
+					<xs:documentation>Singapur</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SH">
+				<xs:annotation>
+					<xs:documentation>Santa Elena, Ascensión y Tristán de Acuña</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SI">
+				<xs:annotation>
+					<xs:documentation>Eslovenia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SJ">
+				<xs:annotation>
+					<xs:documentation>Svalbard y Jan Mayen</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SK">
+				<xs:annotation>
+					<xs:documentation>Eslovaquia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SL">
+				<xs:annotation>
+					<xs:documentation>Sierra Leona</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SM">
+				<xs:annotation>
+					<xs:documentation>San Marino</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SN">
+				<xs:annotation>
+					<xs:documentation>Senegal</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SO">
+				<xs:annotation>
+					<xs:documentation>Somalia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SR">
+				<xs:annotation>
+					<xs:documentation>Surinam</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SS">
+				<xs:annotation>
+					<xs:documentation>Sudán del Sur</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ST">
+				<xs:annotation>
+					<xs:documentation>Santo Tomé y Príncipe</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SV">
+				<xs:annotation>
+					<xs:documentation>El Salvador</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SX">
+				<xs:annotation>
+					<xs:documentation>Sint Maarten (parte holandesa)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SY">
+				<xs:annotation>
+					<xs:documentation>República Árabe Siria</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SZ">
+				<xs:annotation>
+					<xs:documentation>Swazilandia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TC">
+				<xs:annotation>
+					<xs:documentation>Islas Turcas y Caicos</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TD">
+				<xs:annotation>
+					<xs:documentation>Chad</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TF">
+				<xs:annotation>
+					<xs:documentation>Tierras Australes y Antárticas Francesas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TG">
+				<xs:annotation>
+					<xs:documentation>Togo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TH">
+				<xs:annotation>
+					<xs:documentation>Tailandia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TJ">
+				<xs:annotation>
+					<xs:documentation>Tayikistán</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TK">
+				<xs:annotation>
+					<xs:documentation>Tokelau</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TL">
+				<xs:annotation>
+					<xs:documentation>Timor Oriental</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TM">
+				<xs:annotation>
+					<xs:documentation>Turkmenistán</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TN">
+				<xs:annotation>
+					<xs:documentation>Túnez</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TO">
+				<xs:annotation>
+					<xs:documentation>Tonga</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TR">
+				<xs:annotation>
+					<xs:documentation>Turquía</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TT">
+				<xs:annotation>
+					<xs:documentation>Trinidad y Tobago</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TV">
+				<xs:annotation>
+					<xs:documentation>Tuvalu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TW">
+				<xs:annotation>
+					<xs:documentation>Provincia de Taiwán</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TZ">
+				<xs:annotation>
+					<xs:documentation>Tanzania, República Unida de</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="UA">
+				<xs:annotation>
+					<xs:documentation>Ucrania</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="UG">
+				<xs:annotation>
+					<xs:documentation>Uganda</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="UM">
+				<xs:annotation>
+					<xs:documentation>Islas Ultramarinas Menores de Estados Unidos</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="US">
+				<xs:annotation>
+					<xs:documentation>Estados Unidos</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="UY">
+				<xs:annotation>
+					<xs:documentation>Uruguay</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="UZ">
+				<xs:annotation>
+					<xs:documentation>Uzbekistán</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VA">
+				<xs:annotation>
+					<xs:documentation>Santa Sede (Ciudad del Vaticano)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VC">
+				<xs:annotation>
+					<xs:documentation>San Vicente y las Granadinas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VE">
+				<xs:annotation>
+					<xs:documentation>Venezuela, República Bolivariana de</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VG">
+				<xs:annotation>
+					<xs:documentation>Islas Vírgenes británicas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VI">
+				<xs:annotation>
+					<xs:documentation>Islas Vírgenes de los Estados Unidos</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VN">
+				<xs:annotation>
+					<xs:documentation>Vietnam</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VU">
+				<xs:annotation>
+					<xs:documentation>Vanuatu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WF">
+				<xs:annotation>
+					<xs:documentation>Wallis y Futuna</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WS">
+				<xs:annotation>
+					<xs:documentation>Samoa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="YE">
+				<xs:annotation>
+					<xs:documentation>Yemen</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="YT">
+				<xs:annotation>
+					<xs:documentation>Mayotte</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="YU">
+				<xs:annotation>
+					<xs:documentation>Yugoslavia</xs:documentation>
+					<xs:documentation>OBSOLETO - Reemplazada por ME - Montenegro y RS - Serbia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZA">
+				<xs:annotation>
+					<xs:documentation>Sudáfrica</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZM">
+				<xs:annotation>
+					<xs:documentation>Zambia</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZW">
+				<xs:annotation>
+					<xs:documentation>Zimbabue</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List92">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 92">Tipo de identificador de proveedores</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Propietario</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Propietario</xs:documentation>
+					<xs:documentation>OBSOLETO - use 01.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Börsenverein Verkehrsnummer</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Identificador editorial de la Agencia ISBN de Alemania</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>GLN</xs:documentation>
+					<xs:documentation>Número de ubicación global GS1 (anteriormente número de ubicación EAN).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>SAN</xs:documentation>
+					<xs:documentation>Número de dirección estándar para el comercio de libros - Estados Unidos, Reino Unido, etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Distributeurscode Boekenbank</xs:documentation>
+					<xs:documentation>Código del proveedor flamenco.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Fondscode Boekenbank</xs:documentation>
+					<xs:documentation>Código de editorial flamenca.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Número de identificación fiscal</xs:documentation>
+					<xs:documentation>Identificador de una empresa a efectos del IVA, p. ej., dentro del sistema VIES de la UE. Visite http://ec.europa.eu/taxation_customs/vies/faqvies.do para más detalles sobre los identificadores de IVA en la UE, que varían según el país. Por lo general, estos consisten en un código de país de dos letras seguido de 8-12 dígitos del número de identificación fiscal nacional. Algunos países incluyen una o dos letras en su número de identificación fiscal. Visite http://en.wikipedia.org/wiki/VAT_identification_number para ver los países fuera de la Unión Europea que emplean identificadores similares. Se deben omitir los espacios, guiones, etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List93">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 93">Rol del proveedor</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Sin especificar</xs:documentation>
+					<xs:documentation>Por defecto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Editorial para minoristas</xs:documentation>
+					<xs:documentation>Editorial como proveedora de establecimientos de comercio al por menor.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Distribuidor exclusivo de la editorial para el comercio al por menor</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Distribuidor no exclusivo de la editorial para el comercio al por menor</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Mayorista</xs:documentation>
+					<xs:documentation>Mayorista como proveedor de establecimientos de comercio al por menor.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Agente de ventas</xs:documentation>
+					<xs:documentation>OBSOLETO - use &lt;MarketRepresentation> (ONIX 2.1) o &lt;MarketPublishingDetail> (ONIX 3.0) para especificar un agente de ventas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Distribuidor de la editorial a minoristas</xs:documentation>
+					<xs:documentation>En un territorio de suministros especificado. Úselo únicamente cuando el estado exclusivo / no exclusivo sea desconocido. Use 02 ó 03 según convenga, cuando sea posible.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Proveedor POD</xs:documentation>
+					<xs:documentation>Cuando un producto POD se suministra a los minoristas y/o a los consumidores directamente desde una fuente POD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Minorista</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Editorial directamente a clientes finales</xs:documentation>
+					<xs:documentation>Editorial como proveedor directo para consumidores y/o clientes institucionales.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Distribuidor exclusivo a clientes finales</xs:documentation>
+					<xs:documentation>Intermediario como distribuidor exclusivo a consumidores y/o clientes institucionales.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Distribuidor no exclusivo a clientes finales</xs:documentation>
+					<xs:documentation>Intermediario como distribuidor no exclusivo a consumidores y/o clientes institucionales.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Distribuidor a clientes finales</xs:documentation>
+					<xs:documentation>Úselo únicamente cuando el estado exclusivo / no exclusivo sea desconocido. Use 10 ó 11 según convenga, cuando sea posible.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List94">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 94">Unidad lineal por defecto</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="cm">
+				<xs:annotation>
+					<xs:documentation>Centímetros</xs:documentation>
+					<xs:documentation>El milímetro es la unidad de longitud preferencial.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="in">
+				<xs:annotation>
+					<xs:documentation>Pulgadas (US)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="mm">
+				<xs:annotation>
+					<xs:documentation>Milímetros</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List95">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 95">Unidad de peso por defecto</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="lb">
+				<xs:annotation>
+					<xs:documentation>Libras (EE.UU.)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="gr">
+				<xs:annotation>
+					<xs:documentation>Gramos</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="oz">
+				<xs:annotation>
+					<xs:documentation>Onzas (EE.UU.)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List96">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 96">Código de la moneda - ISO 4217</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="AED">
+				<xs:annotation>
+					<xs:documentation>Dírham de los Emiratos Árabes Unidos</xs:documentation>
+					<xs:documentation>Emiratos Árabes Unidos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AFA">
+				<xs:annotation>
+					<xs:documentation>Afgani afgano</xs:documentation>
+					<xs:documentation>OBSOLETO, reemplazado por el afgani afgano.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AFN">
+				<xs:annotation>
+					<xs:documentation>Afgani afgano</xs:documentation>
+					<xs:documentation>Afganistán.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ALL">
+				<xs:annotation>
+					<xs:documentation>Lek albanés</xs:documentation>
+					<xs:documentation>Albania.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AMD">
+				<xs:annotation>
+					<xs:documentation>Dram armenio</xs:documentation>
+					<xs:documentation>Armenia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ANG">
+				<xs:annotation>
+					<xs:documentation>Florín antillano neerlandés</xs:documentation>
+					<xs:documentation>Curazao, Sint Maarten.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AOA">
+				<xs:annotation>
+					<xs:documentation>Kwanza angoleño</xs:documentation>
+					<xs:documentation>Angola.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ARS">
+				<xs:annotation>
+					<xs:documentation>Peso argentino</xs:documentation>
+					<xs:documentation>Argentina.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ATS">
+				<xs:annotation>
+					<xs:documentation>Chelín austriaco</xs:documentation>
+					<xs:documentation>Actualmente reemplazado por el euro (EUR), tan solo se utiliza en los precios históricos anteriores a la introducción del euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AUD">
+				<xs:annotation>
+					<xs:documentation>Dólar australiano</xs:documentation>
+					<xs:documentation>Australia, Isla de Navidad, Islas Cocos (Keeling), Islas Heard y McDonald, Kiribati, Nauru, Isla Norfolk, Tuvalu.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AWG">
+				<xs:annotation>
+					<xs:documentation>Florín arubeño</xs:documentation>
+					<xs:documentation>Aruba.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AZN">
+				<xs:annotation>
+					<xs:documentation>Manat azerbaiyano</xs:documentation>
+					<xs:documentation>Azerbaiyán.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BAM">
+				<xs:annotation>
+					<xs:documentation>Marco convertible</xs:documentation>
+					<xs:documentation>Bosnia y Herzegovina.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BBD">
+				<xs:annotation>
+					<xs:documentation>Dólar de Barbados</xs:documentation>
+					<xs:documentation>Barbados.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BDT">
+				<xs:annotation>
+					<xs:documentation>Taka bangladesí</xs:documentation>
+					<xs:documentation>Bangladés.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BEF">
+				<xs:annotation>
+					<xs:documentation>Franco belga</xs:documentation>
+					<xs:documentation>Actualmente reemplazado por el euro (EUR), tan solo se utiliza en los precios históricos anteriores a la introducción del euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BGL">
+				<xs:annotation>
+					<xs:documentation>Lev</xs:documentation>
+					<xs:documentation>OBSOLETO, reemplazado por el lev búlgaro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BGN">
+				<xs:annotation>
+					<xs:documentation>Lev</xs:documentation>
+					<xs:documentation>Bulgaria.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BHD">
+				<xs:annotation>
+					<xs:documentation>Dinar bareiní</xs:documentation>
+					<xs:documentation>Baréin.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BIF">
+				<xs:annotation>
+					<xs:documentation>Franco de Burundi</xs:documentation>
+					<xs:documentation>Burundi.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BMD">
+				<xs:annotation>
+					<xs:documentation>Dólar bermudeño</xs:documentation>
+					<xs:documentation>Las Islas Bermudas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BND">
+				<xs:annotation>
+					<xs:documentation>Dólar de Brunéi</xs:documentation>
+					<xs:documentation>Estado de Brunéi Darussalam.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BOB">
+				<xs:annotation>
+					<xs:documentation>Boliviano</xs:documentation>
+					<xs:documentation>Bolivia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BRL">
+				<xs:annotation>
+					<xs:documentation>Real brasileño</xs:documentation>
+					<xs:documentation>Brasil.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BSD">
+				<xs:annotation>
+					<xs:documentation>Dólar bahameño</xs:documentation>
+					<xs:documentation>Bahamas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BTN">
+				<xs:annotation>
+					<xs:documentation>Ngultrum butanés</xs:documentation>
+					<xs:documentation>Bután.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BWP">
+				<xs:annotation>
+					<xs:documentation>Pula</xs:documentation>
+					<xs:documentation>Botsuana.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BYR">
+				<xs:annotation>
+					<xs:documentation>Rublo bielorruso</xs:documentation>
+					<xs:documentation>Bielorrusia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BZD">
+				<xs:annotation>
+					<xs:documentation>Dólar beliceño</xs:documentation>
+					<xs:documentation>Belice.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CAD">
+				<xs:annotation>
+					<xs:documentation>Dólar canadiense</xs:documentation>
+					<xs:documentation>Canadá.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CDF">
+				<xs:annotation>
+					<xs:documentation>Franco congoleño</xs:documentation>
+					<xs:documentation>Congo, República Democrática del.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CHF">
+				<xs:annotation>
+					<xs:documentation>Franco suizo</xs:documentation>
+					<xs:documentation>Suiza, Liechtenstein.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CLP">
+				<xs:annotation>
+					<xs:documentation>Peso chileno</xs:documentation>
+					<xs:documentation>Chile.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CNY">
+				<xs:annotation>
+					<xs:documentation>Yuan chino</xs:documentation>
+					<xs:documentation>China.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="COP">
+				<xs:annotation>
+					<xs:documentation>Peso colombiano</xs:documentation>
+					<xs:documentation>Colombia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CRC">
+				<xs:annotation>
+					<xs:documentation>Colón costarricense</xs:documentation>
+					<xs:documentation>Costa Rica.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CSD">
+				<xs:annotation>
+					<xs:documentation>Dinar serbio</xs:documentation>
+					<xs:documentation>Desvalorizado y reemplazado por el RSD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CUC">
+				<xs:annotation>
+					<xs:documentation>Peso cubano convertible</xs:documentation>
+					<xs:documentation>Cuba (moneda alternativa).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CUP">
+				<xs:annotation>
+					<xs:documentation>Peso cubano</xs:documentation>
+					<xs:documentation>Cuba.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CVE">
+				<xs:annotation>
+					<xs:documentation>Escudo caboverdiano</xs:documentation>
+					<xs:documentation>Cabo Verde.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CYP">
+				<xs:annotation>
+					<xs:documentation>Libra chipriota</xs:documentation>
+					<xs:documentation>Actualmente reemplazado por el euro (EUR), tan solo se utiliza en los precios históricos anteriores a la introducción del euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CZK">
+				<xs:annotation>
+					<xs:documentation>Corona checa</xs:documentation>
+					<xs:documentation>República Checa.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DEM">
+				<xs:annotation>
+					<xs:documentation>Alemania, marco</xs:documentation>
+					<xs:documentation>Actualmente reemplazado por el euro (EUR), tan solo se utiliza en los precios históricos anteriores a la introducción del euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DJF">
+				<xs:annotation>
+					<xs:documentation>Franco yibutiano</xs:documentation>
+					<xs:documentation>Yibuti.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DKK">
+				<xs:annotation>
+					<xs:documentation>Corona danesa</xs:documentation>
+					<xs:documentation>Dinamarca, Islas Feroe, Groenlandia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DOP">
+				<xs:annotation>
+					<xs:documentation>Peso dominicano</xs:documentation>
+					<xs:documentation>República Dominicana.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DZD">
+				<xs:annotation>
+					<xs:documentation>Dinar argelino</xs:documentation>
+					<xs:documentation>Argelia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EEK">
+				<xs:annotation>
+					<xs:documentation>Corona</xs:documentation>
+					<xs:documentation>Estonia - actualmente reemplazado por el euro (EUR), tan solo se utiliza en los precios históricos anteriores a la introducción del euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EGP">
+				<xs:annotation>
+					<xs:documentation>Libra egipcia</xs:documentation>
+					<xs:documentation>Egipto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ERN">
+				<xs:annotation>
+					<xs:documentation>Nakfa</xs:documentation>
+					<xs:documentation>Eritrea.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ESP">
+				<xs:annotation>
+					<xs:documentation>España, peseta</xs:documentation>
+					<xs:documentation>Actualmente reemplazado por el euro (EUR), tan solo se utiliza en los precios históricos anteriores a la introducción del euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ETB">
+				<xs:annotation>
+					<xs:documentation>Birr etíope</xs:documentation>
+					<xs:documentation>Etiopía.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EUR">
+				<xs:annotation>
+					<xs:documentation>Euro</xs:documentation>
+					<xs:documentation>Andorra, Austria, Bélgica, Chipre, Estonia, Finlandia, Francia, Guayana Francesa, territorios franceses del sur, Alemania, Grecia, Guadalupe, La Santa Sede (Ciudad del Vaticano), Irlanda, Italia, Luxemburgo, Martinica, Malta, Mayotte, Mónaco, Montenegro, Países Bajos, Portugal, Reunión, San Pedro y Miquelón, San Marino, España.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FIM">
+				<xs:annotation>
+					<xs:documentation>Finlandia, marco</xs:documentation>
+					<xs:documentation>Actualmente reemplazado por el euro (EUR), tan solo se utiliza en los precios históricos anteriores a la introducción del euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FJD">
+				<xs:annotation>
+					<xs:documentation>Dólar fiyiano</xs:documentation>
+					<xs:documentation>Fiyi.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FKP">
+				<xs:annotation>
+					<xs:documentation>Libra malvinense</xs:documentation>
+					<xs:documentation>Islas Malvinas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FRF">
+				<xs:annotation>
+					<xs:documentation>Francia, franco</xs:documentation>
+					<xs:documentation>Actualmente reemplazado por el euro (EUR), tan solo se utiliza en los precios históricos anteriores a la introducción del euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GBP">
+				<xs:annotation>
+					<xs:documentation>Libra esterlina</xs:documentation>
+					<xs:documentation>Reino Unido, Isla de Man, Islas del Canal, Islas Georgia del Sur, Islas Sándwich del Sur, Territorio Británico del Océano Índico.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GEL">
+				<xs:annotation>
+					<xs:documentation>Lari</xs:documentation>
+					<xs:documentation>Georgia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GHC">
+				<xs:annotation>
+					<xs:documentation>Cedi</xs:documentation>
+					<xs:documentation>Desvalorizado y reemplazado por el GHS.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GHS">
+				<xs:annotation>
+					<xs:documentation>Cedi</xs:documentation>
+					<xs:documentation>Ghana.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GIP">
+				<xs:annotation>
+					<xs:documentation>Libra gibraltareña</xs:documentation>
+					<xs:documentation>Gibraltar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GMD">
+				<xs:annotation>
+					<xs:documentation>Dalasi</xs:documentation>
+					<xs:documentation>Gambia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GNF">
+				<xs:annotation>
+					<xs:documentation>Franco guineano</xs:documentation>
+					<xs:documentation>Guinea.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GRD">
+				<xs:annotation>
+					<xs:documentation>Grecia, dracma</xs:documentation>
+					<xs:documentation>Actualmente reemplazado por el euro (EUR), tan solo se utiliza en los precios históricos anteriores a la introducción del euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GTQ">
+				<xs:annotation>
+					<xs:documentation>Quetzal</xs:documentation>
+					<xs:documentation>Guatemala.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GWP">
+				<xs:annotation>
+					<xs:documentation>Peso de Guinea-Bissau</xs:documentation>
+					<xs:documentation>Actualmente reemplazado por el franco CFA BCEAO (XOF), tan solo se utiliza en los precios históricos anteriores a la introducción del franco CFA.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GYD">
+				<xs:annotation>
+					<xs:documentation>Dólar guyanés</xs:documentation>
+					<xs:documentation>Guyana.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HKD">
+				<xs:annotation>
+					<xs:documentation>Dólar de Hong Kong</xs:documentation>
+					<xs:documentation>Hong Kong, pataca de Macao.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HNL">
+				<xs:annotation>
+					<xs:documentation>Lempira</xs:documentation>
+					<xs:documentation>Honduras.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HRK">
+				<xs:annotation>
+					<xs:documentation>Kuna croata</xs:documentation>
+					<xs:documentation>Croacia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HTG">
+				<xs:annotation>
+					<xs:documentation>Gourde</xs:documentation>
+					<xs:documentation>Haití.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HUF">
+				<xs:annotation>
+					<xs:documentation>Florín</xs:documentation>
+					<xs:documentation>Hungría.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IDR">
+				<xs:annotation>
+					<xs:documentation>Rupia</xs:documentation>
+					<xs:documentation>Indonesia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IEP">
+				<xs:annotation>
+					<xs:documentation>Irlanda, libra irlandesa</xs:documentation>
+					<xs:documentation>Actualmente reemplazado por el euro (EUR), tan solo se utiliza en los precios históricos anteriores a la introducción del euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ILS">
+				<xs:annotation>
+					<xs:documentation>Séquel israelí</xs:documentation>
+					<xs:documentation>Israel.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="INR">
+				<xs:annotation>
+					<xs:documentation>Rupia india</xs:documentation>
+					<xs:documentation>India.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IQD">
+				<xs:annotation>
+					<xs:documentation>Dinar iraquí</xs:documentation>
+					<xs:documentation>Irak.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IRR">
+				<xs:annotation>
+					<xs:documentation>Rial iraní</xs:documentation>
+					<xs:documentation>Irán, República Islámica de.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ISK">
+				<xs:annotation>
+					<xs:documentation>Corona islandesa</xs:documentation>
+					<xs:documentation>Islandia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ITL">
+				<xs:annotation>
+					<xs:documentation>Italia, lira</xs:documentation>
+					<xs:documentation>Actualmente reemplazado por el euro (EUR), tan solo se utiliza en los precios históricos anteriores a la introducción del euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="JMD">
+				<xs:annotation>
+					<xs:documentation>Dólar jamaicano</xs:documentation>
+					<xs:documentation>Jamaica.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="JOD">
+				<xs:annotation>
+					<xs:documentation>Dinar jordano</xs:documentation>
+					<xs:documentation>Jordania.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="JPY">
+				<xs:annotation>
+					<xs:documentation>Yen</xs:documentation>
+					<xs:documentation>Japón.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KES">
+				<xs:annotation>
+					<xs:documentation>Chelín keniata</xs:documentation>
+					<xs:documentation>Kenia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KGS">
+				<xs:annotation>
+					<xs:documentation>Som</xs:documentation>
+					<xs:documentation>Kirguistán.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KHR">
+				<xs:annotation>
+					<xs:documentation>Riel</xs:documentation>
+					<xs:documentation>Camboya.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KMF">
+				<xs:annotation>
+					<xs:documentation>Franco comorense</xs:documentation>
+					<xs:documentation>Comoras.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KPW">
+				<xs:annotation>
+					<xs:documentation>Won de Corea del Norte</xs:documentation>
+					<xs:documentation>Corea, República Popular Democrática de.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KRW">
+				<xs:annotation>
+					<xs:documentation>Won</xs:documentation>
+					<xs:documentation>Corea, República de.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KWD">
+				<xs:annotation>
+					<xs:documentation>Dinar kuwaití</xs:documentation>
+					<xs:documentation>Kuwait.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KYD">
+				<xs:annotation>
+					<xs:documentation>Dolar caimanés</xs:documentation>
+					<xs:documentation>Islas Caimán.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KZT">
+				<xs:annotation>
+					<xs:documentation>Tengue</xs:documentation>
+					<xs:documentation>Kazajistán.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LAK">
+				<xs:annotation>
+					<xs:documentation>Kip</xs:documentation>
+					<xs:documentation>República Democrática Popular de Laos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LBP">
+				<xs:annotation>
+					<xs:documentation>Libra libanesa</xs:documentation>
+					<xs:documentation>Líbano.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LKR">
+				<xs:annotation>
+					<xs:documentation>Rupia de Sri Lanka</xs:documentation>
+					<xs:documentation>Sri Lanka.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LRD">
+				<xs:annotation>
+					<xs:documentation>Dólar liberiano</xs:documentation>
+					<xs:documentation>Liberia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LSL">
+				<xs:annotation>
+					<xs:documentation>Loti</xs:documentation>
+					<xs:documentation>Lesoto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LTL">
+				<xs:annotation>
+					<xs:documentation>Litas lituana</xs:documentation>
+					<xs:documentation>Lituania.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LUF">
+				<xs:annotation>
+					<xs:documentation>Luxemburgo, franco</xs:documentation>
+					<xs:documentation>Actualmente reemplazado por el euro (EUR), tan solo se utiliza en los precios históricos anteriores a la introducción del euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LVL">
+				<xs:annotation>
+					<xs:documentation>Lats letón</xs:documentation>
+					<xs:documentation>Letonia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LYD">
+				<xs:annotation>
+					<xs:documentation>Dinar libio</xs:documentation>
+					<xs:documentation>Gran Jamahiriya Árabe Libia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MAD">
+				<xs:annotation>
+					<xs:documentation>Dírham marroquí</xs:documentation>
+					<xs:documentation>Marruecos, Sahara Occidental.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MDL">
+				<xs:annotation>
+					<xs:documentation>Leu moldavo</xs:documentation>
+					<xs:documentation>Moldavia, República de.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MGA">
+				<xs:annotation>
+					<xs:documentation>Ariari</xs:documentation>
+					<xs:documentation>Madagascar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MGF">
+				<xs:annotation>
+					<xs:documentation>Franco malgache</xs:documentation>
+					<xs:documentation>Actualmente se ha reemplazado por el ariari (MGA).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MKD">
+				<xs:annotation>
+					<xs:documentation>Denar</xs:documentation>
+					<xs:documentation>Macedonia, Antigua República Yugoslava de.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MMK">
+				<xs:annotation>
+					<xs:documentation>Kiat</xs:documentation>
+					<xs:documentation>Myanmar (ex Birmania).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MNT">
+				<xs:annotation>
+					<xs:documentation>Tugrik</xs:documentation>
+					<xs:documentation>Mongolia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MOP">
+				<xs:annotation>
+					<xs:documentation>Pataca</xs:documentation>
+					<xs:documentation>Macao.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MRO">
+				<xs:annotation>
+					<xs:documentation>Uquiya</xs:documentation>
+					<xs:documentation>Mauritania.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MTL">
+				<xs:annotation>
+					<xs:documentation>Lira maltesa</xs:documentation>
+					<xs:documentation>Malta - actualmente ha reemplazado por el euro (EUR), tan solo se utiliza en los precios históricos anteriores a la introducción del euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MUR">
+				<xs:annotation>
+					<xs:documentation>Rupia mauriciana</xs:documentation>
+					<xs:documentation>Mauricio.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MVR">
+				<xs:annotation>
+					<xs:documentation>Rupia</xs:documentation>
+					<xs:documentation>Maldivas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MWK">
+				<xs:annotation>
+					<xs:documentation>Kwacha</xs:documentation>
+					<xs:documentation>Malaui.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MXN">
+				<xs:annotation>
+					<xs:documentation>Peso mexicano</xs:documentation>
+					<xs:documentation>México.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MYR">
+				<xs:annotation>
+					<xs:documentation>Ringit malayo</xs:documentation>
+					<xs:documentation>Malasia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MZN">
+				<xs:annotation>
+					<xs:documentation>Metical</xs:documentation>
+					<xs:documentation>Mozambique.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NAD">
+				<xs:annotation>
+					<xs:documentation>Dólar namibio</xs:documentation>
+					<xs:documentation>Namibia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NGN">
+				<xs:annotation>
+					<xs:documentation>Naira</xs:documentation>
+					<xs:documentation>Nigeria.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NIO">
+				<xs:annotation>
+					<xs:documentation>Córdoba oro</xs:documentation>
+					<xs:documentation>Nicaragua.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NLG">
+				<xs:annotation>
+					<xs:documentation>Países Bajos, florín.</xs:documentation>
+					<xs:documentation>Actualmente reemplazado por el euro (EUR), tan solo se utiliza en los precios históricos anteriores a la introducción del euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NOK">
+				<xs:annotation>
+					<xs:documentation>Corona noruega</xs:documentation>
+					<xs:documentation>Noruega, Isla Bouvet, Svalbard y Jan Mayen.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NPR">
+				<xs:annotation>
+					<xs:documentation>Rupia nepalesa</xs:documentation>
+					<xs:documentation>Nepal.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NZD">
+				<xs:annotation>
+					<xs:documentation>Dólar neozelandés</xs:documentation>
+					<xs:documentation>Nueva Zelanda, Islas Cook, Niue, Pitcairn, Tokelau.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="OMR">
+				<xs:annotation>
+					<xs:documentation>Rial omaní</xs:documentation>
+					<xs:documentation>Omán.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PAB">
+				<xs:annotation>
+					<xs:documentation>Balboa</xs:documentation>
+					<xs:documentation>Panamá.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PEN">
+				<xs:annotation>
+					<xs:documentation>Nuevo sol</xs:documentation>
+					<xs:documentation>Perú.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PGK">
+				<xs:annotation>
+					<xs:documentation>Kina</xs:documentation>
+					<xs:documentation>Papúa Nueva Guinea.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PHP">
+				<xs:annotation>
+					<xs:documentation>Peso filipino</xs:documentation>
+					<xs:documentation>Filipinas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PKR">
+				<xs:annotation>
+					<xs:documentation>Rupia pakistaní</xs:documentation>
+					<xs:documentation>Pakistán.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PLN">
+				<xs:annotation>
+					<xs:documentation>Esloti</xs:documentation>
+					<xs:documentation>Polonia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PTE">
+				<xs:annotation>
+					<xs:documentation>Portugal, escudo</xs:documentation>
+					<xs:documentation>Actualmente reemplazado por el euro (EUR), tan solo se utiliza en los precios históricos anteriores a la introducción del euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PYG">
+				<xs:annotation>
+					<xs:documentation>Guaraní</xs:documentation>
+					<xs:documentation>Paraguay.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="QAR">
+				<xs:annotation>
+					<xs:documentation>Rial qatarí</xs:documentation>
+					<xs:documentation>Catar</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ROL">
+				<xs:annotation>
+					<xs:documentation>Leu antiguo</xs:documentation>
+					<xs:documentation>Desvalorizado y reemplazado por el RON.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RON">
+				<xs:annotation>
+					<xs:documentation>Leu rumano</xs:documentation>
+					<xs:documentation>Rumanía.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RSD">
+				<xs:annotation>
+					<xs:documentation>Dinar serbio</xs:documentation>
+					<xs:documentation>Serbia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RUB">
+				<xs:annotation>
+					<xs:documentation>Rublo ruso</xs:documentation>
+					<xs:documentation>Federación de Rusia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RUR">
+				<xs:annotation>
+					<xs:documentation>Rublo ruso</xs:documentation>
+					<xs:documentation>Desvalorizado y reemplazado por el RUB.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RWF">
+				<xs:annotation>
+					<xs:documentation>Franco ruandés</xs:documentation>
+					<xs:documentation>Ruanda.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SAR">
+				<xs:annotation>
+					<xs:documentation>Riyal saudí</xs:documentation>
+					<xs:documentation>Arabia Saudí.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SBD">
+				<xs:annotation>
+					<xs:documentation>Dólar de las Islas Salomón</xs:documentation>
+					<xs:documentation>Islas Salomón.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SCR">
+				<xs:annotation>
+					<xs:documentation>Rupia de Seychelles</xs:documentation>
+					<xs:documentation>Islas Seychelles.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SDD">
+				<xs:annotation>
+					<xs:documentation>Dinar sudanés</xs:documentation>
+					<xs:documentation>Actualmente se ha reemplazado por la libra sudanesa (SDG).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SDG">
+				<xs:annotation>
+					<xs:documentation>Libra sudanesa</xs:documentation>
+					<xs:documentation>Sudán.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SEK">
+				<xs:annotation>
+					<xs:documentation>Corona sueca</xs:documentation>
+					<xs:documentation>Suecia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SGD">
+				<xs:annotation>
+					<xs:documentation>Dólar de Singapur</xs:documentation>
+					<xs:documentation>Singapur.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SHP">
+				<xs:annotation>
+					<xs:documentation>Libra de Santa Elena</xs:documentation>
+					<xs:documentation>Santa Elena.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SIT">
+				<xs:annotation>
+					<xs:documentation>Tólar</xs:documentation>
+					<xs:documentation>Actualmente reemplazado por el euro (EUR), tan solo se utiliza en los precios históricos anteriores a la introducción del euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SKK">
+				<xs:annotation>
+					<xs:documentation>Corona eslovaca</xs:documentation>
+					<xs:documentation>Actualmente reemplazado por el euro (EUR), tan solo se utiliza en los precios históricos anteriores a la introducción del euro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SLL">
+				<xs:annotation>
+					<xs:documentation>Leona</xs:documentation>
+					<xs:documentation>Sierra Leona.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SOS">
+				<xs:annotation>
+					<xs:documentation>Chelín somalí</xs:documentation>
+					<xs:documentation>Somalia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SRD">
+				<xs:annotation>
+					<xs:documentation>Florín surinamés</xs:documentation>
+					<xs:documentation>Surinam.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SRG">
+				<xs:annotation>
+					<xs:documentation>Florín surinamés</xs:documentation>
+					<xs:documentation>Desvalorizado y reemplazado por el SRD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="STD">
+				<xs:annotation>
+					<xs:documentation>Dobra</xs:documentation>
+					<xs:documentation>Santo Tomé y Príncipe.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SVC">
+				<xs:annotation>
+					<xs:documentation>Colón de El Salvador</xs:documentation>
+					<xs:documentation>El Salvador.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SYP">
+				<xs:annotation>
+					<xs:documentation>Libra siria</xs:documentation>
+					<xs:documentation>República Árabe de Siria.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SZL">
+				<xs:annotation>
+					<xs:documentation>Lilangeni</xs:documentation>
+					<xs:documentation>Suazilandia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="THB">
+				<xs:annotation>
+					<xs:documentation>Bat</xs:documentation>
+					<xs:documentation>Tailandia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TJS">
+				<xs:annotation>
+					<xs:documentation>Somoni</xs:documentation>
+					<xs:documentation>Tayikistán.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TMM">
+				<xs:annotation>
+					<xs:documentation>Manat</xs:documentation>
+					<xs:documentation>Desvalorizado y reemplazado por el TMT.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TMT">
+				<xs:annotation>
+					<xs:documentation>Manat</xs:documentation>
+					<xs:documentation>Turkmenistán.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TND">
+				<xs:annotation>
+					<xs:documentation>Dinar tunecino</xs:documentation>
+					<xs:documentation>Túnez.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TOP">
+				<xs:annotation>
+					<xs:documentation>Pa&apos;anga</xs:documentation>
+					<xs:documentation>Tonga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TPE">
+				<xs:annotation>
+					<xs:documentation>Escudo timorense</xs:documentation>
+					<xs:documentation>Ya no tiene vigencia, en Timor-Leste se utiliza el dólar estadounidense.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TRL">
+				<xs:annotation>
+					<xs:documentation>Antigua lira turca</xs:documentation>
+					<xs:documentation>Desvalorizado y reemplazado por el TRY.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TRY">
+				<xs:annotation>
+					<xs:documentation>Nueva lira turca</xs:documentation>
+					<xs:documentation>Turquía, desde el 1 de enero de 2005.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TTD">
+				<xs:annotation>
+					<xs:documentation>Dólar trinitense</xs:documentation>
+					<xs:documentation>Trinidad y Tobago.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TWD">
+				<xs:annotation>
+					<xs:documentation>Dólar taiwanés</xs:documentation>
+					<xs:documentation>Provincia de Taiwán.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TZS">
+				<xs:annotation>
+					<xs:documentation>Chelín tanzano</xs:documentation>
+					<xs:documentation>Tanzania, República Unida de.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="UAH">
+				<xs:annotation>
+					<xs:documentation>Grivna</xs:documentation>
+					<xs:documentation>Ucrania.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="UGX">
+				<xs:annotation>
+					<xs:documentation>Chelín ugandés</xs:documentation>
+					<xs:documentation>Uganda.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="USD">
+				<xs:annotation>
+					<xs:documentation>Dólar estadounidense</xs:documentation>
+					<xs:documentation>Estados Unidos, Samoa Americana, Territorio Británico del Océano Índico, Ecuador, Guam, Islas Marshall, Estados Federados de Micronesia, Islas Marianas del Norte, Palaos, Puerto Rico, Timor-Leste, Islas Turcas y Caicos, Islas Ultramarinas Menores de Estados Unidos, Islas Vírgenes Británicas, Islas Vírgenes de los Estados Unidos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="UYU">
+				<xs:annotation>
+					<xs:documentation>Peso uruguayo</xs:documentation>
+					<xs:documentation>Uruguay.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="UZS">
+				<xs:annotation>
+					<xs:documentation>Sum de Uzbekistán</xs:documentation>
+					<xs:documentation>Uzbekistán.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VEB">
+				<xs:annotation>
+					<xs:documentation>Bolívar</xs:documentation>
+					<xs:documentation>Desvalorizado y reemplazado por el VEF.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VEF">
+				<xs:annotation>
+					<xs:documentation>Bolívar fuerte</xs:documentation>
+					<xs:documentation>Venezuela.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VND">
+				<xs:annotation>
+					<xs:documentation>Dong</xs:documentation>
+					<xs:documentation>Vietnam.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VUV">
+				<xs:annotation>
+					<xs:documentation>Vatu</xs:documentation>
+					<xs:documentation>Vanuatu.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WST">
+				<xs:annotation>
+					<xs:documentation>Tala</xs:documentation>
+					<xs:documentation>Samoa.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XAF">
+				<xs:annotation>
+					<xs:documentation>Franco CFA BEAC</xs:documentation>
+					<xs:documentation>Camerún, República Centroafricana, Chad, Congo, Guinea Ecuatorial, Gabón.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XCD">
+				<xs:annotation>
+					<xs:documentation>Dólar del Caribe Oriental</xs:documentation>
+					<xs:documentation>Anguila, Antigua y Barbuda, Dominica, Granada, Montserrat, San Cristóbal y Nieves, Santa Lucía, San Vicente y las Granadinas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XOF">
+				<xs:annotation>
+					<xs:documentation>Franco CFA BCEAO</xs:documentation>
+					<xs:documentation>Benín, Burkina Faso, Costa de Marfil, Guinea-Bissau, Mali, Níger, Senegal, Togo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XPF">
+				<xs:annotation>
+					<xs:documentation>Franco CFP</xs:documentation>
+					<xs:documentation>Polinesia Francesa, Nueva Caledonia, Wallis y Futuna.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="YER">
+				<xs:annotation>
+					<xs:documentation>Rial yemení</xs:documentation>
+					<xs:documentation>Yemen.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="YUM">
+				<xs:annotation>
+					<xs:documentation>Dinar yugoslavo</xs:documentation>
+					<xs:documentation>Desvalorizado y reemplazado por el CSD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZAR">
+				<xs:annotation>
+					<xs:documentation>Rand</xs:documentation>
+					<xs:documentation>Sudáfrica.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZMK">
+				<xs:annotation>
+					<xs:documentation>Kwacha</xs:documentation>
+					<xs:documentation>Zambia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZWD">
+				<xs:annotation>
+					<xs:documentation>Dólar zimbabuense</xs:documentation>
+					<xs:documentation>Desvalorizado y reemplazado por el ZWL.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZWL">
+				<xs:annotation>
+					<xs:documentation>Dólar zimbabuense</xs:documentation>
+					<xs:documentation>Zimbabue.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List97">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 97">Función del texto de la Biblia</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="RL">
+				<xs:annotation>
+					<xs:documentation>Letra roja</xs:documentation>
+					<xs:documentation>Las palabras pronunciadas por Cristo están escritas en rojo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List98">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 98">Valor de la función de la forma del producto - color de la encuadernación o del borde de la página</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="BLK">
+				<xs:annotation>
+					<xs:documentation>Negro</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BLU">
+				<xs:annotation>
+					<xs:documentation>Azul</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BRN">
+				<xs:annotation>
+					<xs:documentation>Marrón</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BUR">
+				<xs:annotation>
+					<xs:documentation>Borgoña/granate</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CRE">
+				<xs:annotation>
+					<xs:documentation>Crema</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FCO">
+				<xs:annotation>
+					<xs:documentation>A cuatro colores</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FCS">
+				<xs:annotation>
+					<xs:documentation>A cuatro colores y color plano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GLD">
+				<xs:annotation>
+					<xs:documentation>Dorado</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GRN">
+				<xs:annotation>
+					<xs:documentation>Verde</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GRY">
+				<xs:annotation>
+					<xs:documentation>Gris</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MUL">
+				<xs:annotation>
+					<xs:documentation>Multicolor</xs:documentation>
+					<xs:documentation>Use &lt;ProductFormFeatureDescription> para añadir algunos datos si fuera necesario.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NAV">
+				<xs:annotation>
+					<xs:documentation>Azul marino/oscuro</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ORG">
+				<xs:annotation>
+					<xs:documentation>Naranja</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PNK">
+				<xs:annotation>
+					<xs:documentation>Rosa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PUR">
+				<xs:annotation>
+					<xs:documentation>Morado</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RED">
+				<xs:annotation>
+					<xs:documentation>Rojo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SLV">
+				<xs:annotation>
+					<xs:documentation>Plateado</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TAN">
+				<xs:annotation>
+					<xs:documentation>Canela</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WHI">
+				<xs:annotation>
+					<xs:documentation>Blanco</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="YEL">
+				<xs:annotation>
+					<xs:documentation>Amarillo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZZZ">
+				<xs:annotation>
+					<xs:documentation>Otro</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List99">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 99">Valor de la función de la forma del producto - material especial para la portada</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Piel de Berkshire</xs:documentation>
+					<xs:documentation>Piel de cerdo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Piel de becerro</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Protectorado francés de Marruecos</xs:documentation>
+					<xs:documentation>De serraje de becerro o de oveja.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Marruecos</xs:documentation>
+					<xs:documentation>Piel de cabra.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Grano regenerado de búfalo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Grano regenerado de becerro</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Cordobán regenerado</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Piel regenerada de anguila</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Piel Ostraleg</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Avestruz regenerada</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Grano regenerado de reptil</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Cuero regenerado</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Cuero bovino</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Piel de anguila</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Kivar</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Cuero flexible</xs:documentation>
+					<xs:documentation>Material para la encuadernación de cuero de imitación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Molesquín</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Cuero fino</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Metal</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Terciopelo</xs:documentation>
+					<xs:documentation>Terciopelo alemán.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>Nácar</xs:documentation>
+					<xs:documentation>Nácar español.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Papiro</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Géltex</xs:documentation>
+					<xs:documentation>Material para la encuadernación de tejido de imitación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Guaflex</xs:documentation>
+					<xs:documentation>Material para la encuadernación de cuero de imitación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List100">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 100">Tipo de código de descuento</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Código de grupo de descuento BIC</xs:documentation>
+					<xs:documentation>El código de grupo de descuento de la editorial o el distribuidor de Reino Unido en el formato especificado por BIC para asegurar exclusividad.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Código de descuento del propietario</xs:documentation>
+					<xs:documentation>Código propio de una editorial o de un proveedor que identifica la categoría de descuento de una transacción. El descuento está establecido en el acuerdo de asociación comercial y se aplica a bienes incluidos en los términos estándares para descuentos comerciales.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Boeksoort</xs:documentation>
+					<xs:documentation>Código de condiciones utilizado en el comercio de libros de los Países Bajos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Código de condiciones alemán</xs:documentation>
+					<xs:documentation>Código de condiciones utilizado en las aplicaciones ONIX alemanas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Código de comisión del propietario</xs:documentation>
+					<xs:documentation>Código propio de una editorial o de un proveedor que identifica la categoría de las tasas de comisión, establecidas en el acuerdo de asociación comercial, y que se aplica en bienes suministrados en términos de organismos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Código de grupo de comisión de BIC</xs:documentation>
+					<xs:documentation>El código de grupo de comisión de la editorial o el distribuidor de Reino Unido en el formato especificado por BIC para asegurar exclusividad. El formato es el mismo que el código de grupo de descuento BIC, pero indica una comisión en lugar de un descuento, el cual se aplica a bienes suministrados en los términos de agencia.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List101">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 101">Tipo de identificador del nombre de la persona</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Propietario</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>PND</xs:documentation>
+					<xs:documentation>Personennamendatei - archivo de la autoridad de los nombres de las personas utilizado por la Biblioteca Nacional de Alemania y en otros países de habla alemana. Véase http://www.d-nb.de/standardisierung/normdateien/pnd.htm (alemán) o http://www.d-nb.de/eng/standardisierung/normdateien/pnd.htm (inglés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>ISNI</xs:documentation>
+					<xs:documentation>International Standard Name Identifier. Véase &quot;http://www.isni.org/&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List102">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 102">Tipo de identificador de los puntos de venta</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Propietario</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Código de identificación de los puntos de venta BIC</xs:documentation>
+					<xs:documentation>Desvalorizado - utilice el código 03.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Código de identificación de los puntos de venta ONIX</xs:documentation>
+					<xs:documentation>De la Lista 139.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List121">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 121">Código de escritura del texto - ISO 15924</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Afak">
+				<xs:annotation>
+					<xs:documentation>Afaka</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Arab">
+				<xs:annotation>
+					<xs:documentation>Árabe</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Armi">
+				<xs:annotation>
+					<xs:documentation>Arameo imperial</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Armn">
+				<xs:annotation>
+					<xs:documentation>Armenio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Avst">
+				<xs:annotation>
+					<xs:documentation>Avestan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Bali">
+				<xs:annotation>
+					<xs:documentation>Balinese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Bamu">
+				<xs:annotation>
+					<xs:documentation>Bamun</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Bass">
+				<xs:annotation>
+					<xs:documentation>Bassa Vah</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Batk">
+				<xs:annotation>
+					<xs:documentation>Batak</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Beng">
+				<xs:annotation>
+					<xs:documentation>Bengalí</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Blis">
+				<xs:annotation>
+					<xs:documentation>Blissymbols</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Bopo">
+				<xs:annotation>
+					<xs:documentation>Bopomofo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Brah">
+				<xs:annotation>
+					<xs:documentation>Brahmi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Brai">
+				<xs:annotation>
+					<xs:documentation>Braille</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Bugi">
+				<xs:annotation>
+					<xs:documentation>Bugis</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Buhd">
+				<xs:annotation>
+					<xs:documentation>Buhid</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Cakm">
+				<xs:annotation>
+					<xs:documentation>Chakma</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Cans">
+				<xs:annotation>
+					<xs:documentation>Silabario Aborigen Canadiense Unificado</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Cari">
+				<xs:annotation>
+					<xs:documentation>Carian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Cham">
+				<xs:annotation>
+					<xs:documentation>Cham</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Cher">
+				<xs:annotation>
+					<xs:documentation>Cheroqui</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Cirt">
+				<xs:annotation>
+					<xs:documentation>Cirth</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Copt">
+				<xs:annotation>
+					<xs:documentation>Cópco</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Cprt">
+				<xs:annotation>
+					<xs:documentation>Chipriota</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Cyrl">
+				<xs:annotation>
+					<xs:documentation>Cirílico</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Cyrs">
+				<xs:annotation>
+					<xs:documentation>Cirílico (antiguo eslavo eclesiástico)</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Deva">
+				<xs:annotation>
+					<xs:documentation>Devanagari (Nagari)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Dsrt">
+				<xs:annotation>
+					<xs:documentation>Deseret (Mormon)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Dupl">
+				<xs:annotation>
+					<xs:documentation>Duployan shorthand, Duployan stenography</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Egyd">
+				<xs:annotation>
+					<xs:documentation>Egipcio demótico</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Egyh">
+				<xs:annotation>
+					<xs:documentation>Egipcio hierático</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Egyp">
+				<xs:annotation>
+					<xs:documentation>Jeroglíficos egipcios</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Elba">
+				<xs:annotation>
+					<xs:documentation>Elbasan</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Ethi">
+				<xs:annotation>
+					<xs:documentation>Etíope (Ge&apos;ez)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Geok">
+				<xs:annotation>
+					<xs:documentation>Khutsuri (Asomtavruli and Khutsuri)</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Geor">
+				<xs:annotation>
+					<xs:documentation>Georgian (Mkhedruli)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Glag">
+				<xs:annotation>
+					<xs:documentation>Glagolitic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Goth">
+				<xs:annotation>
+					<xs:documentation>Gothic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Gran">
+				<xs:annotation>
+					<xs:documentation>Grantha</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Grek">
+				<xs:annotation>
+					<xs:documentation>Greek</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Gujr">
+				<xs:annotation>
+					<xs:documentation>Gujarati</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Guru">
+				<xs:annotation>
+					<xs:documentation>Gurmukhi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Hang">
+				<xs:annotation>
+					<xs:documentation>Hangul (Hangeul)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Hani">
+				<xs:annotation>
+					<xs:documentation>Han (hanzi, kanji, hanja)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Hano">
+				<xs:annotation>
+					<xs:documentation>Hanunoo (hanunóo)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Hans">
+				<xs:annotation>
+					<xs:documentation>Han (simplified variant)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Hant">
+				<xs:annotation>
+					<xs:documentation>Han (traditional variant)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Hebr">
+				<xs:annotation>
+					<xs:documentation>Hebreo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Hira">
+				<xs:annotation>
+					<xs:documentation>Hiragana</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Hmng">
+				<xs:annotation>
+					<xs:documentation>Pahawh Hmong</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Hrkt">
+				<xs:annotation>
+					<xs:documentation>Japanese syllabaries (alias for hiragana + katakana)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Hung">
+				<xs:annotation>
+					<xs:documentation>Old Hungarian</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Inds">
+				<xs:annotation>
+					<xs:documentation>Indus (harappan)</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Ital">
+				<xs:annotation>
+					<xs:documentation>Old Italic (etruscan, oscan, etc.)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Java">
+				<xs:annotation>
+					<xs:documentation>Javanese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Jpan">
+				<xs:annotation>
+					<xs:documentation>Japanese syllabaries (alias for Han + Hiragana + Katakana)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Jurc">
+				<xs:annotation>
+					<xs:documentation>Jurchen</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Kali">
+				<xs:annotation>
+					<xs:documentation>Kayah Li</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Kana">
+				<xs:annotation>
+					<xs:documentation>Katakana</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Khar">
+				<xs:annotation>
+					<xs:documentation>Kharoshthi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Khmr">
+				<xs:annotation>
+					<xs:documentation>Khmer</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Khoj">
+				<xs:annotation>
+					<xs:documentation>Khojki</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Knda">
+				<xs:annotation>
+					<xs:documentation>Kannada</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Kore">
+				<xs:annotation>
+					<xs:documentation>Korean (alias for hangul + han)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Kpel">
+				<xs:annotation>
+					<xs:documentation>Kpelle</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Kthi">
+				<xs:annotation>
+					<xs:documentation>Kaithi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Lana">
+				<xs:annotation>
+					<xs:documentation>Lanna, Tai Tham</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Laoo">
+				<xs:annotation>
+					<xs:documentation>Lao</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Latf">
+				<xs:annotation>
+					<xs:documentation>Latin (Fraktur variant)</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Latg">
+				<xs:annotation>
+					<xs:documentation>Latin (Gaelic variant)</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Latn">
+				<xs:annotation>
+					<xs:documentation>Latín</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Lepc">
+				<xs:annotation>
+					<xs:documentation>Lepcha (Róng)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Limb">
+				<xs:annotation>
+					<xs:documentation>Limbu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Lina">
+				<xs:annotation>
+					<xs:documentation>Linear A</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Linb">
+				<xs:annotation>
+					<xs:documentation>Linear B</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Lisu">
+				<xs:annotation>
+					<xs:documentation>Lisu (Fraser)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Loma">
+				<xs:annotation>
+					<xs:documentation>Loma</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Lyci">
+				<xs:annotation>
+					<xs:documentation>Lycian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Lydi">
+				<xs:annotation>
+					<xs:documentation>Lydian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Mand">
+				<xs:annotation>
+					<xs:documentation>Mandaic, mandaean</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Mani">
+				<xs:annotation>
+					<xs:documentation>Manichaean</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Maya">
+				<xs:annotation>
+					<xs:documentation>Mayan hieroglyphs</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Mend">
+				<xs:annotation>
+					<xs:documentation>Mende</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Merc">
+				<xs:annotation>
+					<xs:documentation>Meroitic cursive</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Mero">
+				<xs:annotation>
+					<xs:documentation>Meroitic hieroglyphs</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Mlym">
+				<xs:annotation>
+					<xs:documentation>Malayalam</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Mong">
+				<xs:annotation>
+					<xs:documentation>Mongolian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Moon">
+				<xs:annotation>
+					<xs:documentation>Moon (Moon code, Moon script, Moon type)</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Mroo">
+				<xs:annotation>
+					<xs:documentation>Mro, Mru</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Mtei">
+				<xs:annotation>
+					<xs:documentation>Meitei Mayek (meithei, meetei)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Mymr">
+				<xs:annotation>
+					<xs:documentation>Myanmar (burmese)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Narb">
+				<xs:annotation>
+					<xs:documentation>Old North Arabian (Ancient North Arabian)</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Nbat">
+				<xs:annotation>
+					<xs:documentation>Nabatean</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Nkgb">
+				<xs:annotation>
+					<xs:documentation>Nakhi Geba (Naxi Geba)</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Nkoo">
+				<xs:annotation>
+					<xs:documentation>N&apos;Ko</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Nshu">
+				<xs:annotation>
+					<xs:documentation>Nüshu</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Ogam">
+				<xs:annotation>
+					<xs:documentation>Ogham</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Olck">
+				<xs:annotation>
+					<xs:documentation>Ol Chiki (Ol Cemet&apos;, Ol, Santali)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Orkh">
+				<xs:annotation>
+					<xs:documentation>Old turkic, orkhon runic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Orya">
+				<xs:annotation>
+					<xs:documentation>Oriya</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Osma">
+				<xs:annotation>
+					<xs:documentation>Osmanya</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Palm">
+				<xs:annotation>
+					<xs:documentation>Palmyrene</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Perm">
+				<xs:annotation>
+					<xs:documentation>Old permic</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Phag">
+				<xs:annotation>
+					<xs:documentation>Phags-pa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Phli">
+				<xs:annotation>
+					<xs:documentation>Inscriptional pahlavi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Phlp">
+				<xs:annotation>
+					<xs:documentation>Psalter pahlavi</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Phlv">
+				<xs:annotation>
+					<xs:documentation>Book Pahlavi</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Phnx">
+				<xs:annotation>
+					<xs:documentation>Fenicio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Plrd">
+				<xs:annotation>
+					<xs:documentation>Miao (Pollard)</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Prti">
+				<xs:annotation>
+					<xs:documentation>Inscriptional parthian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Qaaa">
+				<xs:annotation>
+					<xs:documentation>Reservado para uso privado (iniciar)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Qabx">
+				<xs:annotation>
+					<xs:documentation>Reservado para uso privado (finalizar)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Rjng">
+				<xs:annotation>
+					<xs:documentation>Rejang (redjang, kaganga)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Roro">
+				<xs:annotation>
+					<xs:documentation>Rongorongo</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Runr">
+				<xs:annotation>
+					<xs:documentation>Runic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Samr">
+				<xs:annotation>
+					<xs:documentation>Samaritan</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Sara">
+				<xs:annotation>
+					<xs:documentation>Sarati</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Sarb">
+				<xs:annotation>
+					<xs:documentation>Old South Arabian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Saur">
+				<xs:annotation>
+					<xs:documentation>Saurashtra</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Sgnw">
+				<xs:annotation>
+					<xs:documentation>SignWriting</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Shaw">
+				<xs:annotation>
+					<xs:documentation>Shavian (Shaw)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Shrd">
+				<xs:annotation>
+					<xs:documentation>Sharada</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Sind">
+				<xs:annotation>
+					<xs:documentation>Khudawadi, Sindhi</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Sinh">
+				<xs:annotation>
+					<xs:documentation>Sinhala</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Sora">
+				<xs:annotation>
+					<xs:documentation>Sora Sompeng</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Sund">
+				<xs:annotation>
+					<xs:documentation>Sundanese</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Sylo">
+				<xs:annotation>
+					<xs:documentation>Syloti nagri</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Syrc">
+				<xs:annotation>
+					<xs:documentation>Syriac</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Syre">
+				<xs:annotation>
+					<xs:documentation>Syriac (Estrangelo variant)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Syrj">
+				<xs:annotation>
+					<xs:documentation>Syriac (Western variant)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Syrn">
+				<xs:annotation>
+					<xs:documentation>Syriac (Eastern variant)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Tagb">
+				<xs:annotation>
+					<xs:documentation>Tagbanwa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Takr">
+				<xs:annotation>
+					<xs:documentation>Takri</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Tale">
+				<xs:annotation>
+					<xs:documentation>Tai Le</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Talu">
+				<xs:annotation>
+					<xs:documentation>New Tai Lue</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Taml">
+				<xs:annotation>
+					<xs:documentation>Tamil</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Tang">
+				<xs:annotation>
+					<xs:documentation>Tangut</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Tavt">
+				<xs:annotation>
+					<xs:documentation>Tai Viet</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Telu">
+				<xs:annotation>
+					<xs:documentation>Telugu</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Teng">
+				<xs:annotation>
+					<xs:documentation>Tengwar</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Tfng">
+				<xs:annotation>
+					<xs:documentation>Tifinagh (berber)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Tglg">
+				<xs:annotation>
+					<xs:documentation>Tagalog (baybayin, alibata)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Thaa">
+				<xs:annotation>
+					<xs:documentation>Thaana</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Thai">
+				<xs:annotation>
+					<xs:documentation>Tailandés</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Tibt">
+				<xs:annotation>
+					<xs:documentation>Tibetano</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Tirh">
+				<xs:annotation>
+					<xs:documentation>Tiruta</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Ugar">
+				<xs:annotation>
+					<xs:documentation>Ugaritic</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Vaii">
+				<xs:annotation>
+					<xs:documentation>Vai</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Visp">
+				<xs:annotation>
+					<xs:documentation>Visible Speech</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Wara">
+				<xs:annotation>
+					<xs:documentation>Warang Citi (Varang Kshiti)</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Wole">
+				<xs:annotation>
+					<xs:documentation>Woleai</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Xpeo">
+				<xs:annotation>
+					<xs:documentation>Old Persian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Xsux">
+				<xs:annotation>
+					<xs:documentation>Cuneiform, sumero-akkadian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Yiii">
+				<xs:annotation>
+					<xs:documentation>Yi</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Zinh">
+				<xs:annotation>
+					<xs:documentation>Código para sistema de escritura heredado</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Zmth">
+				<xs:annotation>
+					<xs:documentation>Notación matemática</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Zsym">
+				<xs:annotation>
+					<xs:documentation>Símbolos</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Zxxx">
+				<xs:annotation>
+					<xs:documentation>Código para documentos no escritos</xs:documentation>
+					<xs:documentation>No soportado en Unicode.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Zyyy">
+				<xs:annotation>
+					<xs:documentation>Código para sistemas de escritura no determinados</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Zzzz">
+				<xs:annotation>
+					<xs:documentation>Código para sistema de escritura sin código específico</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List138">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 138">Código del sistema de transliteración</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="SFS4900">
+				<xs:annotation>
+					<xs:documentation>Estándar finlandés SFS 4900</xs:documentation>
+					<xs:documentation>Transliteración de caracteres cirílicos - lenguas eslavas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SFS5807">
+				<xs:annotation>
+					<xs:documentation>Estándar finlandés SFS 5807</xs:documentation>
+					<xs:documentation>Transliteración y transcripción de caracteres griegos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SFS5755">
+				<xs:annotation>
+					<xs:documentation>Estándar finlandés SFS 5755</xs:documentation>
+					<xs:documentation>Transliteración de caracteres árabes.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SFS3602">
+				<xs:annotation>
+					<xs:documentation>Estándar finlandés SFS 5824</xs:documentation>
+					<xs:documentation>Transliteración de caracteres hebreos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ISO3602">
+				<xs:annotation>
+					<xs:documentation>ISO 3602</xs:documentation>
+					<xs:documentation>Documentación - Romanización del japonés (escritura kana).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ISO7098">
+				<xs:annotation>
+					<xs:documentation>ISO 7098</xs:documentation>
+					<xs:documentation>Información y documentación - Romanización del chino.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List139">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 139">Identificador ONIX de punto de venta</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ACM">
+				<xs:annotation>
+					<xs:documentation>A C Moore</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AAP">
+				<xs:annotation>
+					<xs:documentation>A&amp;P</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ALB">
+				<xs:annotation>
+					<xs:documentation>Albertson&apos;s</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AMZ">
+				<xs:annotation>
+					<xs:documentation>Amazon</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ANR">
+				<xs:annotation>
+					<xs:documentation>Angus and Robertson</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ANB">
+				<xs:annotation>
+					<xs:documentation>Anobii</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="APC">
+				<xs:annotation>
+					<xs:documentation>Apple Computer stores</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ASD">
+				<xs:annotation>
+					<xs:documentation>Asda</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AUD">
+				<xs:annotation>
+					<xs:documentation>Audible</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BDL">
+				<xs:annotation>
+					<xs:documentation>B Dalton</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BNO">
+				<xs:annotation>
+					<xs:documentation>Barnes &amp; Noble</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BBB">
+				<xs:annotation>
+					<xs:documentation>Bed Bath &amp; Beyond</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BST">
+				<xs:annotation>
+					<xs:documentation>Best Buy</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BIL">
+				<xs:annotation>
+					<xs:documentation>Bilbary</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BJW">
+				<xs:annotation>
+					<xs:documentation>BJ&apos;s Wholesale Club</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BLK">
+				<xs:annotation>
+					<xs:documentation>Blackwell&apos;s</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BCA">
+				<xs:annotation>
+					<xs:documentation>Book Club Associates</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BSH">
+				<xs:annotation>
+					<xs:documentation>Bookish</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BKP">
+				<xs:annotation>
+					<xs:documentation>Bookpeople</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BKM">
+				<xs:annotation>
+					<xs:documentation>Books-A-Million</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BRD">
+				<xs:annotation>
+					<xs:documentation>Borders</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BRB">
+				<xs:annotation>
+					<xs:documentation>Borders/Books Etc</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BRT">
+				<xs:annotation>
+					<xs:documentation>British Bookshops</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CHD">
+				<xs:annotation>
+					<xs:documentation>Christianbook.com</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CST">
+				<xs:annotation>
+					<xs:documentation>Costco</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CRB">
+				<xs:annotation>
+					<xs:documentation>Crate &amp; Barrel</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CVS">
+				<xs:annotation>
+					<xs:documentation>CVS Drug Stores</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DSG">
+				<xs:annotation>
+					<xs:documentation>Dick&apos;s Sporting Goods</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DYM">
+				<xs:annotation>
+					<xs:documentation>Dymocks</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ELC">
+				<xs:annotation>
+					<xs:documentation>Early Learning Centre</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ESN">
+				<xs:annotation>
+					<xs:documentation>Eason</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EBC">
+				<xs:annotation>
+					<xs:documentation>Ebooks Corp</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ECH">
+				<xs:annotation>
+					<xs:documentation>eChristian</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ELB">
+				<xs:annotation>
+					<xs:documentation>Elib.se</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EMP">
+				<xs:annotation>
+					<xs:documentation>Empik</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ENH">
+				<xs:annotation>
+					<xs:documentation>English Heritage</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FNC">
+				<xs:annotation>
+					<xs:documentation>Fnac</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FRY">
+				<xs:annotation>
+					<xs:documentation>Fry&apos;s Electronics</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GMS">
+				<xs:annotation>
+					<xs:documentation>Gamestop</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GOO">
+				<xs:annotation>
+					<xs:documentation>Google Books</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="GOS">
+				<xs:annotation>
+					<xs:documentation>GoSpoken</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HST">
+				<xs:annotation>
+					<xs:documentation>Hastings Entertainment</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HMV">
+				<xs:annotation>
+					<xs:documentation>HMV</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="HMD">
+				<xs:annotation>
+					<xs:documentation>Home Depot</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="IND">
+				<xs:annotation>
+					<xs:documentation>Indigo-Chapters</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="JSM">
+				<xs:annotation>
+					<xs:documentation>John Smith &amp; Son</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KMT">
+				<xs:annotation>
+					<xs:documentation>K-Mart</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KNB">
+				<xs:annotation>
+					<xs:documentation>KNFB/Blio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KNO">
+				<xs:annotation>
+					<xs:documentation>Kno Inc</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KBO">
+				<xs:annotation>
+					<xs:documentation>Kobo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KOO">
+				<xs:annotation>
+					<xs:documentation>Koorong</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="KRG">
+				<xs:annotation>
+					<xs:documentation>Kroger</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LWE">
+				<xs:annotation>
+					<xs:documentation>Lowe&apos;s</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MKS">
+				<xs:annotation>
+					<xs:documentation>Marks &amp; Spencer</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MAT">
+				<xs:annotation>
+					<xs:documentation>Matras</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MMS">
+				<xs:annotation>
+					<xs:documentation>Media Markt/Saturn</xs:documentation>
+					<xs:documentation>También conocido como Media World.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MCR">
+				<xs:annotation>
+					<xs:documentation>Microcenter</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MRR">
+				<xs:annotation>
+					<xs:documentation>Morrisons</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MTC">
+				<xs:annotation>
+					<xs:documentation>Mothercare</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="NTR">
+				<xs:annotation>
+					<xs:documentation>National Trust</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="OFD">
+				<xs:annotation>
+					<xs:documentation>Office Depot</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="OFM">
+				<xs:annotation>
+					<xs:documentation>Office Max</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="OLF">
+				<xs:annotation>
+					<xs:documentation>OLF</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PST">
+				<xs:annotation>
+					<xs:documentation>Past Times</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PTS">
+				<xs:annotation>
+					<xs:documentation>Pet Smart</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PTC">
+				<xs:annotation>
+					<xs:documentation>Petco</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PLY">
+				<xs:annotation>
+					<xs:documentation>Play.com</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PTB">
+				<xs:annotation>
+					<xs:documentation>Pottery Barn</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RCL">
+				<xs:annotation>
+					<xs:documentation>ReadCloud</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RST">
+				<xs:annotation>
+					<xs:documentation>Restoration Hardware</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RET">
+				<xs:annotation>
+					<xs:documentation>Rethink</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="RTZ">
+				<xs:annotation>
+					<xs:documentation>Ritz Camera</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SFW">
+				<xs:annotation>
+					<xs:documentation>Safeway</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SNS">
+				<xs:annotation>
+					<xs:documentation>Sainsbury&apos;s</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SLF">
+				<xs:annotation>
+					<xs:documentation>Selfridges</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SNY">
+				<xs:annotation>
+					<xs:documentation>Sony</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="STP">
+				<xs:annotation>
+					<xs:documentation>Staples</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TRG">
+				<xs:annotation>
+					<xs:documentation>Target</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TES">
+				<xs:annotation>
+					<xs:documentation>Tesco</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TSR">
+				<xs:annotation>
+					<xs:documentation>Toys &apos;R&apos; Us</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TSO">
+				<xs:annotation>
+					<xs:documentation>TSO (The Stationery Office)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VRG">
+				<xs:annotation>
+					<xs:documentation>Virgin Megastores</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WHS">
+				<xs:annotation>
+					<xs:documentation>W H Smith</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WTR">
+				<xs:annotation>
+					<xs:documentation>Waitrose</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WLM">
+				<xs:annotation>
+					<xs:documentation>Wal-Mart</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WST">
+				<xs:annotation>
+					<xs:documentation>Waterstone&apos;s</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WHT">
+				<xs:annotation>
+					<xs:documentation>Whitcoul&apos;s</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WLS">
+				<xs:annotation>
+					<xs:documentation>Williams Sonoma</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="WLW">
+				<xs:annotation>
+					<xs:documentation>Woolworths</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZVV">
+				<xs:annotation>
+					<xs:documentation>Zavvi</xs:documentation>
+					<xs:documentation>Antes &quot;Virgin Megastores&quot; (UK).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZZZ">
+				<xs:annotation>
+					<xs:documentation>Otro</xs:documentation>
+					<xs:documentation>Incluya el nombre del vendedor en &lt;SalesOutletName>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List140">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 140">Código de aviso de peligro de asfixia US CPSIA</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>AVISO: PELIGRO DE ASFIXIA - Piezas pequeñas | No para menores de 3 años.
+</xs:documentation>
+					<xs:documentation>Lista retirada. Utilice la Lista 143.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>AVISO: PELIGRO DE ASFIXIA - Este juguete es una pelota o bola de pequeño tamaño | No para menores de 3 años.
+</xs:documentation>
+					<xs:documentation>Lista retirada. Utilice la Lista 143.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>AVISO: PELIGRO DE ASFIXIA - Este juguete contiene una pelota o bola de pequeño tamaño | No para menores de 3 años.</xs:documentation>
+					<xs:documentation>Lista retirada. Utilice la Lista 143.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>AVISO: PELIGRO DE ASFIXIA | No para menores de 8 años. pueden ahogarse o asfixiarse con globos deshinchados o rotos.  Se requiere la supervisión de un adulto | No deje globos deshinchados al alcance de los niños. Retire inmediatamente los globos rotos.</xs:documentation>
+					<xs:documentation>Lista retirada. Utilice la Lista 143.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>AVISO: PELIGRO DE ASFIXIA - Este juguete es una canica | No para menores de 3 años
+</xs:documentation>
+					<xs:documentation>Lista retirada. Utilice la Lista 143.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>AVISO: PELIGRO DE ASFIXIA - Este juguete contiene una canica | No para menores de 3 años
+</xs:documentation>
+					<xs:documentation>Lista retirada. Utilice la Lista 143.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>No es necesario un aviso de peligro de asfixia
+</xs:documentation>
+					<xs:documentation>Lista retirada. Utilice la Lista 143.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List141">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 141">Indicador de código de barras</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Sin código de barras</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Con código de barras; régimen indeterminado</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>GTIN-13</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>GTIN-13+5 (Precio en dólares EE.UU. codificado)
+</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>GTIN-13+5 (Precio en dólares de Canadá codificado)
+</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>GTIN-13+5 (Sin precio codificado)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>UPC12 (item-specific)</xs:documentation>
+					<xs:documentation>AKA artículo/precio</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (item-specific)</xs:documentation>
+					<xs:documentation>AKA artículo/precio</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>UPC12 (item-specific)</xs:documentation>
+					<xs:documentation>AKA precio/artículo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>UPC12+5 (price-point)</xs:documentation>
+					<xs:documentation>AKA precio/artículo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List142">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 142">Posición en el producto</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Desconocido / no especificado</xs:documentation>
+					<xs:documentation>Posición desconocida o no especificada.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>4ª de cubierta</xs:documentation>
+					<xs:documentation>La contraportada de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>3ª de cubierta</xs:documentation>
+					<xs:documentation>La contraportada interior de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>2ª de cubierta</xs:documentation>
+					<xs:documentation>La portada interior de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>1ª de cubierta</xs:documentation>
+					<xs:documentation>La portada de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>En el lomo</xs:documentation>
+					<xs:documentation>El lomo de un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>En la caja</xs:documentation>
+					<xs:documentation>Para productos presentados en caja.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>En etiqueta</xs:documentation>
+					<xs:documentation>Solo para etiquetas colgantes.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>En la parte inferior</xs:documentation>
+					<xs:documentation>No usar para libros salvo que se presenten en algún tipo de embalaje externo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>En la parte trasera</xs:documentation>
+					<xs:documentation>No usar para libros salvo que se presenten en algún tipo de embalaje externo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>En una funda exterior o en la parte trasera</xs:documentation>
+					<xs:documentation>Tan solo se utiliza en los productos empaquetados en fundas exteriores.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>En envoltorio desechable</xs:documentation>
+					<xs:documentation>Para productos empaquetados mediante retractilado u otros envoltorios desechables similares.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List143">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 143">Código de aviso de peligro de asfixia US CPSIA</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>AVISO: PELIGRO DE ASFIXIA - Piezas pequeñas | No para menores de 3 años.
+</xs:documentation>
+					<xs:documentation>Requerido en productos de venta en EE.UU.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>AVISO: PELIGRO DE ASFIXIA | No para menores de 8 años. pueden ahogarse o asfixiarse con globos deshinchados o rotos.  Se requiere la supervisión de un adulto | No deje globos deshinchados al alcance de los niños. Retire inmediatamente los globos rotos.</xs:documentation>
+					<xs:documentation>Requerido en productos de venta en EE.UU.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>AVISO: PELIGRO DE ASFIXIA - Este juguete es una pelota o bola de pequeño tamaño | No para menores de 3 años.
+</xs:documentation>
+					<xs:documentation>Requerido en productos de venta en EE.UU.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>AVISO: PELIGRO DE ASFIXIA - Este juguete contiene una pelota o bola de pequeño tamaño | No para menores de 3 años.</xs:documentation>
+					<xs:documentation>Requerido en productos de venta en EE.UU.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>AVISO: PELIGRO DE ASFIXIA - Este juguete es una canica | No para menores de 3 años
+</xs:documentation>
+					<xs:documentation>Requerido en productos de venta en EE.UU.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>AVISO: PELIGRO DE ASFIXIA - Este juguete contiene una canica | No para menores de 3 años
+</xs:documentation>
+					<xs:documentation>Requerido en productos de venta en EE.UU.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>No es necesario un aviso de peligro de asfixia
+</xs:documentation>
+					<xs:documentation>Cuando el proveedor desea hacer explícita la no obligatoriedad de este tipo de aviso para un producto concreto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List144">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 144">Protección técnica de publicación digital</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Ninguno</xs:documentation>
+					<xs:documentation>Sin protección técnica (sin DRM)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>DRM</xs:documentation>
+					<xs:documentation>Tiene protección DRM.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Marca de agua digital</xs:documentation>
+					<xs:documentation>Incluye marca de agua digital.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>DRM de Adobe</xs:documentation>
+					<xs:documentation>Tiene protección DRM proporcionada por el  Adobe CS4 Content Server Package o por el servicio alojado Adobe ADEPT.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>DRM de Apple</xs:documentation>
+					<xs:documentation>Protección DRM &quot;FairPlay&quot; aplicada por la tienda en línea de Apple.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>DRM de OMA</xs:documentation>
+					<xs:documentation>Incluye protección DRM OMA v2, para protección de algunos contenidos en teléfonos móviles.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List145">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 145">Tipo de uso</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Previsualizar</xs:documentation>
+					<xs:documentation>Vista previa antes de la compra.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Imprimir</xs:documentation>
+					<xs:documentation>Impresión en papel de un extracto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Copiar / pegar</xs:documentation>
+					<xs:documentation>Copia en formato digital de un extracto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Compartir</xs:documentation>
+					<xs:documentation>Posibilidad de compartir múltiples copias concurrentes en varios dispositivos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Texto a voz</xs:documentation>
+					<xs:documentation>&quot;Lectura en voz alta&quot;, mediante funcionalidad de conversión de texto a voz.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Préstamo</xs:documentation>
+					<xs:documentation>Se permite su préstamo a otro propietario de un dispositivo lector o de una cuenta de acceso: por ejemplo, préstamo a un amigo, préstamo en biblioteca. La copia primaria de la obra no es accesible mientras la copia secundaria esté &quot;en préstamo&quot; salvo que se especifique, adicionalmente, un número de copias concurrentes autorizadas.
+</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Licencia por tiempo limitado</xs:documentation>
+					<xs:documentation>La licencia de la obra digital tiene una duración limitada. Úsese con el código 02 de la Lista 146 y un valor de días en  &lt;EpubUsageLimit>.
+</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List146">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 146">Permiso de uso</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Permitido sin límites</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Permitido, con limitaciones</xs:documentation>
+					<xs:documentation>La limitación se debe indicar en &lt;EpubUsageLimit>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>No permitido</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List147">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 147">Permiso de uso</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Copias / Ejemplares</xs:documentation>
+					<xs:documentation>Número máximo de copias que se pueden realizar de un determinado extracto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Caracteres</xs:documentation>
+					<xs:documentation>Número máximo de caracteres permitidos en un extracto para un uso determinado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Palabras</xs:documentation>
+					<xs:documentation>Número máximo de palabras permitidas en un extracto para un uso determinado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Páginas</xs:documentation>
+					<xs:documentation>Número máximo de páginas permitidas en un extracto para un uso determinado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Porcentaje</xs:documentation>
+					<xs:documentation>Porcentaje máximo del total, permitido en un extracto para un uso determinado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Dispositivos</xs:documentation>
+					<xs:documentation>Número máximo de dispositivos en un grupo de uso compartido (&quot;share group&quot;).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Usuarios/as concurrentes</xs:documentation>
+					<xs:documentation>Número máximo de usuarios/as concurrentes. Número máximo de usuarios/as concurrentes. NOTA: si este número no está limitado, de forma explícita, indique un valor 0&quot; (cero) en este campo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Porcentaje por periodo de tiempo</xs:documentation>
+					<xs:documentation>Porcentaje máximo del total, permitido para un uso determinado durante un periodo de tiempo dado; el periodo de tiempo se debe indicar en otro bloque  EpubUsageQuantity.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Días</xs:documentation>
+					<xs:documentation>Periodo máximo en días.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Veces / Repeticiones</xs:documentation>
+					<xs:documentation>Número máximo de veces permitido para un uso determinado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Página inicial de uso permitido</xs:documentation>
+					<xs:documentation>Número de la página en la que comienza la autorización para un uso específico. El elemento &lt;Quantity> debe contener un número de página absoluto, incluyendo la cubierta como página número 1. (Este tipo de numeración no puede emplearse en el caso de que la publicación digital no incluya un sistema de numeración fija de páginas).. Utilizar con &quot;número máximo de páginas&quot;, &quot;porcentaje de contenido&quot; o &quot;página final&quot; para especificar el contenido que se puede mostrar en la previsualización.
+</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Página final de uso permitido</xs:documentation>
+					<xs:documentation>Número de la página en la que termina la autorización para un uso específico.
+. El elemento &lt;Quantity> debe contener un número de página absoluto, incluyendo la cubierta como página número 1. (Este tipo de numeración no puede emplearse en el caso de que la publicación digital no incluya un sistema de numeración fija de páginas).. Utilizar con &quot;página inicial&quot; para especificar el contenido que se puede mostrar en la previsualización.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List148">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 148">Tipo de colección o serie</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>No especificado (valor por defecto)</xs:documentation>
+					<xs:documentation>No especificado (valor por defecto)</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Conjunto definido por la editorial</xs:documentation>
+					<xs:documentation>El conjunto (colección u Obra Completa (publicación en varios volúmenes)) está definido como tal por la editorial, bien en el propio producto o mediante información aneja al producto proporcionada por la editorial.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Conjunto definido por algún agente externo a la editorial</xs:documentation>
+					<xs:documentation>El conjunto (colección, Obra completa (publicación en varios volúmenes) o pack) se ha definido e identificado como tal por una entidad, dentro de la cadena de suministro de metadatos, ajena a la editorial; en general, puede ser un agregador de metadatos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List149">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 149">Nivel del elemento del título</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Producto</xs:documentation>
+					<xs:documentation>El elemento del título se refiere a un producto individual (monografía).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Nivel del conjunto</xs:documentation>
+					<xs:documentation>El elemento del título se refiere al elemento principal (primero en la jerarquía) de un conjunto bibliográfico: colección u Obra completa (publicación en varios volúmenes).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Subnivel</xs:documentation>
+					<xs:documentation>El elemento del título se refiere a un elemento de nivel intermedio de un conjunto bibliográfico: colección u Obra completa (publicación en varios volúmenes), que incluya varios niveles jerárquicos (por ejemplo &quot;subcolecciones&quot;).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Elemento de contenido</xs:documentation>
+					<xs:documentation>El elemento del título se refiere a un elemento de contenido dentro de la obra, por ejemplo un capítulo de la obra u el título de una obra contenida, en el caso de que el producto incluya varias (por ejemplo, un repertorio de novelas cortas encuadernadas en un único volumen).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List150">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 150">Forma del producto</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Sin definir</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AA">
+				<xs:annotation>
+					<xs:documentation>Audio</xs:documentation>
+					<xs:documentation>Grabación de audio; detalle sin especificar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AB">
+				<xs:annotation>
+					<xs:documentation>Cinta de audio</xs:documentation>
+					<xs:documentation>Cinta de audio (analógica).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AC">
+				<xs:annotation>
+					<xs:documentation>CD de audio</xs:documentation>
+					<xs:documentation>CD de audio en cualquier formato: utilice la codificación que figura en el Detalle del formulario del producto para especificar el formato, si procede.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AD">
+				<xs:annotation>
+					<xs:documentation>DAT</xs:documentation>
+					<xs:documentation>Cinta de audio digital.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AE">
+				<xs:annotation>
+					<xs:documentation>Disco de audio</xs:documentation>
+					<xs:documentation>Disco de audio (sin incluir los CD).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AF">
+				<xs:annotation>
+					<xs:documentation>Cinta de audio</xs:documentation>
+					<xs:documentation>Cinta audio (bobina).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AG">
+				<xs:annotation>
+					<xs:documentation>MiniDisc</xs:documentation>
+					<xs:documentation>Formato MiniDisc de Sony.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AH">
+				<xs:annotation>
+					<xs:documentation>CD-Extra</xs:documentation>
+					<xs:documentation>CD de audio con una parte para contenido de CD-ROM.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AI">
+				<xs:annotation>
+					<xs:documentation>DVD Audio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AJ">
+				<xs:annotation>
+					<xs:documentation>Archivo de audio descargable</xs:documentation>
+					<xs:documentation>Grabación de audio descargable en línea.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AK">
+				<xs:annotation>
+					<xs:documentation>Reproductor de audio digital pregrabado</xs:documentation>
+					<xs:documentation>Por ejemplo, el reproductor y audiolibro Playaway: utilice la codificación que figura en el Detalle del formulario del producto para especificar el formato de grabación, si procede.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AL">
+				<xs:annotation>
+					<xs:documentation>Tarjeta SD pregrabada</xs:documentation>
+					<xs:documentation>Por ejemplo, un chip del audiolibro Audiofy.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="AZ">
+				<xs:annotation>
+					<xs:documentation>Otro formato de audio</xs:documentation>
+					<xs:documentation>Otro formato audio distinto de los indicados de AB a AL.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BA">
+				<xs:annotation>
+					<xs:documentation>Libro</xs:documentation>
+					<xs:documentation>Libro; detalle sin especificar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BB">
+				<xs:annotation>
+					<xs:documentation>Tapa dura</xs:documentation>
+					<xs:documentation>Libro de tapa dura o encuadernado en tapa suelta.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BC">
+				<xs:annotation>
+					<xs:documentation>En rústica/de tapa blanda</xs:documentation>
+					<xs:documentation>Libro en rústica u otro tipo de libro de tapa blanda.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BD">
+				<xs:annotation>
+					<xs:documentation>Hojas sueltas</xs:documentation>
+					<xs:documentation>Libro de hojas sueltas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BE">
+				<xs:annotation>
+					<xs:documentation>Encuadernación de espiral</xs:documentation>
+					<xs:documentation>Libro con encuadernación de espiral, con tornillos o en bobina.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BF">
+				<xs:annotation>
+					<xs:documentation>Panfleto</xs:documentation>
+					<xs:documentation>Panfleto o folleto, grapado; en alemán: &apos;geheftet&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BG">
+				<xs:annotation>
+					<xs:documentation>Encuadernación fina/de cuero</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BH">
+				<xs:annotation>
+					<xs:documentation>Libro de tapas de cartón</xs:documentation>
+					<xs:documentation>Libro infantil con todas las páginas impresas en cartón.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BI">
+				<xs:annotation>
+					<xs:documentation>Libro de tela</xs:documentation>
+					<xs:documentation>Libro infantil con todas las páginas impresas en tela.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BJ">
+				<xs:annotation>
+					<xs:documentation>Libro acuático</xs:documentation>
+					<xs:documentation>Libro infantil impreso en material impermeable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BK">
+				<xs:annotation>
+					<xs:documentation>Libro novedoso</xs:documentation>
+					<xs:documentation>Libro cuya novedad consiste total o parcialmente en un formato que no puede describirse mediante ningún otro código de los disponibles (se prefiere utilizar siempre un código de un formato &quot;convencional&quot;); siempre que sea posible se debería utilizar uno o más códigos de Detalle del formulario del producto, p. ej., del grupo B2nn, para proporcionar más información.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BL">
+				<xs:annotation>
+					<xs:documentation>Con diapositivas</xs:documentation>
+					<xs:documentation>Libro con diapositivas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BM">
+				<xs:annotation>
+					<xs:documentation>Libro grande</xs:documentation>
+					<xs:documentation>Formato extragrande para profesores, etc.; este formato y esta terminología pueden ser específicos del Reino Unido; necesario como diferenciador de máximo nivel.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BN">
+				<xs:annotation>
+					<xs:documentation>Trabajo parcial (fascículo)</xs:documentation>
+					<xs:documentation>Fascículo emitido con su propio ISBN y pensado para recopilarse y encuadernarse en un libro completo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BO">
+				<xs:annotation>
+					<xs:documentation>Gráfico o libro desplegable</xs:documentation>
+					<xs:documentation>Gráfico o libro con plegado de acordeón, diseñado para plegarlo hasta un tamaño de bolsillo o de una página normal: uso para el alemán &apos;Leporello&apos;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BP">
+				<xs:annotation>
+					<xs:documentation>Libro de espuma</xs:documentation>
+					<xs:documentation>Libro infantil cuyas páginas y portada están hechas de espuma.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="BZ">
+				<xs:annotation>
+					<xs:documentation>Otro formato de libro</xs:documentation>
+					<xs:documentation>Libro en otro formato o encuadernación no relacionado de BB a BP.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CA">
+				<xs:annotation>
+					<xs:documentation>Hoja cartográfica</xs:documentation>
+					<xs:documentation>Hoja cartográfica; detalle sin especificar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CB">
+				<xs:annotation>
+					<xs:documentation>Hoja cartográfica, plegada</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CC">
+				<xs:annotation>
+					<xs:documentation>Hoja cartográfica, aplanada</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CD">
+				<xs:annotation>
+					<xs:documentation>Hoja cartográfica, enrollada</xs:documentation>
+					<xs:documentation>Para &quot;enrollado en un tubo&quot; véase la lista de códigos 80.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CE">
+				<xs:annotation>
+					<xs:documentation>Globo</xs:documentation>
+					<xs:documentation>Globo o planisferio.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="CZ">
+				<xs:annotation>
+					<xs:documentation>Otro cartográfico</xs:documentation>
+					<xs:documentation>Otro formato cartográfico no especificado de CB a CE.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DA">
+				<xs:annotation>
+					<xs:documentation>Digital (en algún tipo de soporte material)</xs:documentation>
+					<xs:documentation>Contenido digital accesible mediante algún tipo de soporte material (detalles no especificados).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DB">
+				<xs:annotation>
+					<xs:documentation>CD-ROM</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DC">
+				<xs:annotation>
+					<xs:documentation>CD-I</xs:documentation>
+					<xs:documentation>CD interactivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DE">
+				<xs:annotation>
+					<xs:documentation>Cartucho de juego</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DF">
+				<xs:annotation>
+					<xs:documentation>Disquete</xs:documentation>
+					<xs:documentation>También conocido como &quot;disco flexible&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DI">
+				<xs:annotation>
+					<xs:documentation>DVD-ROM</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DJ">
+				<xs:annotation>
+					<xs:documentation>Tarjeta de memoria digital segura (SD)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DK">
+				<xs:annotation>
+					<xs:documentation>Tarjeta de memoria Flash compacta</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DL">
+				<xs:annotation>
+					<xs:documentation>Tarjeta de memoria</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DM">
+				<xs:annotation>
+					<xs:documentation>Memoria USB</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DN">
+				<xs:annotation>
+					<xs:documentation>CD/DVD de dos caras</xs:documentation>
+					<xs:documentation>Disco de dos caras, por una cara es CD/CD-ROM de audio y, por la otra, DVD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="DZ">
+				<xs:annotation>
+					<xs:documentation>Otro material digital</xs:documentation>
+					<xs:documentation>Otro material digital o multimedia no relacionado de DB a DN.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EA">
+				<xs:annotation>
+					<xs:documentation>Digital (suministrado electrónicamente)</xs:documentation>
+					<xs:documentation>Contenido digital suministrado electrónicamente (método de suministro no especificado).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EB">
+				<xs:annotation>
+					<xs:documentation>Digital: descarga y online</xs:documentation>
+					<xs:documentation>Contenido digital accesible tanto mediante descarga como mediante acceso online.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="EC">
+				<xs:annotation>
+					<xs:documentation>Digital: online</xs:documentation>
+					<xs:documentation>Contenido digital accesible solo online.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ED">
+				<xs:annotation>
+					<xs:documentation>Digital: descarga</xs:documentation>
+					<xs:documentation>Contenido digital accesible solo mediante descarga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FA">
+				<xs:annotation>
+					<xs:documentation>Película o transparencia</xs:documentation>
+					<xs:documentation>Película o transparencia; detalle sin especificar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FC">
+				<xs:annotation>
+					<xs:documentation>Diapositivas</xs:documentation>
+					<xs:documentation>Transparencias fotográficas montadas para la proyección.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FD">
+				<xs:annotation>
+					<xs:documentation>Transparencias para retroproyector</xs:documentation>
+					<xs:documentation>Transparencias para retroproyector.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FE">
+				<xs:annotation>
+					<xs:documentation>Tira de película</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FF">
+				<xs:annotation>
+					<xs:documentation>Película</xs:documentation>
+					<xs:documentation>Película continua frente a una tira de película.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="FZ">
+				<xs:annotation>
+					<xs:documentation>Otro formato de película o transparencia</xs:documentation>
+					<xs:documentation>Otro formato de película o transparencia no especificado de FB a FF.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LA">
+				<xs:annotation>
+					<xs:documentation>Licencia para producto digital</xs:documentation>
+					<xs:documentation>Licencia para producto digital (método de suministro no especificado).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LB">
+				<xs:annotation>
+					<xs:documentation>Clave de licencia para producto digital</xs:documentation>
+					<xs:documentation>Licencia para producto digital proporcionada a través de la cadena de suministro en forma de un soporte físico (tarjeta, impreso, cuadernillo, etc.) que incluye un código que permite al usuario/a descargar o activar el producto digital asociado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="LC">
+				<xs:annotation>
+					<xs:documentation>Código de licencia para producto digital</xs:documentation>
+					<xs:documentation>Licencia para producto digital proporcionada mediante correo electrónico u otro mecanismo de distribución electrónica, en general mediante un código que permite al usuario/a descargar o activar el producto digital asociado, o bien obtener una versión ampliada o mejorada, o ampliar el periodo de uso de un producto ya adquirido.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MA">
+				<xs:annotation>
+					<xs:documentation>Microforma</xs:documentation>
+					<xs:documentation>Microforma; detalle sin especificar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MB">
+				<xs:annotation>
+					<xs:documentation>Microficha</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MC">
+				<xs:annotation>
+					<xs:documentation>Microfilm</xs:documentation>
+					<xs:documentation>Microfilm en bobina.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="MZ">
+				<xs:annotation>
+					<xs:documentation>Otra microforma</xs:documentation>
+					<xs:documentation>Otra microforma no especificada por MB o MC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PA">
+				<xs:annotation>
+					<xs:documentation>Impresiones variadas</xs:documentation>
+					<xs:documentation>Material impreso variado; detalle sin especificar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PB">
+				<xs:annotation>
+					<xs:documentation>Agenda de direcciones</xs:documentation>
+					<xs:documentation>Se pueden utilizar los códigos P201 a P204 del Detalle del formulario del producto para especificar la encuadernación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PC">
+				<xs:annotation>
+					<xs:documentation>Calendario</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PD">
+				<xs:annotation>
+					<xs:documentation>Tarjetas</xs:documentation>
+					<xs:documentation>Tarjetas, flash cards (p. ej., para enseñar a leer).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PE">
+				<xs:annotation>
+					<xs:documentation>Fichas fotocopiables</xs:documentation>
+					<xs:documentation>Fichas fotocopiables.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PF">
+				<xs:annotation>
+					<xs:documentation>Diario</xs:documentation>
+					<xs:documentation>Se pueden utilizar los códigos P201 a P204 del Detalle del formulario del producto para especificar la encuadernación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PG">
+				<xs:annotation>
+					<xs:documentation>Friso</xs:documentation>
+					<xs:documentation>Hoja impresa estrecha en forma de tira empleada sobre todo para la enseñanza o en productos infantiles (p. ej., un abecedario ilustrado, una línea de números, procesión de caracteres ilustrados, etc.). Normalmente pensado para una presentación horizontal.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PH">
+				<xs:annotation>
+					<xs:documentation>Kit</xs:documentation>
+					<xs:documentation>Piezas para un montaje posterior a la compra.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PI">
+				<xs:annotation>
+					<xs:documentation>Partituras</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PJ">
+				<xs:annotation>
+					<xs:documentation>Pack o libro de tarjetas postales</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PK">
+				<xs:annotation>
+					<xs:documentation>Póster</xs:documentation>
+					<xs:documentation>Póster para la venta; véase también XF.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PL">
+				<xs:annotation>
+					<xs:documentation>Libro de registro</xs:documentation>
+					<xs:documentation>Álbum de recuerdos (por ejemplo, álbum de cumpleaños, álbum del bebé). Se pueden utilizar los códigos P201 a P204 en ProductFormDetail para indicar detalles de encuadernación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PM">
+				<xs:annotation>
+					<xs:documentation>Cartera o carpeta</xs:documentation>
+					<xs:documentation>Cartera o carpeta (que alberga hojas sueltas, etc.): es preferible codificar los contenidos y tratar &quot;cartera&quot; como un embalaje (lista 80), pero, de no ser posible, el producto en su conjunto se puede codificar como &quot;cartera&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PN">
+				<xs:annotation>
+					<xs:documentation>Imágenes o fotografías</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PO">
+				<xs:annotation>
+					<xs:documentation>Gráfico mural</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PP">
+				<xs:annotation>
+					<xs:documentation>Pegatinas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PQ">
+				<xs:annotation>
+					<xs:documentation>Lámina</xs:documentation>
+					<xs:documentation>Una hoja de tamaño libro (frente al tamaño póster), normalmente impresa en calidad alta o en color.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PR">
+				<xs:annotation>
+					<xs:documentation>Cuaderno/libro en blanco</xs:documentation>
+					<xs:documentation>Libro con las páginas en blanco para uso propio del comprador. Se pueden utilizar los códigos P201 a P204 para indicar detalles de encuadernación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PS">
+				<xs:annotation>
+					<xs:documentation>Organizador</xs:documentation>
+					<xs:documentation>Se pueden utilizar los códigos P201 a P204 del Detalle del formulario del producto para especificar la encuadernación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PT">
+				<xs:annotation>
+					<xs:documentation>Marcador</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="PZ">
+				<xs:annotation>
+					<xs:documentation>Otro elemento impreso</xs:documentation>
+					<xs:documentation>Otro material impreso no relacionado de PB a PT.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SA">
+				<xs:annotation>
+					<xs:documentation>Producto de venta con múltiples elementos</xs:documentation>
+					<xs:documentation>Sin detalle de presentación. El formato de los elementos individuales debe describirse en &lt;ProductPart>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SB">
+				<xs:annotation>
+					<xs:documentation>Producto compuesto, para venta al por menor, en caja</xs:documentation>
+					<xs:documentation>El formato de los elementos individuales debe describirse en &lt;ProductPart>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SC">
+				<xs:annotation>
+					<xs:documentation>Producto compuesto, para venta al por menor, en funda</xs:documentation>
+					<xs:documentation>El formato de los elementos individuales debe describirse en &lt;ProductPart>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SD">
+				<xs:annotation>
+					<xs:documentation>Producto compuesto, para venta al por menor, retractilado</xs:documentation>
+					<xs:documentation>El formato de los elementos individuales debe describirse en &lt;ProductPart>. Use el código XL para paquetes retractilados para suministro del comercio, donde los artículos de venta al por menor se pueden vender individualmente.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SE">
+				<xs:annotation>
+					<xs:documentation>Producto compuesto, para venta al por menor, elementos sueltos</xs:documentation>
+					<xs:documentation>El formato de los elementos individuales debe describirse en &lt;ProductPart>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="SF">
+				<xs:annotation>
+					<xs:documentation>Producto compuesto, para venta al por menor, en paquete(s) único(s)</xs:documentation>
+					<xs:documentation>Producto compuesto en el que los componentes están incluidos dentro de la parte(s) principal: por ejemplo un libro con un CD en una funda pegada a la cubierta posterior. El formato de los elementos individuales debe describirse en &lt;ProductPart>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VA">
+				<xs:annotation>
+					<xs:documentation>Vídeo</xs:documentation>
+					<xs:documentation>Vídeo; detalle sin especificar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VF">
+				<xs:annotation>
+					<xs:documentation>Videodisco</xs:documentation>
+					<xs:documentation>p. ej., Laserdisc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VI">
+				<xs:annotation>
+					<xs:documentation>DVD vídeo</xs:documentation>
+					<xs:documentation>DVD vídeo: especificar el estándar de TV en la lista 78.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VJ">
+				<xs:annotation>
+					<xs:documentation>VHS vídeo</xs:documentation>
+					<xs:documentation>Cinta VHS: especificar el estándar de TV en la lista 78.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VK">
+				<xs:annotation>
+					<xs:documentation>Vídeo Betamax</xs:documentation>
+					<xs:documentation>Cinta Betamax: especificar el estándar de TV en la lista 78.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VL">
+				<xs:annotation>
+					<xs:documentation>VCD</xs:documentation>
+					<xs:documentation>Vídeo CD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VM">
+				<xs:annotation>
+					<xs:documentation>SVCD</xs:documentation>
+					<xs:documentation>Super Video CD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VN">
+				<xs:annotation>
+					<xs:documentation>HD DVD</xs:documentation>
+					<xs:documentation>Disco DVD de alta definición, formato HD DVD de Toshiba.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VO">
+				<xs:annotation>
+					<xs:documentation>Blu-ray</xs:documentation>
+					<xs:documentation>Disco DVD de alta definición, formato Blu-ray de Sony.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VP">
+				<xs:annotation>
+					<xs:documentation>UMD Video</xs:documentation>
+					<xs:documentation>Universal Media Disc de Sony.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="VZ">
+				<xs:annotation>
+					<xs:documentation>Otro formato de vídeo</xs:documentation>
+					<xs:documentation>Otro formato de vídeo no especificado de VB a VP.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XA">
+				<xs:annotation>
+					<xs:documentation>Material solo para venta</xs:documentation>
+					<xs:documentation>Material solo para venta (sin especificar).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XB">
+				<xs:annotation>
+					<xs:documentation>Cubeta; vacía</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XC">
+				<xs:annotation>
+					<xs:documentation>Cubeta; llena</xs:documentation>
+					<xs:documentation>Cubeta con contenidos. Se deben incorporar ISBN (donde sea de aplicación) y formato de los elementos contenidos en Product Part. </xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XD">
+				<xs:annotation>
+					<xs:documentation>Expositor de mesa; vacío</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XE">
+				<xs:annotation>
+					<xs:documentation>Expositor de mesa; lleno</xs:documentation>
+					<xs:documentation>Expositor de mesa con contenidos. Se deben incorporar ISBN (donde sea de aplicación) y formato de los elementos contenidos en Product Part. </xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XF">
+				<xs:annotation>
+					<xs:documentation>Póster, promocional</xs:documentation>
+					<xs:documentation>Póster promocional para exposición, no para venta; véase también PK.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XG">
+				<xs:annotation>
+					<xs:documentation>Cinta portaprecios</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XH">
+				<xs:annotation>
+					<xs:documentation>Pieza para ventana</xs:documentation>
+					<xs:documentation>Pieza promocional para exponer en escaparates.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XI">
+				<xs:annotation>
+					<xs:documentation>Banderín</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XJ">
+				<xs:annotation>
+					<xs:documentation>Exhibidor giratorio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XK">
+				<xs:annotation>
+					<xs:documentation>Presentación de un libro de gran tamaño</xs:documentation>
+					<xs:documentation>Facsímil a gran escala de un libro para su exposición promocional.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XL">
+				<xs:annotation>
+					<xs:documentation>Paquete con película de plástico</xs:documentation>
+					<xs:documentation>Productos en cantidad, en un paquete con código de producto propio, para venta exclusiva a la cadena de aprovisionamiento: los artículos que contiene deben venderse individualmente. Se deben incorporar ISBN (donde sea de aplicación) y formato de los elementos contenidos en Product Part.  Para productos o lotes retractilados destinados a la venta al por menor, utilice el código SD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="XZ">
+				<xs:annotation>
+					<xs:documentation>Otro punto de venta</xs:documentation>
+					<xs:documentation>Otro material existente en el punto de venta no especificado de XB a XL.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZA">
+				<xs:annotation>
+					<xs:documentation>Mercancía general </xs:documentation>
+					<xs:documentation>Mercancía general; sin especificar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZB">
+				<xs:annotation>
+					<xs:documentation>Muñeca</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZC">
+				<xs:annotation>
+					<xs:documentation>Peluche</xs:documentation>
+					<xs:documentation>Muñeco de peluche.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZD">
+				<xs:annotation>
+					<xs:documentation>Juguete</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZE">
+				<xs:annotation>
+					<xs:documentation>Juego</xs:documentation>
+					<xs:documentation>Juego de mesa u otro juego (excepto juego de ordenador: véase DE).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZF">
+				<xs:annotation>
+					<xs:documentation>Camiseta</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="ZZ">
+				<xs:annotation>
+					<xs:documentation>Otros productos</xs:documentation>
+					<xs:documentation>Otros productos no especificados de ZB a ZF.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List151">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 151">Relación de colaborador/a con un lugar</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Nacido en</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Fallecido en</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Con residencia anterior en</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Con residencia actual en</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Se formó en</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Trabajó en</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Tuvo éxito en</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List152">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 152">Ilustrado/No ilustrado</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Núm.</xs:documentation>
+					<xs:documentation>No ilustrado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Sí</xs:documentation>
+					<xs:documentation>Ilustrado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List153">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 153">Tipo de texto</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Texto definido por el remitente</xs:documentation>
+					<xs:documentation>Utilizar solo cuando las partes de un intercambio de mensajes acuerden incluir texto que (a) no sea de distribución general, y (b) no se pueda codificar en otro lugar. Si se envía más de un tipo de texto, este se debe identificar mediante etiquetas dentro del propio texto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Breve descripción/anotación</xs:documentation>
+					<xs:documentation>Límite máximo: 350 caracteres.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Descripción</xs:documentation>
+					<xs:documentation>Sin límite de extensión.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Tabla de contenidos</xs:documentation>
+					<xs:documentation>Se usa cuando la tabla de contenidos se envía como un único campo de texto que puede contener, o no, estructuras expresadas en XHTML.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Texto de solapa/contraportada</xs:documentation>
+					<xs:documentation>Breve texto descriptivo tomado de la contraportada o solapas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Cita de reseña</xs:documentation>
+					<xs:documentation>Cita tomada de una reseña de un producto o de la obra en cuestión donde no es necesario tener en cuenta diferentes ediciones.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Cita de reseña: edición anterior</xs:documentation>
+					<xs:documentation>Una cita tomada de una reseña de una edición anterior de la obra.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Cita de reseña: obra anterior</xs:documentation>
+					<xs:documentation>Una cita tomada de una reseña de una obra anterior del mismo autor(es)/a(as) o de la misma serie.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Recomendación</xs:documentation>
+					<xs:documentation>Una cita generalmente facilitada por un famoso para promocionar un nuevo libro, no de una reseña.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Titular promocional</xs:documentation>
+					<xs:documentation>Frase promocional utilizada como titular de la descripción de un producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Destacar</xs:documentation>
+					<xs:documentation>Texto que describe una característica del producto que la editorial quiere destacar para fines promocionales.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Nota bibliográfica</xs:documentation>
+					<xs:documentation>Nota referida a todos los colaboradores/as de un producto, no a una persona en concreto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Nota de la editorial</xs:documentation>
+					<xs:documentation>Declaración de la editorial en cumplimiento de sus obligaciones contractuales: por ejemplo, una cláusula de limitación de responsabilidad, nota de un patrocinador, o cualquier otro tipo de advertencia legal. La inclusión de una nota de este tipo no obliga a su reproducción por parte de quien utiliza el registro ONIX.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Extracto</xs:documentation>
+					<xs:documentation>Un extracto breve de la obra.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Índice</xs:documentation>
+					<xs:documentation>Se usa cuando el índice se envía como un único campo de texto, que puede estar estructurado mediante XHTML.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Breve descripción/anotación para colección</xs:documentation>
+					<xs:documentation>(de la que el producto forma parte). Limitada a un máximo de 350 caracteres.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Descripción para colección</xs:documentation>
+					<xs:documentation>(de la que el producto forma parte.) Sin límite de extensión.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List154">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 154">Público del contenido</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Sin restringir</xs:documentation>
+					<xs:documentation>Cualquier público.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Restricciones</xs:documentation>
+					<xs:documentation>Distribución mediante acuerdo entre las partes del intercambio del mensaje ONIX (este valor se le atribuye a las solicitudes en las que el contenido ONIX incluye material que no es de distribución general).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Comercio de libros</xs:documentation>
+					<xs:documentation>Distribuidores, librerías, personal de la editorial, etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Cliente final</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Bibliotecarios</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Profesores</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Estudiantes</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Editorial</xs:documentation>
+					<xs:documentation>Prensa y otros medios de comunicación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Servicio de comparación de compras</xs:documentation>
+					<xs:documentation>Cuando una descripción con formato especial sea necesaria para este público.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List155">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 155">Función de la fecha de contenido</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Fecha de publicación</xs:documentation>
+					<xs:documentation>Fecha nominal de publicación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Fecha de emisión</xs:documentation>
+					<xs:documentation>Fecha en la que un programa de televisión o radio fue/será emitido.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Fecha &quot;Desde&quot;</xs:documentation>
+					<xs:documentation>Fecha desde la que se puede referenciar o utilizar un elemento de contenido o recurso de apoyo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Fecha &quot;Hasta&quot;</xs:documentation>
+					<xs:documentation>Fecha hasta la que se puede referenciar o utilizar un elemento de contenido o recurso de apoyo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Última actualización</xs:documentation>
+					<xs:documentation>Fecha en la que se modificó o actualizó un recurso por última vez.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Fecha &quot;Desde… Hasta&quot;</xs:documentation>
+					<xs:documentation>Combina las fechas &quot;Desde&quot; y &quot;Hasta&quot; para definir un periodo (ambas están incluidas). Utilizar con, por ejemplo, DateFormat=06.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List156">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 156">Tipo de contenido citado</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Revisión</xs:documentation>
+					<xs:documentation>El texto completo de una reseña en una publicación de un tercero en cualquier medio.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Listado de superventas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Mención en medios</xs:documentation>
+					<xs:documentation>Distinta de una reseña.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Programa &quot;One locality, one book&quot; (&quot;Una localidad, un libro&quot;)</xs:documentation>
+					<xs:documentation>(Norteamérica) Inclusión en un programa como &quot;Chicago Reads&quot;, &quot;Seattle Reads&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List157">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 157">Tipo de fuente del contenido</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Medio impreso</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Página web</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Radio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Televisión</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List158">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 158">Tipo de contenido del recurso</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Portada</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Contraportada</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Portada/paquete</xs:documentation>
+					<xs:documentation>Sin limitación a portada o contraportada.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Foto de colaborador/a</xs:documentation>
+					<xs:documentation>Fotografía o retrato de colaborador(es)/a(as).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Imagen de la colección</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Logotipo de la colección</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Imagen del producto</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Logotipo del producto</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Logotipo de la editorial</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Logotipo del sello editorial</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Entrevista al colaborador/a</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Presentación del colaborador/a</xs:documentation>
+					<xs:documentation>Presentación o comentario del colaborador/a.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Lectura del colaborador/a</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Agenda de eventos del colaborador/a</xs:documentation>
+					<xs:documentation>Enlace a la agenda en formato iCalendar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Contenido de muestra</xs:documentation>
+					<xs:documentation>Ejemplos de muestras: texto de un capítulo, fotos de páginas, capturas de pantalla.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>&quot;Widget&quot;</xs:documentation>
+					<xs:documentation>Una función &quot;mira en el interior&quot; presentada en forma de pequeña aplicación incrustada.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Revisión</xs:documentation>
+					<xs:documentation>Utilice el bloque &lt;TextContent> para citas de reseñas dentro del registro ONIX. Utilice el bloque &lt;CitedContent> para reseñas de terceros que se referencien en el registro ONIX. Utilice &lt;SupportingResource> solo para reseñas que se ofrezcan para reproducir como parte del material promocional del producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Otro comentario/discusión</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Guía de lectura en grupo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Guía para el profesor</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>Artículo de fondo</xs:documentation>
+					<xs:documentation>Artículo de fondo proporcionado por la editorial.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>&quot;Entrevista&quot; al personaje</xs:documentation>
+					<xs:documentation>&quot;Entrevista&quot; a un personaje ficticio.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Fondo de pantalla/salvapantallas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Nota de prensa</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Tabla de contenidos</xs:documentation>
+					<xs:documentation>Tabla de contenidos alojada en una página web, no en el registro ONIX.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="26">
+				<xs:annotation>
+					<xs:documentation>Tráiler</xs:documentation>
+					<xs:documentation>Un vídeo promocional, similar a un tráiler de película (a veces llamado &quot;book trailer&quot; en inglés).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="27">
+				<xs:annotation>
+					<xs:documentation>Miniatura de la portada</xs:documentation>
+					<xs:documentation>Para uso transitorio EXCLUSIVAMENTE, cuando los registros ONIX 2.1 referencien miniaturas existentes cuyo tamaño en píxeles se desconoce y que se vayan a reexpresar en ONIX 3.0. Utilice el código 01 para todas las nuevas portadas y cuando el tamaño en píxeles de las antiguas se conozca.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="28">
+				<xs:annotation>
+					<xs:documentation>Contenido completo</xs:documentation>
+					<xs:documentation>El contenido completo del producto (o el producto en sí), provisto como ejemplo de apoyo para la búsqueda en el texto completo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="29">
+				<xs:annotation>
+					<xs:documentation>Portada completa</xs:documentation>
+					<xs:documentation>Incluye portada, contraportada, lomo y solapas, si las hubiera.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List159">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 159">Modo del recurso</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Aplicación</xs:documentation>
+					<xs:documentation>Un ejecutable y los datos con los que opera.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Audio</xs:documentation>
+					<xs:documentation>Una grabación de sonido.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Imagen</xs:documentation>
+					<xs:documentation>Una imagen estática.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Texto</xs:documentation>
+					<xs:documentation>Texto legible, con o sin imágenes asociadas, etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Vídeo</xs:documentation>
+					<xs:documentation>Imágenes en movimiento, con o sin sonido que las acompañe.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Multimodo</xs:documentation>
+					<xs:documentation>Un sitio web u otros recursos de apoyo que suministren contenido de formas diversas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List160">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 160">Tipo de funcionalidad del recurso</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Crédito necesario</xs:documentation>
+					<xs:documentation>Crédito que debe aparecer cuando se utiliza un recurso (p. ej.: &quot;Photo Jerry Bauer&quot; o &quot;© Magnum Photo&quot;). El texto de crédito debe estar incluido en &lt;FeatureNote>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Título</xs:documentation>
+					<xs:documentation>Pie explicativo que puede acompañar a un recurso (p. ej. para identificar a un autor/a en una fotografía). El texto del pie debe estar incluido en &lt;FeatureNote>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Titular de los derechos de autor</xs:documentation>
+					<xs:documentation>Titular de los derechos de autor del recurso (solamente indicativo, ya que el recurso puede usarse sin consultar). El texto de los derechos de autor debe estar incluido en&lt;FeatureNote>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Extensión en minutos</xs:documentation>
+					<xs:documentation>Extensión aproximada en minutos de un recurso de audio o vídeo. &lt;FeatureValue> debe contener la extensión de tiempo como un número entero de minutos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List161">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 161">Formato del recurso</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Recurso enlazable</xs:documentation>
+					<xs:documentation>Recurso al que se puede acceder mediante un hipervínculo. El servidor actual (p. ej. el remitente ONIX, que puede ser la editorial) proveerá servicios de alojamiento para el recurso durante toda su vida activa (o al menos hasta la fecha &quot;Hasta&quot; especificada en &lt;ContentDate>). El receptor ONIX puede incrustar la URL en un sitio web orientado al público (p. ej. como atributo src de un enlace &lt;img>) y no necesita alojar una copia independiente del recurso.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Archivo descargable</xs:documentation>
+					<xs:documentation>Un archivo que puede ser descargado bajo demanda para uso por parte de terceros. El remitente ONIX alojará una copia del recurso hasta la fecha &quot;Hasta&quot; especificada, pero solo para el uso directo del receptor ONIX. El receptor ONIX debe descargar una copia del recurso y alojar una copia independiente del mismo si se utiliza en un sitio web orientado al público. Se debe prestar atención especial a &quot;Última actualización&quot; en &lt;ContentDate> para asegurar que la copia independiente del recurso está actualizada.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Aplicación incrustable</xs:documentation>
+					<xs:documentation>Una aplicación que se suministra de forma que se pueda incrustar en una página web de terceros. Como el tipo 02, salvo que el recurso contiene contenido activo como JavaScript, Flash, etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List162">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 162">Tipo de funcionalidad de la versión del recurso</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Formato del archivo</xs:documentation>
+					<xs:documentation>Resource Version Feature Value contiene un código de la Lista 178.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Altura de la imagen en píxeles</xs:documentation>
+					<xs:documentation>Resource Version Feature Value contiene un número entero.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Ancho de la imagen en píxeles</xs:documentation>
+					<xs:documentation>Resource Version Feature Value contiene un número entero.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Nombre de archivo</xs:documentation>
+					<xs:documentation>Resource Version Feature Value contiene el nombre del archivo del recurso de apoyo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Tamaño aproximado del archivo de descarga en megabytes</xs:documentation>
+					<xs:documentation>Resource Version Feature Value contiene solo un número decimal. Se sugiere no utilizar más de 2 dígitos significativos (p. ej. 1.7, y no 1.7462).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Valor de hash MD5</xs:documentation>
+					<xs:documentation>Valor de hash MD5 del archivo recurso. &lt;ResourceVersionFeatureValue> debe contener este valor (en 32 dígitos hexadecimales). Se puede utilizar como comprobación criptográfica de la integridad del recurso tras su recuperación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Tamaño exacto del archivo de descarga en bytes</xs:documentation>
+					<xs:documentation>Resource Version Feature Value incluye solo un número entero (p. ej. 1831023).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List163">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 163">Función de la fecha de publicación</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Fecha de publicación</xs:documentation>
+					<xs:documentation>Fecha nominal de publicación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Fecha de embargo</xs:documentation>
+					<xs:documentation>Si existe una prohibición de venta al por menor (&quot;embargo&quot;) en este mercado antes de cierta fecha, la fecha a partir de la que se termina esta prohibición.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Fecha de anuncio público</xs:documentation>
+					<xs:documentation>Fecha en la que un producto nuevo se anuncia al público general.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Fecha de anuncio para el sector</xs:documentation>
+					<xs:documentation>Fecha en la que un nuevo producto se anuncia para el sector exclusivamente.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Fecha de primera publicación</xs:documentation>
+					<xs:documentation>Fecha en la que la obra incorporada en un producto se publicó por primera vez.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Fecha de última reimpresión</xs:documentation>
+					<xs:documentation>Fecha de la última reimpresión de un producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Fecha de descatalogación/eliminación</xs:documentation>
+					<xs:documentation>Fecha en la que un producto se descatalogó o eliminó.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Fecha de la última reedición</xs:documentation>
+					<xs:documentation>Fecha de la última reedición de un producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Fecha de publicación de la versión impresa</xs:documentation>
+					<xs:documentation>Fecha de publicación de un libro que es la versión impresa de una edición digital.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Fecha de la primera publicación en lengua original</xs:documentation>
+					<xs:documentation>Año en el que la versión en lengua original de una obra incorporada en un producto se publicó por primera vez (nota: utilizar solo cuando sea diferente al código 11).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="21">
+				<xs:annotation>
+					<xs:documentation>Fecha de la próxima reedición</xs:documentation>
+					<xs:documentation>Fecha en la que un producto será reeditado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="22">
+				<xs:annotation>
+					<xs:documentation>Fecha esperada de disponibilidad tras retirada temporal</xs:documentation>
+					<xs:documentation>Fecha en la que se espera que un producto retirado temporalmente del mercado por cualquier motivo vuelva a estar disponible, p. ej. después de la corrección de problemas de calidad o técnicos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="23">
+				<xs:annotation>
+					<xs:documentation>Fecha de embargo para reseñas</xs:documentation>
+					<xs:documentation>Fecha en la que la reseña de un producto puede publicarse, p. ej. en periódicos y revistas o en línea. Se suministra al sector solo para informar: no se espera que periódicos y revistas sean receptores de metadatos ONIX.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List164">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 164">Código de relación de obra</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Manifestación de</xs:documentation>
+					<xs:documentation>El producto X es o incluye una manifestación de la obra Y.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Derivado de</xs:documentation>
+					<xs:documentation>El producto X es o incluye una manifestación de una obra derivada de la obra relacionada Y, en una o varias de las formas especificadas en las reglas ISTC. La finalidad de este tipo de relación es permitir relacionar productos con una misma obra &quot;padre&quot; sin especificar la forma precisa en la que se han derivado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Obra relacionada derivada de esta</xs:documentation>
+					<xs:documentation>El producto X es una manifestación de una obra de la que la obra relacionada Y se deriva, en una o varias de las formas especificadas en las reglas ISTC (recíproco del código 02).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Otra obra en la misma colección</xs:documentation>
+					<xs:documentation>El producto X es una manifestación de una obra en la misma colección que la obra relacionada Y.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Otra obra del mismo colaborador/a</xs:documentation>
+					<xs:documentation>El producto X es una manifestación de la obra del mismo colaborador/a que la obra relacionada Y.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List165">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 165">Tipo de código propio del proveedor</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Clasificación de ventas del proveedor</xs:documentation>
+					<xs:documentation>Una valoración asignada por el proveedor (normalmente mayorista) para indicar su evaluación del nivel de ventas esperado o real de un producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Eligibilidad para bonificaciones asignada por un proveedor</xs:documentation>
+					<xs:documentation>Código asignado por un proveedor para indicar la elegibilidad de un producto en un programa de bonificaciones sobre ventas totales.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Clasificación de ventas de la editorial</xs:documentation>
+					<xs:documentation>Una valoración asignada por la editorial para definir la categoría de ventas (p. ej. de fondo/novedades, inventario principal, etc.). Utilice solo cuando la editorial no es el &quot;proveedor&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Clasificación de restricción de precios del proveedor</xs:documentation>
+					<xs:documentation>Una clasificación aplicada por el proveedor a un producto vendido según las condiciones de una agencia, para indicar que existen restricciones respecto al precio de venta al público.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List166">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 166">Función de la fecha de provisión</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Fecha de embargo</xs:documentation>
+					<xs:documentation>Si existe una prohibición de venta al por menor (&quot;embargo&quot;) antes de cierta fecha, la fecha a partir de la que se termina esta prohibición.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Fecha esperada de disponibilidad</xs:documentation>
+					<xs:documentation>La fecha en la que se espera que haya existencias físicas disponibles para enviar a los puntos de venta, o la fecha en la que se espera que un producto digital se publique.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Última fecha para devoluciones</xs:documentation>
+					<xs:documentation>Última fecha en la que se aceptarán devoluciones, generalmente para un producto que se va a descatalogar o liquidar sus existencias.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="25">
+				<xs:annotation>
+					<xs:documentation>Fecha límite para pedidos de reserva</xs:documentation>
+					<xs:documentation>Última fecha en la que se puede realizar un pedido con entrega garantizada antes de la fecha de publicación. Puede o no estar vinculada a un precio especial de reserva o prepublicación.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List167">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 167">Tipo de condición de precio</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Incluye actualizaciones</xs:documentation>
+					<xs:documentation>La compra a este precio incluye actualizaciones especificadas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Deben comprarse también las actualizaciones</xs:documentation>
+					<xs:documentation>La compra a este precio exige el compromiso de compra de las actualizaciones especificadas, no incluidas en el precio.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Actualizaciones disponibles</xs:documentation>
+					<xs:documentation>Las actualizaciones se pueden comprar de forma separada, no se exige ningún compromiso mínimo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List168">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 168">Tipo de cantidad para condición de precio</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Periodo de tiempo</xs:documentation>
+					<xs:documentation>El valor indicado en el campo PriceConditionQuantity representa un periodo de tiempo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Número de actualizaciones</xs:documentation>
+					<xs:documentation>El valor indicado en el campo PriceConditionQuantity representa un número de actualizaciones.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List169">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 169">Unidad de cantidad</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Unidades</xs:documentation>
+					<xs:documentation>La cantidad se refiere a una unidad implícita en el tipo de cantidad.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>Semanas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Meses</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List170">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 170">Tipo de descuento</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="List171">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 171">Tipo de impuesto</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>IVA</xs:documentation>
+					<xs:documentation>Impuesto sobre el Valor Añadido (TVA, IVA, MwSt, etc.).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>IGV</xs:documentation>
+					<xs:documentation>Impuesto General a las Ventas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List172">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 172">Zona monetaria</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="EUR">
+				<xs:annotation>
+					<xs:documentation>Eurozona</xs:documentation>
+					<xs:documentation>Países que actualmente tienen el euro como moneda nacional. Obsoleto en ONIX 3.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List173">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 173">Función de la fecha de precio</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Fecha &quot;Desde&quot;</xs:documentation>
+					<xs:documentation>Fecha en la que el precio se haga efectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Fecha &quot;Hasta&quot;</xs:documentation>
+					<xs:documentation>Fecha en la que el precio deja de ser efectivo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="24">
+				<xs:annotation>
+					<xs:documentation>Fecha &quot;Desde… Hasta&quot;</xs:documentation>
+					<xs:documentation>Combina las fechas &quot;Desde&quot; y &quot;Hasta&quot; para definir un periodo (ambas están incluidas). Utilizar con, por ejemplo, DateFormat=06.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List174">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 174">Impreso en el producto</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Núm.</xs:documentation>
+					<xs:documentation>Precio no impreso en el producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Sí</xs:documentation>
+					<xs:documentation>Precio impreso en el producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List175">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 175">Detalle del formato del producto</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="A101">
+				<xs:annotation>
+					<xs:documentation>Formato CD audio estándar</xs:documentation>
+					<xs:documentation>Formato de CD &quot;red book&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A102">
+				<xs:annotation>
+					<xs:documentation>Formato SACD super audio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A103">
+				<xs:annotation>
+					<xs:documentation>Formato MP3</xs:documentation>
+					<xs:documentation>Archivo MPEG-1/2 Audio Layer III.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A104">
+				<xs:annotation>
+					<xs:documentation>Formato WAV</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A105">
+				<xs:annotation>
+					<xs:documentation>Formato Real Audio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A106">
+				<xs:annotation>
+					<xs:documentation>WMA</xs:documentation>
+					<xs:documentation>Formato Windows Media Audio.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A107">
+				<xs:annotation>
+					<xs:documentation>AAC</xs:documentation>
+					<xs:documentation>Formato Advanced Audio Coding.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A108">
+				<xs:annotation>
+					<xs:documentation>Ogg/Vorbis</xs:documentation>
+					<xs:documentation>Formato Vorbis audio en un contenedor Ogg.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A109">
+				<xs:annotation>
+					<xs:documentation>Audible</xs:documentation>
+					<xs:documentation>Formato de audio propio de Audible.com.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A110">
+				<xs:annotation>
+					<xs:documentation>FLAC</xs:documentation>
+					<xs:documentation>Free lossless audio codec.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A111">
+				<xs:annotation>
+					<xs:documentation>AIFF</xs:documentation>
+					<xs:documentation>Formato Audio Interchangeable File.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A112">
+				<xs:annotation>
+					<xs:documentation>ALAC</xs:documentation>
+					<xs:documentation>Apple Lossless Audio Codec.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A201">
+				<xs:annotation>
+					<xs:documentation>DAISY 2: audio completo solo con título (sin navegación)</xs:documentation>
+					<xs:documentation>Obsoleto, no cumple el estándar DAISY 2. Utilice códigos de audiolibro convencionales en su lugar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A202">
+				<xs:annotation>
+					<xs:documentation>DAISY 2: audio completo con navegación (sin texto)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A203">
+				<xs:annotation>
+					<xs:documentation>DAISY 2: audio completo con navegación y texto parcial</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A204">
+				<xs:annotation>
+					<xs:documentation>DAISY 2: audio completo con navegación y texto completo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A205">
+				<xs:annotation>
+					<xs:documentation>DAISY 2: texto completo con navegación y audio parcial</xs:documentation>
+					<xs:documentation>Algunos sistemas de lectura pueden ofrecer audio completo mediante síntesis de voz.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A206">
+				<xs:annotation>
+					<xs:documentation>DAISY 2: texto completo con navegación, pero sin audio</xs:documentation>
+					<xs:documentation>Algunos sistemas de lectura pueden ofrecer audio completo mediante síntesis de voz.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A207">
+				<xs:annotation>
+					<xs:documentation>DAISY 3: audio completo solo con título (sin navegación)</xs:documentation>
+					<xs:documentation>Obsoleto, no cumple el estándar DAISY 3. Utilice códigos de audiolibro convencionales en su lugar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A208">
+				<xs:annotation>
+					<xs:documentation>DAISY 3: audio completo con navegación (sin texto)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A209">
+				<xs:annotation>
+					<xs:documentation>DAISY 3: audio completo con navegación y texto parcial</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A210">
+				<xs:annotation>
+					<xs:documentation>DAISY 3: audio completo con navegación y texto completo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A211">
+				<xs:annotation>
+					<xs:documentation>DAISY 3: texto completo con navegación y audio parcial</xs:documentation>
+					<xs:documentation>Algunos sistemas de lectura pueden ofrecer audio completo mediante síntesis de voz.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A212">
+				<xs:annotation>
+					<xs:documentation>DAISY 3: texto completo con navegación, pero sin audio</xs:documentation>
+					<xs:documentation>Algunos sistemas de lectura pueden ofrecer audio completo mediante síntesis de voz.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A301">
+				<xs:annotation>
+					<xs:documentation>Audio autónomo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A302">
+				<xs:annotation>
+					<xs:documentation>Audio para lectura acompañada</xs:documentation>
+					<xs:documentation>Audio cuya finalidad exclusiva es ser utilizado junto con la versión impresa de un libro. Un producto para el público infantil en la mayoría de los casos. Habitualmente contiene instrucciones como &quot;pasa la página ahora&quot; y otras referencias al producto impreso. Se suele vender empaquetado junto con la copia impresa.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A303">
+				<xs:annotation>
+					<xs:documentation>Audio de acompañamiento</xs:documentation>
+					<xs:documentation>Audio destinado al acompañamiento musical, p. ej. &quot;Music minus one&quot;, etc., a menudo para aprender música. Incluye audio para acompañamiento vocal para aprender música o para actividades tipo karaoke.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A304">
+				<xs:annotation>
+					<xs:documentation>Audio para hablar al mismo tiempo</xs:documentation>
+					<xs:documentation>Audio destinado al aprendizaje de idiomas, incluye discursos con silencios que el oyente debe rellenar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B101">
+				<xs:annotation>
+					<xs:documentation>Mass market (rack) paperback</xs:documentation>
+					<xs:documentation>En Norteamérica, un tipo de libro en rústica caracterizada parcialmente por el tamaño de página (típicamente 4¼ x 7 1/8 pulgadas) y parcialmente por el mercado objetivo y las condiciones de comercio. El elemento Product Form debe tener el valor BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B102">
+				<xs:annotation>
+					<xs:documentation>Trade paperback (EE. UU.)</xs:documentation>
+					<xs:documentation>En Norteamérica, un tipo de libro en rústica caracterizado parcialmente por el tamaño de página y por el mercado objetivo y las condiciones de comercio. También conocido como &quot;libro en rústica de calidad&quot;, incluye libros de texto. La mayoría de los libros en rústica vendidos en Norteamérica salvo &quot;mass market&quot; (B101) y &quot;tall rack&quot; (B107) se describen correctamente con este código. El elemento Product Form debe tener el valor BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B103">
+				<xs:annotation>
+					<xs:documentation>Digest format paperback</xs:documentation>
+					<xs:documentation>En Norteamérica, un tipo de libro en rústica caracterizado por el tamaño de página, generalmente utilizado para libros infantiles. El elemento Product Form debe tener el valor BC. Nota: se mostraba erróneamente como B102 (entrada duplicada) en la Edición 3.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B104">
+				<xs:annotation>
+					<xs:documentation>Libro en rústica en formato A</xs:documentation>
+					<xs:documentation>En el Reino Unido, un tipo de libro en rústica caracterizado por el tamaño de página (normalmente 178 x 111 mm aprox.). El elemento Product Form debe tener el valor BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B105">
+				<xs:annotation>
+					<xs:documentation>Libro en rústica en formato B</xs:documentation>
+					<xs:documentation>En el Reino Unido, un tipo de libro en rústica caracterizado por el tamaño de página (normalmente 198 x 129 mm aprox.). El elemento Product Form debe tener el valor BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B106">
+				<xs:annotation>
+					<xs:documentation>Trade paperback (Reino Unido)</xs:documentation>
+					<xs:documentation>En el Reino Unido, un tipo de libro en rústica caracterizado parcialmente por su tamaño (habitualmente con las dimensiones de un libro de tapa dura tradicional), y a menudo utilizado para originales en rústica. El elemento Product Form debe tener el valor BC (reemplaza el &quot;formato-C&quot; de la anterior Lista 8).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B107">
+				<xs:annotation>
+					<xs:documentation>Tall rack paperback (EE. UU.)</xs:documentation>
+					<xs:documentation>En Norteamérica, un tipo de libro en rústica caracterizado parcialmente por el tamaño de página y parcialmente por el mercado objetivo y las condiciones de comercio. El elemento Product Form debe tener el valor BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B108">
+				<xs:annotation>
+					<xs:documentation>A5:Tankobon</xs:documentation>
+					<xs:documentation>210 x 148 mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B109">
+				<xs:annotation>
+					<xs:documentation>JIS B5:Tankobon</xs:documentation>
+					<xs:documentation>Tamaño de serie B japonés, 257 x 182 mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B110">
+				<xs:annotation>
+					<xs:documentation>JIS B6:Tankobon</xs:documentation>
+					<xs:documentation>Tamaño de serie B japonés, 182 x 128 mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B111">
+				<xs:annotation>
+					<xs:documentation>A6:Bunko</xs:documentation>
+					<xs:documentation>148 x 105 mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B112">
+				<xs:annotation>
+					<xs:documentation>B40-dori Shinsho</xs:documentation>
+					<xs:documentation>Formato japonés, 182 x 103 mm o 173 x 105 mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B113">
+				<xs:annotation>
+					<xs:documentation>Pocket (Suecia)</xs:documentation>
+					<xs:documentation>Formato en rústica específico en Suecia. El elemento Product Form debe tener el valor BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B114">
+				<xs:annotation>
+					<xs:documentation>Storpocket (Suecia)</xs:documentation>
+					<xs:documentation>Formato en rústica específico en Suecia. El elemento Product Form debe tener el valor BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B115">
+				<xs:annotation>
+					<xs:documentation>Kartonnage (Suecia)</xs:documentation>
+					<xs:documentation>Formato de tapa dura específico en Suecia. El elemento Product Form debe tener el valor BB.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B116">
+				<xs:annotation>
+					<xs:documentation>Flexband (Suecia)</xs:documentation>
+					<xs:documentation>Formato en rústica específico en Suecia. El elemento Product Form debe tener el valor BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B117">
+				<xs:annotation>
+					<xs:documentation>Mook</xs:documentation>
+					<xs:documentation>En Japón, un libro en rústica con el formato de una revista pero que se vende como un libro.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B118">
+				<xs:annotation>
+					<xs:documentation>Dwarsligger</xs:documentation>
+					<xs:documentation>Conocido en España como &quot;Librino&quot;. Libro en rústica en un formato propio particularmente compacto con páginas en impresión apaisada en papel muy fino y con encuadernación horizontal (vea www.dwarsligger.com).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B119">
+				<xs:annotation>
+					<xs:documentation>Tamaño 46</xs:documentation>
+					<xs:documentation>Formato japonés: 188 x 127 mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B120">
+				<xs:annotation>
+					<xs:documentation>Tamaño 46-Henkei</xs:documentation>
+					<xs:documentation>Formato japonés.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B121">
+				<xs:annotation>
+					<xs:documentation>A4</xs:documentation>
+					<xs:documentation>297 x 210 mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B122">
+				<xs:annotation>
+					<xs:documentation>Tamaño A4-Henkei</xs:documentation>
+					<xs:documentation>Formato japonés.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B123">
+				<xs:annotation>
+					<xs:documentation>Tamaño A5-Henkei</xs:documentation>
+					<xs:documentation>Formato japonés.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B124">
+				<xs:annotation>
+					<xs:documentation>Tamaño B5-Henkei</xs:documentation>
+					<xs:documentation>Formato japonés.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B125">
+				<xs:annotation>
+					<xs:documentation>Tamaño B6-Henkei</xs:documentation>
+					<xs:documentation>Formato japonés.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B126">
+				<xs:annotation>
+					<xs:documentation>Tamaño AB</xs:documentation>
+					<xs:documentation>257 x 210 mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B127">
+				<xs:annotation>
+					<xs:documentation>Tamaño JIS B7</xs:documentation>
+					<xs:documentation>Tamaño de serie B japonesa, 128 x 91 mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B128">
+				<xs:annotation>
+					<xs:documentation>Tamaño Kiku</xs:documentation>
+					<xs:documentation>Formato japonés: 218 x 152 mm o 227 x 152 mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B129">
+				<xs:annotation>
+					<xs:documentation>Tamaño Kiku-Henkei</xs:documentation>
+					<xs:documentation>Formato japonés.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B130">
+				<xs:annotation>
+					<xs:documentation>Tamaño JIS B4</xs:documentation>
+					<xs:documentation>Tamaño de serie B japonés, 257 x 364 mm.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B201">
+				<xs:annotation>
+					<xs:documentation>Libro para colorear o unir puntos</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B202">
+				<xs:annotation>
+					<xs:documentation>Libro con desplegables</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B204">
+				<xs:annotation>
+					<xs:documentation>Minilibro</xs:documentation>
+					<xs:documentation>Nota: mostrado de forma incorrecta como B203 (entrada duplicada) en el número 3.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B205">
+				<xs:annotation>
+					<xs:documentation>Libro con imágenes en movimiento o folioscopio</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B206">
+				<xs:annotation>
+					<xs:documentation>Libro tridimensional</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B207">
+				<xs:annotation>
+					<xs:documentation>Libro perfumado o con olores</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B208">
+				<xs:annotation>
+					<xs:documentation>Libro con sonidos o ruidos</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B209">
+				<xs:annotation>
+					<xs:documentation>Libro de pegatinas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B210">
+				<xs:annotation>
+					<xs:documentation>Libro con texturas</xs:documentation>
+					<xs:documentation>Libro cuyas páginas presentan una variedad de texturas diseñadas para estimular la exploración táctil: vea también B214 y B215.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B212">
+				<xs:annotation>
+					<xs:documentation>Libro troquelado</xs:documentation>
+					<xs:documentation>Libro que está recortado en una forma distintiva no lineal o en el que se han recortado agujeros o formas en el interior. &quot;Troquelado&quot; se usa aquí como una taquigrafía conveniente y no implica una limitación estricta a un proceso determinado de producción.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B213">
+				<xs:annotation>
+					<xs:documentation>Libro juguete</xs:documentation>
+					<xs:documentation>Libro que es también un juguete o que incorpora un juguete como parte fundamental. Sin embargo, no utilizar B213 para un producto con múltiples objetos que incluya un libro y un juguete como objetos separados.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B214">
+				<xs:annotation>
+					<xs:documentation>Libro de tacto suave</xs:documentation>
+					<xs:documentation>Libro cuya cubierta tiene un acabado con una textura suave, normalmente en la anterior.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B215">
+				<xs:annotation>
+					<xs:documentation>Libro con recortables de fieltro</xs:documentation>
+					<xs:documentation>Libro con piezas de fieltro desmontables y páginas con texturas donde pueden añadirse estas piezas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B221">
+				<xs:annotation>
+					<xs:documentation>Libro de imágenes</xs:documentation>
+					<xs:documentation>Libro de imágenes para niños: utilizar con el código de formulario de producto pertinente.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B222">
+				<xs:annotation>
+					<xs:documentation>Libro &quot;Carousel&quot;</xs:documentation>
+					<xs:documentation>(también llamado libro &quot;Star&quot;). El tratamiento fiscal de los productos puede variar con respecto a productos con códigos similares, como el libro juguete o el libro tridimensional).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B301">
+				<xs:annotation>
+					<xs:documentation>Hojas intercambiables: hojas y archivador</xs:documentation>
+					<xs:documentation>Usar con el código BD de formulario de producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B302">
+				<xs:annotation>
+					<xs:documentation>Hojas intercambiables: solo el archivador</xs:documentation>
+					<xs:documentation>Usar con el código BD de formulario de producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B303">
+				<xs:annotation>
+					<xs:documentation>Hojas intercambiables: solo las hojas</xs:documentation>
+					<xs:documentation>Usar con el código BD de formulario de producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B304">
+				<xs:annotation>
+					<xs:documentation>Cosido</xs:documentation>
+					<xs:documentation>También llamado suturado; para ver &quot;cosido con hilo&quot;, vea el código B310.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B305">
+				<xs:annotation>
+					<xs:documentation>No cosido o con encuadernado arráfica</xs:documentation>
+					<xs:documentation>Incluye &quot;encuadernado perfecto&quot;, &quot;con pegamento&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B306">
+				<xs:annotation>
+					<xs:documentation>Encuadernación de biblioteca</xs:documentation>
+					<xs:documentation>Encuadernación reforzada para bibliotecas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B307">
+				<xs:annotation>
+					<xs:documentation>Encuadernación reforzada</xs:documentation>
+					<xs:documentation>Encuadernación reforzada, no necesariamente para bibliotecas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B308">
+				<xs:annotation>
+					<xs:documentation>Media encuadernación</xs:documentation>
+					<xs:documentation>Debe ir acompañado por un código que especifique un material, p.ej. &quot;media encuadernación en piel auténtica&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B309">
+				<xs:annotation>
+					<xs:documentation>Encuadernación en cuarto</xs:documentation>
+					<xs:documentation>Debe ir acompañado por un código que especifique un material &quot;encuadernación en cuarto en piel auténtica&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B310">
+				<xs:annotation>
+					<xs:documentation>Cosido</xs:documentation>
+					<xs:documentation>También llamado &quot;grapado&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B311">
+				<xs:annotation>
+					<xs:documentation>Encuadernación con peine</xs:documentation>
+					<xs:documentation>Formas redondas u ovaladas de plástico configuradas en forma de pinza: utilizar con el código de formulario de producto BE.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B312">
+				<xs:annotation>
+					<xs:documentation>Wire-O</xs:documentation>
+					<xs:documentation>Doble espiral metálica: utilizar con el código de formulario de producto BE.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B313">
+				<xs:annotation>
+					<xs:documentation>Alambre oculto</xs:documentation>
+					<xs:documentation>Encuadernación Wire-O recubierta: utilizar con el código de formulario de producto BE.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B401">
+				<xs:annotation>
+					<xs:documentation>Tela sobre cubiertas</xs:documentation>
+					<xs:documentation>También llamado tejido o lino sobre cubiertas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B402">
+				<xs:annotation>
+					<xs:documentation>Papel sobre las tapas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B403">
+				<xs:annotation>
+					<xs:documentation>Piel auténtica</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B404">
+				<xs:annotation>
+					<xs:documentation>Piel imitación</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B405">
+				<xs:annotation>
+					<xs:documentation>Cuero regenerado</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B406">
+				<xs:annotation>
+					<xs:documentation>Vitela</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B409">
+				<xs:annotation>
+					<xs:documentation>Tela</xs:documentation>
+					<xs:documentation>Tela, no necesariamente sobre las cubiertas; vea B401.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B410">
+				<xs:annotation>
+					<xs:documentation>Tela de imitación</xs:documentation>
+					<xs:documentation>Símil-tela español.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B411">
+				<xs:annotation>
+					<xs:documentation>Terciopelo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B412">
+				<xs:annotation>
+					<xs:documentation>Portada flexible de plástico o vinilo</xs:documentation>
+					<xs:documentation>También llamado &quot;flexibound&quot;: utilizar con el código de formulario de producto BC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B413">
+				<xs:annotation>
+					<xs:documentation>Cubierta de plástico</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B414">
+				<xs:annotation>
+					<xs:documentation>Cubierta de vinilo</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B415">
+				<xs:annotation>
+					<xs:documentation>Cubierta laminada</xs:documentation>
+					<xs:documentation>Libro, material de laminado no especificado: utilizar L101 para &quot;todo el producto laminado&quot;, p.ej., una página de mapa o póster laminados.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B501">
+				<xs:annotation>
+					<xs:documentation>Con sobrecubierta</xs:documentation>
+					<xs:documentation>Tipo no especificado.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B502">
+				<xs:annotation>
+					<xs:documentation>Con sobrecubierta impresa</xs:documentation>
+					<xs:documentation>Usado para distinguir de B503.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B503">
+				<xs:annotation>
+					<xs:documentation>Con sobrecubierta translúcida</xs:documentation>
+					<xs:documentation>Con cubierta protectora translúcida de papel o plástico.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B504">
+				<xs:annotation>
+					<xs:documentation>Con solapas</xs:documentation>
+					<xs:documentation>Para libros en rústica con solapas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B505">
+				<xs:annotation>
+					<xs:documentation>Con índice de pestañas</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B506">
+				<xs:annotation>
+					<xs:documentation>Con cinta(s) marcapáginas</xs:documentation>
+					<xs:documentation>Si el número de marcapáginas es relevante, se puede exponer como texto libre en &lt;ProductFormDescription>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B507">
+				<xs:annotation>
+					<xs:documentation>Con cremallera</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B508">
+				<xs:annotation>
+					<xs:documentation>Con cierre de botón a presión</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B509">
+				<xs:annotation>
+					<xs:documentation>Encuadernación a la holandesa</xs:documentation>
+					<xs:documentation>También conocido como bodes de encuadernación flexible.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B510">
+				<xs:annotation>
+					<xs:documentation>Canto rugoso</xs:documentation>
+					<xs:documentation>Con los bordes cortados de forma desigual, sin cuidado y de forma irregular. También conocido como borde intonso o borde con barbas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B601">
+				<xs:annotation>
+					<xs:documentation>Libro para dar la vuelta</xs:documentation>
+					<xs:documentation>Libro en el cual la mitad del contenido está impreso de forma inversa para leerse al revés. También conocido como &quot;libro para voltear&quot; (normalmente la unión de dos libros).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B602">
+				<xs:annotation>
+					<xs:documentation>Formato manga sin adaptación de lectura</xs:documentation>
+					<xs:documentation>Manga con páginas y secuencias ordenadas según el original japonés, pero con texto occidental.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B701">
+				<xs:annotation>
+					<xs:documentation>Braille no contraído de Reino Unido</xs:documentation>
+					<xs:documentation>Solo letras sueltas. Se ha identificado anteriormente como Braille de Reino Unido de grado 1.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B702">
+				<xs:annotation>
+					<xs:documentation>Braille contraído de Reino Unido</xs:documentation>
+					<xs:documentation>Con algunas combinaciones de letras. Antes se identificaba como braille del Reino Unido de grado 2.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B703">
+				<xs:annotation>
+					<xs:documentation>Braille de EEUU</xs:documentation>
+					<xs:documentation>OBSOLETO. Utilizar B704 o B705 según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B704">
+				<xs:annotation>
+					<xs:documentation>Braille no contraído de EE.UU.</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B705">
+				<xs:annotation>
+					<xs:documentation>Braille contraído de EE.UU.</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B706">
+				<xs:annotation>
+					<xs:documentation>Braille inglés unificado</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="B707">
+				<xs:annotation>
+					<xs:documentation>Alfabeto Moon</xs:documentation>
+					<xs:documentation>Alfabeto en relieve Moon, usado por lectores con deficiencias visuales y con dificultades con el Braille.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D101">
+				<xs:annotation>
+					<xs:documentation>Formato Real Video</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D102">
+				<xs:annotation>
+					<xs:documentation>Formato Quicktime</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D103">
+				<xs:annotation>
+					<xs:documentation>Formato AVI</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D104">
+				<xs:annotation>
+					<xs:documentation>Formato Windows Media Video</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D105">
+				<xs:annotation>
+					<xs:documentation>MPEG-4</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D201">
+				<xs:annotation>
+					<xs:documentation>MS-DOS</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto D* pertinente. Tenga en cuenta que se puede dar más detalle de los requisitos del sistema en un compuesto de características de formulario de producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D202">
+				<xs:annotation>
+					<xs:documentation>Windows</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto D* pertinente; vea la nota en D201.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D203">
+				<xs:annotation>
+					<xs:documentation>Macintosh</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto D* pertinente; vea la nota en D201.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D204">
+				<xs:annotation>
+					<xs:documentation>UNIX / LINUX</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto D* pertinente; vea la nota en D201.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D205">
+				<xs:annotation>
+					<xs:documentation>Otros sistemas operativos</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto D* pertinente; vea la nota en D201.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D206">
+				<xs:annotation>
+					<xs:documentation>Palm OS</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto D* pertinente; vea la nota en D201.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D207">
+				<xs:annotation>
+					<xs:documentation>Windows Mobile</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto D* pertinente; vea la nota en D201.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D301">
+				<xs:annotation>
+					<xs:documentation>Microsoft XBox</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto DE o DB según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D302">
+				<xs:annotation>
+					<xs:documentation>Nintendo Gameboy Color</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto DE o DB según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D303">
+				<xs:annotation>
+					<xs:documentation>Nintendo Gameboy Advanced</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto DE o DB según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D304">
+				<xs:annotation>
+					<xs:documentation>Nintendo Gameboy</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto DE o DB según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D305">
+				<xs:annotation>
+					<xs:documentation>Nintendo Gamecube</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto DE o DB según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D306">
+				<xs:annotation>
+					<xs:documentation>Nintendo 64</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto DE o DB según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D307">
+				<xs:annotation>
+					<xs:documentation>Sega Dreamcast</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto DE o DB según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D308">
+				<xs:annotation>
+					<xs:documentation>Sega Genesis/Megadrive</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto DE o DB según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D309">
+				<xs:annotation>
+					<xs:documentation>Sega Saturn</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto DE o DB según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D310">
+				<xs:annotation>
+					<xs:documentation>Sony PlayStation 1</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto DE o DB según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D311">
+				<xs:annotation>
+					<xs:documentation>Sony PlayStation 2</xs:documentation>
+					<xs:documentation>Utilizar con un código de formulario de producto DE o DB según convenga.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D312">
+				<xs:annotation>
+					<xs:documentation>Nintendo Dual Screen</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D313">
+				<xs:annotation>
+					<xs:documentation>Sony PlayStation 3</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D314">
+				<xs:annotation>
+					<xs:documentation>Xbox 360</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D315">
+				<xs:annotation>
+					<xs:documentation>Nintendo Wii</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D316">
+				<xs:annotation>
+					<xs:documentation>Sony PlayStation Portable (PSP)</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E100">
+				<xs:annotation>
+					<xs:documentation>Otro</xs:documentation>
+					<xs:documentation>Código para la publicación electrónica aún por establecer.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E101">
+				<xs:annotation>
+					<xs:documentation>EPUB</xs:documentation>
+					<xs:documentation>Open Publication Structure / formato contenedor estándar OPS del International Digital Publishing Forum (IDPF) [Extensión de archivo .epub].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E102">
+				<xs:annotation>
+					<xs:documentation>OEB</xs:documentation>
+					<xs:documentation>Formato Open EBook del IDPF, predecesor del formato EPUB completo, todavía soportado en 2008 como parte de este último [Extensión de archivo .opf]. También formato EPUB hasta la versión 2 incluida, pero se prefiere el código E101 para EPUB 2. Usar siempre el código E101 para EPUB 3.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E103">
+				<xs:annotation>
+					<xs:documentation>DOC</xs:documentation>
+					<xs:documentation>Formato de documento binario de Microsoft Word [Extensión de archivo .doc].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E104">
+				<xs:annotation>
+					<xs:documentation>DOCX</xs:documentation>
+					<xs:documentation>Formato de documento Microsoft Word XML / Office Open XML (ISO/ IEC 29500:2008) [Extensión de archivo .docx].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E105">
+				<xs:annotation>
+					<xs:documentation>HTML</xs:documentation>
+					<xs:documentation>Lenguaje de marcado de hipertexto (del inglés, HyperText Mark-up Language) [Extensión de archivo .html, .htm].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E106">
+				<xs:annotation>
+					<xs:documentation>ODF</xs:documentation>
+					<xs:documentation>Formato de documento abierto para aplicaciones ofimáticas (del inglés, Open Document Format) [Extensión de archivo .odt].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E107">
+				<xs:annotation>
+					<xs:documentation>PDF</xs:documentation>
+					<xs:documentation>Formato de almacenamiento para documentos digitales (del inglés, Portable Document Format, ISO 32000-1:2008) [Extensión de archivo .pdf].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E108">
+				<xs:annotation>
+					<xs:documentation>PDF/A</xs:documentation>
+					<xs:documentation>Formato para archivos PDF definido por la ISO 19005-1:2005 [Extensión de archivo .pdf].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E109">
+				<xs:annotation>
+					<xs:documentation>RTF</xs:documentation>
+					<xs:documentation>Formato de texto enriquecido (del inglés, Rich Text Format) [Extensión de archivo .rtf].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E110">
+				<xs:annotation>
+					<xs:documentation>SGML</xs:documentation>
+					<xs:documentation>Lenguaje de marcado generalizado estándar (del inglés, Standard Generalized Mark-up Language).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E111">
+				<xs:annotation>
+					<xs:documentation>TCR</xs:documentation>
+					<xs:documentation>Formato de texto comprimido utilizado principalmente en dispositivos de mano Psion [Extensión de archivo .tcr].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E112">
+				<xs:annotation>
+					<xs:documentation>TXT</xs:documentation>
+					<xs:documentation>Archivo de texto sin formato [Extensión de archivo .txt].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E113">
+				<xs:annotation>
+					<xs:documentation>XHTML</xs:documentation>
+					<xs:documentation>Formato de HTML expresado como XML válido (del inglés, Extensible Hypertext Markup Language) [Extensión de archivo .xhtml, .xht, .xml, .html, .htm].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E114">
+				<xs:annotation>
+					<xs:documentation>zTXT</xs:documentation>
+					<xs:documentation>Formato de texto comprimido utilizado principalmente en dispositivos de mano Palm [Extensión de archivo .pdb. Vea también E121, E125, E130].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E115">
+				<xs:annotation>
+					<xs:documentation>XPS</xs:documentation>
+					<xs:documentation>Formato de lenguaje de descripción de páginas (del inglés, XML Paper Specification) [Extensión de archivo .xps].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E116">
+				<xs:annotation>
+					<xs:documentation>Amazon Kindle</xs:documentation>
+					<xs:documentation>Formato propio de Amazon para sus dispositivos de lectura Kindle o sus programas informáticos de lectura [Extensión de archivo .azw, .mobi, .prc].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E117">
+				<xs:annotation>
+					<xs:documentation>BBeB</xs:documentation>
+					<xs:documentation>Formato propio de Sony utilizado para sus dispositivos de lectura Sony Reader y LIBRIé [Extensión de archivo .lrf].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E118">
+				<xs:annotation>
+					<xs:documentation>DXReader</xs:documentation>
+					<xs:documentation>Formato propio utilizado por el programa DXReader.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E119">
+				<xs:annotation>
+					<xs:documentation>EBL</xs:documentation>
+					<xs:documentation>Formato propio del servicio Ebook Library.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E120">
+				<xs:annotation>
+					<xs:documentation>Ebrary</xs:documentation>
+					<xs:documentation>Formato propio del servicio Ebrary.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E121">
+				<xs:annotation>
+					<xs:documentation>eReader</xs:documentation>
+					<xs:documentation>Formato propio para el programa eReader (también conocido como &quot;Palm Reader&quot;) en distintas plataformas [Extensión de archivo .pdb. Vea también E114, E125, E130].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E122">
+				<xs:annotation>
+					<xs:documentation>Exebook</xs:documentation>
+					<xs:documentation>Formato propio que incorpora su sistema de lectura exclusivo para plataformas Windows [Extensión de archivo .exe].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E123">
+				<xs:annotation>
+					<xs:documentation>Franklin eBookman</xs:documentation>
+					<xs:documentation>Formato propio para el dispositivo de lectura Franklin eBookman.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E124">
+				<xs:annotation>
+					<xs:documentation>Gemstar Rocketbook</xs:documentation>
+					<xs:documentation>Formato propio para el dispositivo de lectura Gemstar Rocketbook [Extensión de archivo .rb].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E125">
+				<xs:annotation>
+					<xs:documentation>iSilo</xs:documentation>
+					<xs:documentation>Formato propio para el programa iSilo en distintas plataformas [Extensión de archivo .pdb. Vea también E114, E121, E130].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E126">
+				<xs:annotation>
+					<xs:documentation>Microsoft Reader</xs:documentation>
+					<xs:documentation>Formato propio para el programa Microsoft Reader en plataformas Windows y Pocket PC [Extensión de archivo .lit].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E127">
+				<xs:annotation>
+					<xs:documentation>Mobipocket</xs:documentation>
+					<xs:documentation>Formato propio para el software Mobipocket en distintas plataformas [Extensiones de archivo .mobi, .prc]. También formatos de Amazon Kindle hasta la versión 7 incluida. Se prefiere el código E116 para la versión 7. Usar siempre el código E116 para KF8.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E128">
+				<xs:annotation>
+					<xs:documentation>MyiLibrary</xs:documentation>
+					<xs:documentation>Formato propio del servicio MyiLibrary.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E129">
+				<xs:annotation>
+					<xs:documentation>NetLibrary</xs:documentation>
+					<xs:documentation>Formato propio del servicio NetLibrary.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E130">
+				<xs:annotation>
+					<xs:documentation>Plucker</xs:documentation>
+					<xs:documentation>Formato propio para el programa de lectura Plucker en Palm y otros dispositivos de mano [Extensión de archivo .pdb. Vea también E114, E121, E125].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E131">
+				<xs:annotation>
+					<xs:documentation>VitalBook</xs:documentation>
+					<xs:documentation>Formato propietario del servicio VitalSource.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E132">
+				<xs:annotation>
+					<xs:documentation>Vook</xs:documentation>
+					<xs:documentation>Producto digital propio que combina texto y vídeo. Disponible en línea y en forma de aplicación descargable para dispositivo móvil. Vea www.vook.com.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E133">
+				<xs:annotation>
+					<xs:documentation>Google Edition</xs:documentation>
+					<xs:documentation>Publicación electrónica distribuida por Google en asociación con una editorial, que se puede leer en línea mediante un navegador o bien sin conexión en lectores de libros electrónicos específicos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E134">
+				<xs:annotation>
+					<xs:documentation>Aplicación de lectura para iOS</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato de aplicación para iOS (Apple iPhone, iPad, etc.) que contiene el código ejecutable y el contenido. Usar &lt;ProductContentType> para describir el contenido y &lt;ProductFormFeatureType> para enumerar los requisitos técnicos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E135">
+				<xs:annotation>
+					<xs:documentation>Aplicación de libros para Android</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato de aplicación para Android (teléfono o tableta) que contiene el código ejecutable y el contenido. Usar &lt;ProductContentType> para describir el contenido y &lt;ProductFormFeatureType> para enumerar los requisitos técnicos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E136">
+				<xs:annotation>
+					<xs:documentation>Aplicación de libros para otro sistema operativo</xs:documentation>
+					<xs:documentation>Publicación electrónica en formato de aplicación que contiene el código ejecutable y el contenido. Usar cuando otros códigos de aplicación no son apropiados. Deberían proporcionarse requisitos técnicos como el sistema operativo de destino o el dispositivo, por ejemplo en &lt;ProductFormFeatureType>. El tipo de contenido (texto o texto con distintas &quot;mejoras&quot;) puede describirse con &lt;ProductContentType>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E139">
+				<xs:annotation>
+					<xs:documentation>CEB</xs:documentation>
+					<xs:documentation>Formato básico del libro electrónico propio de Apabi.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E140">
+				<xs:annotation>
+					<xs:documentation>CEBX</xs:documentation>
+					<xs:documentation>Formato XML del libro electrónico propio de Apabi.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E141">
+				<xs:annotation>
+					<xs:documentation>iBook</xs:documentation>
+					<xs:documentation>Formato iBook de Apple (una extensión propietaria de EPUB), únicamente legible con dispositivos que cuenten con el sistema operativo iOS de Apple.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E142">
+				<xs:annotation>
+					<xs:documentation>ePIB</xs:documentation>
+					<xs:documentation>Formato propietario utilizado por Barnes and Noble, legible en dispositivos NOOK y con el software de lectura Nook.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E200">
+				<xs:annotation>
+					<xs:documentation>Ajustable</xs:documentation>
+					<xs:documentation>Usar cuando un tipo específico de publicación electrónica (se indica usando los códigos a partir del E100) tiene formato tanto fijo como ajustable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E201">
+				<xs:annotation>
+					<xs:documentation>Formato fijo</xs:documentation>
+					<xs:documentation>Usar cuando un tipo específico de publicación electrónica (se indica usando los códigos a partir del E100) tiene formato tanto fijo como ajustable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E202">
+				<xs:annotation>
+					<xs:documentation>Disponible sin conexión</xs:documentation>
+					<xs:documentation>Todos los recursos de publicaciones electrónicas se incluyen en el paquete de publicaciones electrónicas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E203">
+				<xs:annotation>
+					<xs:documentation>Se requiere conexión a una red</xs:documentation>
+					<xs:documentation>La publicación electrónica necesita una conexión de red para acceder a algunos recursos (como un libro electrónico mejorado donde los vídeos no se almacenan en la propia publicación electrónica, sino que se proporcionan a través de una conexión a Internet).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="L101">
+				<xs:annotation>
+					<xs:documentation>Laminado</xs:documentation>
+					<xs:documentation>Producto entero laminado (p.ej., mapa laminado, gráfica desplegable, póster, etc.): utilizar B415 para libros con la portada laminada.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P101">
+				<xs:annotation>
+					<xs:documentation>Calendario de escritorio</xs:documentation>
+					<xs:documentation>Utilizar con el código de formulario de producto PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P102">
+				<xs:annotation>
+					<xs:documentation>Minicalendario</xs:documentation>
+					<xs:documentation>Utilizar con el código de formulario de producto PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P103">
+				<xs:annotation>
+					<xs:documentation>Agenda de citas</xs:documentation>
+					<xs:documentation>Utilizar con el código de formulario de producto PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P104">
+				<xs:annotation>
+					<xs:documentation>Calendario diario</xs:documentation>
+					<xs:documentation>Utilizar con el código de formulario de producto PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P105">
+				<xs:annotation>
+					<xs:documentation>Calendario en forma de póster</xs:documentation>
+					<xs:documentation>Utilizar con el código de formulario de producto PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P106">
+				<xs:annotation>
+					<xs:documentation>Calendario de pared</xs:documentation>
+					<xs:documentation>Utilizar con el código de formulario de producto PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P107">
+				<xs:annotation>
+					<xs:documentation>Calendario perpetuo</xs:documentation>
+					<xs:documentation>Utilizar con el código de formulario de producto PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P108">
+				<xs:annotation>
+					<xs:documentation>Calendario de Adviento</xs:documentation>
+					<xs:documentation>Utilizar con el código de formulario de producto PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P109">
+				<xs:annotation>
+					<xs:documentation>Calendario marcapáginas</xs:documentation>
+					<xs:documentation>Utilizar con el código de formulario de producto PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P110">
+				<xs:annotation>
+					<xs:documentation>Calendario escolarl</xs:documentation>
+					<xs:documentation>Utilizar con el código de formulario de producto PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P111">
+				<xs:annotation>
+					<xs:documentation>Calendario para proyectos</xs:documentation>
+					<xs:documentation>Utilizar con el código de formulario de producto PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P112">
+				<xs:annotation>
+					<xs:documentation>Almanaque</xs:documentation>
+					<xs:documentation>Utilizar con el código de formulario de producto PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P113">
+				<xs:annotation>
+					<xs:documentation>Otro tipo de calendario</xs:documentation>
+					<xs:documentation>Calendario que no es ninguno de los tipos especificados: utilizar con el código del formulario de producto PC.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P114">
+				<xs:annotation>
+					<xs:documentation>Otro tipo de producto para calendarios o agendas</xs:documentation>
+					<xs:documentation>Producto que está asociado o bien es un accesorio de un calendario o agenda, p.ej., un soporte para un calendario, o bien un encaje para un organizador: utilizar con el código de formulario de producto PC o PS.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P201">
+				<xs:annotation>
+					<xs:documentation>Tapa dura (artículos de papelería)</xs:documentation>
+					<xs:documentation>Artículos de papelería en formato de libro de tapa dura.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P202">
+				<xs:annotation>
+					<xs:documentation>Encuadernación rústica (artículos de papelería)</xs:documentation>
+					<xs:documentation>Artículo de papelería en formato de libro con encuadernación rústica.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P203">
+				<xs:annotation>
+					<xs:documentation>Encuadernación en espiral (artículo de papelería)</xs:documentation>
+					<xs:documentation>Artículo de papelería en formato de libro con encuadernación en espiral.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="P204">
+				<xs:annotation>
+					<xs:documentation>Encuadernación en piel o de lujo (artículo de papelería)</xs:documentation>
+					<xs:documentation>Artículo de papelería en formato de libro con encuadernación en piel o de lujo.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="V201">
+				<xs:annotation>
+					<xs:documentation>PAL</xs:documentation>
+					<xs:documentation>Estándar de televisión para vídeo y DVD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="V202">
+				<xs:annotation>
+					<xs:documentation>NTSC</xs:documentation>
+					<xs:documentation>Estándar de televisión para vídeo y DVD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="V203">
+				<xs:annotation>
+					<xs:documentation>SECAM</xs:documentation>
+					<xs:documentation>Estándar de televisión para vídeo y DVD.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List176">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 176">Función del producto: sistema operativo</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Android</xs:documentation>
+					<xs:documentation>Sistema operativo para dispositivos móviles de código abierto desarrollado en un principio por Google y apoyado por el Open Handset Alliance.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>BlackBerry OS</xs:documentation>
+					<xs:documentation>Sistema operativo propio distribuido por Research In Motion para sus dispositivos portátiles BlackBerry.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>iOS</xs:documentation>
+					<xs:documentation>Sistema operativo propio basado en Mac OS X, distribuido por Apple para sus dispositivos portátiles iPhone, iPad y iPod Touch.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Linux</xs:documentation>
+					<xs:documentation>Sistema operativo basado en el núcleo de Linux.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Mac OS</xs:documentation>
+					<xs:documentation>[Sistema operativo propio distribuido por Apple para equipos Macintosh hasta 2002] OBSOLETO. Usar el código 13 para todas las versiones del sistema operativo Mac.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Mac OS X</xs:documentation>
+					<xs:documentation>[Sistema operativo propio distribuido por Apple para equipos Macintosh en 2001/2002] OBSOLETO. Usar el código 13 para todas las versiones del sistema operativo Mac.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Palm OS</xs:documentation>
+					<xs:documentation>Sistema operativo propio (también conocido como Garnet OS) desarrollado en un principio para dispositivos portátiles.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="08">
+				<xs:annotation>
+					<xs:documentation>webOS</xs:documentation>
+					<xs:documentation>Sistema operativo propio basado en Linux para dispositivos portátiles, desarrollado en un principio por Palm (ahora propiedad de HP).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="09">
+				<xs:annotation>
+					<xs:documentation>Symbian</xs:documentation>
+					<xs:documentation>Sistema operativo para dispositivos portátiles, desarrollado en un principio como sistema propio pero programado para ser completamente abierto desde 2010.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>Windows</xs:documentation>
+					<xs:documentation>Sistema operativo propio distribuido por Microsoft.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Windows CE</xs:documentation>
+					<xs:documentation>Sistema operativo propio (también conocido como Windows Embedded Compact, WinCE) distribuido por Microsoft para dispositivos de tamaño reducido.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Windows Mobile</xs:documentation>
+					<xs:documentation>Sistema operativo propio distribuido por Microsoft para dispositivos móviles.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Mac OS</xs:documentation>
+					<xs:documentation>Sistema operativo propio distribuido por Apple en equipos Macintosh.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Windows Phone 7</xs:documentation>
+					<xs:documentation>Sistema operativo propio distribuido por Microsoft para dispositivos móviles, sucesor de Windows Mobile.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List177">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 177">Función de la fecha de persona/organización</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="50">
+				<xs:annotation>
+					<xs:documentation>Fecha de nacimiento</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="51">
+				<xs:annotation>
+					<xs:documentation>Fecha de fallecimiento</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List178">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 178">Formato del archivo del recurso de soporte</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="A103">
+				<xs:annotation>
+					<xs:documentation>MP3</xs:documentation>
+					<xs:documentation>Archivo MPEG 1/2 Audio Layer III.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A104">
+				<xs:annotation>
+					<xs:documentation>WAV</xs:documentation>
+					<xs:documentation>Archivo de audio Waveform.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A105">
+				<xs:annotation>
+					<xs:documentation>Real Audio</xs:documentation>
+					<xs:documentation>Formato propio de RealNetworks.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A106">
+				<xs:annotation>
+					<xs:documentation>WMA</xs:documentation>
+					<xs:documentation>Formato Windows Media Audio.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A107">
+				<xs:annotation>
+					<xs:documentation>AAC</xs:documentation>
+					<xs:documentation>Formato Advanced Audio Coding.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="A111">
+				<xs:annotation>
+					<xs:documentation>AIFF</xs:documentation>
+					<xs:documentation>Formato Audio Interchange File (formato de archivo de intercambio de audio).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D101">
+				<xs:annotation>
+					<xs:documentation>Real Video</xs:documentation>
+					<xs:documentation>Formato propio de RealNetworks.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D102">
+				<xs:annotation>
+					<xs:documentation>Quicktime</xs:documentation>
+					<xs:documentation>Formato contenedor de Quicktime (.mov).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D103">
+				<xs:annotation>
+					<xs:documentation>AVI</xs:documentation>
+					<xs:documentation>Formato Audio Video Interleave.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D104">
+				<xs:annotation>
+					<xs:documentation>WMV</xs:documentation>
+					<xs:documentation>Formato Windows Media Video.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D105">
+				<xs:annotation>
+					<xs:documentation>MPEG-4</xs:documentation>
+					<xs:documentation>Formato contenedor MPEG-4 (.mp4, .m4a).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D106">
+				<xs:annotation>
+					<xs:documentation>FLV</xs:documentation>
+					<xs:documentation>Flash Video (.flv, .f4v).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D107">
+				<xs:annotation>
+					<xs:documentation>SWF</xs:documentation>
+					<xs:documentation>ShockWave (.swf).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D108">
+				<xs:annotation>
+					<xs:documentation>3GP</xs:documentation>
+					<xs:documentation>Formato contenedor de 3GPP (.3gp, .3g2).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D109">
+				<xs:annotation>
+					<xs:documentation>WebM</xs:documentation>
+					<xs:documentation>Formato contenedor de WebM (incluye .mkv).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D401">
+				<xs:annotation>
+					<xs:documentation>PDF</xs:documentation>
+					<xs:documentation>Formato de almacenamiento para archivos digitales (del inglés, Portable Document File).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D501">
+				<xs:annotation>
+					<xs:documentation>GIF</xs:documentation>
+					<xs:documentation>Formato de archivo de intercambio de imágenes (del inglés, Graphic Interchange File).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D502">
+				<xs:annotation>
+					<xs:documentation>JPEG</xs:documentation>
+					<xs:documentation>Formato de archivo de imagen comprimido (del inglés, Joint Photographic Experts Group).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D503">
+				<xs:annotation>
+					<xs:documentation>PNG</xs:documentation>
+					<xs:documentation>Formato de imagen de compresión sin pérdida (del inglés, Portable Network Graphics).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="D504">
+				<xs:annotation>
+					<xs:documentation>TIFF</xs:documentation>
+					<xs:documentation>Formato de archivo de imagen con etiquetas (del inglés, Tagged Image File format).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E101">
+				<xs:annotation>
+					<xs:documentation>EPUB</xs:documentation>
+					<xs:documentation>Open Publication Structure / formato contenedor estándar OPS del International Digital Publishing Forum (IDPF) [Extensión de archivo .epub].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E105">
+				<xs:annotation>
+					<xs:documentation>HTML</xs:documentation>
+					<xs:documentation>Lenguaje de marcado de hipertexto (del inglés, HyperText Mark-up Language) [Extensión de archivo .html, .htm].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E107">
+				<xs:annotation>
+					<xs:documentation>PDF</xs:documentation>
+					<xs:documentation>Formato de almacenamiento para documentos digitales (del inglés, Portable Document Format, ISO 32000-1:2008) [Extensión de archivo .pdf].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E113">
+				<xs:annotation>
+					<xs:documentation>XHTML</xs:documentation>
+					<xs:documentation>Formato de HTML expresado como XML válido (del inglés, Extensible Hypertext Markup Language) [Extensión de archivo .xhtml, .xht, .xml, .html, .htm].</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="E115">
+				<xs:annotation>
+					<xs:documentation>XPS</xs:documentation>
+					<xs:documentation>XML Paper Specification.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List179">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 179">Tipo de código de precio</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Propietario</xs:documentation>
+					<xs:documentation>Código particular de una editorial o un distribuidor que identifica códigos de precio concretos, o grupos o bandas de precios.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Código de precio para libros de bolsillo en Finlandia</xs:documentation>
+					<xs:documentation>Código de precios utilizado en Finlandia para los libros de bolsillo (&quot;Pokkareiden hintaryhmä&quot;). Los precios se indican mediante letras A-J en &lt;PriceCode>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List184">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 184">Advertencia de seguridad de la Directiva europea sobre la seguridad de juguetes</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="00">
+				<xs:annotation>
+					<xs:documentation>Sin advertencias</xs:documentation>
+					<xs:documentation>Usar para indicar que no se requieren advertencias.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Lleva el logotipo &quot;CE&quot;</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Lleva una advertencia de edad mínima</xs:documentation>
+					<xs:documentation>Para especificar la edad (en años o en años y meses). Incluye el texto en &lt;ProductFormFeatureDescription>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Lleva el logotipo de advertencia de la Directiva europea sobre la seguridad de juguetes &quot;No apto para menores de entre 0 y 3 años&quot;</xs:documentation>
+					<xs:documentation>Lleva logotipo y debe estar acompañado de la advertencia por defecto &quot;No apto para menores de 36 meses&quot; (o equivalentes en otras lenguas), a menos que se incluya un texto alternativo en &lt;ProductFormFeatureDescription>. Si se incluye un texto específico alternativo en &lt;ProductFormFeatureDescription>, deberá usarse en lugar del texto por defecto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Lleva la advertencia de peligro de la Directiva europea sobre la seguridad de juguetes</xs:documentation>
+					<xs:documentation>El texto exacto de advertencia debe incluirse en &lt;ProductFormFeatureDescription>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Lleva otro texto sobre seguridad del juguete</xs:documentation>
+					<xs:documentation>El texto exacto (no una advertencia en sí) debe incluirse en &lt;ProductFormFeatureDescription>. Puede usarse sin advertencia o como texto adicional a una advertencia. Si no hay advertencias aplicables, el código 00 lo indica. Ejemplo de uso: &quot;Apto para todas las edades&quot;.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="06">
+				<xs:annotation>
+					<xs:documentation>Disponible ficha de datos de seguridad</xs:documentation>
+					<xs:documentation>Está disponible en línea la ficha de datos de seguridad de componentes y materias (un documento exigido por la Directiva europea de seguridad de juguetes), como archivo PDF o similar. &lt;ProductFormFeatureDescription> debe llevar la URL del documento.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="07">
+				<xs:annotation>
+					<xs:documentation>Declaración de conformidad disponible</xs:documentation>
+					<xs:documentation>La declaración de conformidad (el documento que conforma la marca CE) está disponible en línea, como archivo PDF o similar. &lt;ProductFormFeatureDescription> debe llevar la URL del documento.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List196">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 196">Detalles de accesibilidad de la publicación electrónica</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Esquema de conformidad LIA</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="10">
+				<xs:annotation>
+					<xs:documentation>No está desactivada ninguna opción de accesibilidad al sistema de lectura (con excepción)</xs:documentation>
+					<xs:documentation>No está desactivada en el producto ninguna de las funcionalidades ofrecidas por el sistema de lectura, por el dispositivo o el programa de lectura (incluyendo pero no limitado a la elección de tipo y tamaño de letra, el color del texto o el fondo, la síntesis de voz), EXCEPTO (en mensajes ONIX 3) aquellas específicamente sujetas a prohibición o limitación en &lt;EpubUsageConstraint>. Téngase en cuenta que la inclusión de partes significativas del contenido textual en forma de imagen (por ejemplo como imágenes del texto en lugar del texto en sí) impide inevitablemente el uso de opciones de accesibilidad.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="11">
+				<xs:annotation>
+					<xs:documentation>Navegación en la tabla de contenidos</xs:documentation>
+					<xs:documentation>La tabla de contenidos permite acceso directo (por ejemplo, mediante hiperenlaces) a todos los niveles de organización del texto por encima del nivel de párrafo (por ejemplo a todas las secciones y subsecciones) y a todas las tablas, figuras, ilustraciones, etc. También debe poder accederse a los objetos no textuales como ilustraciones, tablas, audio o vídeo desde la tabla de contenidos o desde una lista similar de ilustraciones o de tablas, etc.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="12">
+				<xs:annotation>
+					<xs:documentation>Navegación en el índice</xs:documentation>
+					<xs:documentation>El índice proporciona acceso directo (por ejemplo, mediante hiperenlaces) a los usos de los términos del índice en el cuerpo del documento.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="13">
+				<xs:annotation>
+					<xs:documentation>Orden de lectura</xs:documentation>
+					<xs:documentation>Todos o casi todos los temas textuales están organizados en un único orden de lectura lógico (incluye el texto visualmente separado del flujo del texto principal, por ejemplo, en recuadros, notas al pie, citas, tablas, etc.). El contenido no textual también está vinculado desde dentro del orden de lectura lógico. (El contenido no textual meramente decorativo puede ignorarse).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="14">
+				<xs:annotation>
+					<xs:documentation>Descripciones alternativas cortas</xs:documentation>
+					<xs:documentation>Todo o casi todo el contenido no textual tiene descripciones alternativas cortas, normalmente proporcionadas mediante atributos &quot;alt&quot;. Esto se aplica a imágenes (como por ejemplo fotografías, esquemas y diagramas) y a grabaciones de audio o video incrustadas, etc. El contenido de audio y vídeo debe incluir descripciones adecuadas para lectores/as impedidos auditiva o visualmente. (El contenido no textual meramente decorativo puede ignorarse, pero la accesibilidad a recursos en línea no incluidos en la publicación electrónica debe incluirse).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="15">
+				<xs:annotation>
+					<xs:documentation>Descripciones alternativas completas</xs:documentation>
+					<xs:documentation>Todo o casi todo el contenido no textual tiene descripciones alternativas completas. Esto se aplica a imágenes (como por ejemplo fotografías, esquemas y diagramas) y a grabaciones de audio o video incrustadas, etc. El contenido de audio y vídeo debe incluir descripciones alternativas (por ejemplo, vídeo con audiodescripción) y subtítulos u otros textos adecuados para lectores/as impedidos auditiva o visualmente. (El contenido no textual meramente decorativo puede ignorarse, pero la accesibilidad a recursos en línea no incluidos en la publicación electrónica debe incluirse).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="16">
+				<xs:annotation>
+					<xs:documentation>Datos visuales también disponibles como datos no gráficos</xs:documentation>
+					<xs:documentation>Cuando se incluyen representaciones visuales de datos (por ejemplo, gráficos y esquemas), los datos están también disponibles en forma no gráfica (a menudo, en forma de texto).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="17">
+				<xs:annotation>
+					<xs:documentation>Contenido matemático accesible</xs:documentation>
+					<xs:documentation>El contenido matemático, como ecuaciones, se puede usar con tecnologías de asistencia, como MathML. Es preferible la versión semántica de MathML, pero la versión de presentación es aceptable.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="18">
+				<xs:annotation>
+					<xs:documentation>Contenido de notación química accesible</xs:documentation>
+					<xs:documentation>El contenido químico, como las fórmulas químicas, se puede usar con tecnologías de asistencia, como a través de ChemML.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="19">
+				<xs:annotation>
+					<xs:documentation>Numeración de páginas equivalente a la de la versión impresa</xs:documentation>
+					<xs:documentation>Para una publicación electrónica ajustable, contiene referencia al número de página del producto equivalente en versión impresa.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="20">
+				<xs:annotation>
+					<xs:documentation>Audio pregrabado sincronizado</xs:documentation>
+					<xs:documentation>Incluye una narración de audio (con voz natural o sintetizada) pregrabada y sincronizada con el texto, para prácticamente todo el contenido textual, incluyendo las descripciones alternativas.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="97">
+				<xs:annotation>
+					<xs:documentation>Probado para compatibilidad</xs:documentation>
+					<xs:documentation>&lt;ProductFormFeatureDescription> lleva una breve descripción de la prueba de compatibilidad llevada a cabo para este producto, lo que incluye la compatibilidad con distintas tecnologías de asistencia como programas de lectores de pantalla.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="98">
+				<xs:annotation>
+					<xs:documentation>Contacto intermediario de confianza</xs:documentation>
+					<xs:documentation>&lt;ProductFormFeatureDescription> incluye una dirección de correo electrónico de un &quot;intermediario de confianza&quot; a quien se pueden dirigir preguntas detalladas sobre la accesibilidad del producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="99">
+				<xs:annotation>
+					<xs:documentation>Contacto del editor para más información sobre accesibilidad</xs:documentation>
+					<xs:documentation>&lt;ProductFormFeatureDescription> incluye una dirección de correo electrónico del editor a quien se pueden dirigir preguntas detalladas sobre la accesibilidad de un producto.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List197">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 197">Tipo de secuencia en una colección</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Propietario</xs:documentation>
+					<xs:documentation>Se debe incluir una breve etiqueta explicativa de la secuencia en &lt;CollectionSequenceTypeName>.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Orden por títulos</xs:documentation>
+					<xs:documentation>Orden determinado por el título, por ejemplo, por volumen o número de secuencia, proporcionado para confirmar.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="03">
+				<xs:annotation>
+					<xs:documentation>Orden de publicación</xs:documentation>
+					<xs:documentation>Orden de publicación de los productos de la colección.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="04">
+				<xs:annotation>
+					<xs:documentation>Orden temporal/narrativo</xs:documentation>
+					<xs:documentation>Orden determinado por el hilo narrativo o la secuencia temporal de los productos de la colección. Aplicable tanto a ficción como a no ficción (por ejemplo, a colecciones de libros de texto de historia).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="05">
+				<xs:annotation>
+					<xs:documentation>Orden de publicación original</xs:documentation>
+					<xs:documentation>Orden de publicación original, para una colección reeditada u obras de colección inicialmente publicadas fuera de la colección.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="List198">
+		<xs:annotation>
+			<xs:documentation source="ONIX Code List 198">Función del contacto del producto</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="01">
+				<xs:annotation>
+					<xs:documentation>Contacto para solicitar accesibilidad</xs:documentation>
+					<xs:documentation>Por ejemplo, para solicitar una versión editable de los archivos digitales para convertirlos a otros formatos.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="02">
+				<xs:annotation>
+					<xs:documentation>Promotional contact</xs:documentation>
+					<xs:documentation/>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="SourceTypeCode">
+		<xs:restriction base="List3"/>
+	</xs:simpleType>
+	<xs:simpleType name="TextCaseCode">
+		<xs:restriction base="List14"/>
+	</xs:simpleType>
+	<xs:simpleType name="TextFormatCode">
+		<xs:restriction base="List34"/>
+	</xs:simpleType>
+	<xs:simpleType name="TransliterationCode">
+		<xs:restriction base="List138"/>
+	</xs:simpleType>
+</xs:schema>


### PR DESCRIPTION
OMP comes with the ONIX code list - a list of book-related metadata. The list has not been translated in some languages used by OMP. @marcbria has provided us with Catalan and Spanish translations. Please merge or advise on how to proceed, @asmecher.