### PR TITLE
pkp/pkp-lib#1263 native export fixes

### DIFF
--- a/plugins/importexport/native/native.xsd
+++ b/plugins/importexport/native/native.xsd
@@ -30,8 +30,9 @@
 						<simpleType>
 							<restriction base="string">
 								<enumeration value="submission" />
+								<enumeration value="internalReview" />
 								<enumeration value="externalReview" />
-								<enumeration value="editing" />
+								<enumeration value="editorial" />
 								<enumeration value="production" />
 							</restriction>
 						</simpleType>


### PR DESCRIPTION
S. #1263
This PR
-- c) adds " internalReview" as a possible monograph stage attribute
-- d) adapts the submission stage attribute value to "editorial" (instead of "editing")