### PR TITLE
pkp/pkp-lib#1342 standardizes all DataObject subclasses on getSequence()/setSequence()

### DIFF
--- a/classes/publicationFormat/PublicationFormatDAO.inc.php
+++ b/classes/publicationFormat/PublicationFormatDAO.inc.php
@@ -149,7 +149,7 @@ class PublicationFormatDAO extends RepresentationDAO {
 		$publicationFormat->setIsApproved($row['is_approved']);
 		$publicationFormat->setEntryKey($row['entry_key']);
 		$publicationFormat->setPhysicalFormat($row['physical_format']);
-		$publicationFormat->setSeq($row['seq']);
+		$publicationFormat->setSequence($row['seq']);
 		$publicationFormat->setId($row['publication_format_id']);
 		$publicationFormat->setSubmissionId($row['submission_id']);
 		$publicationFormat->setFileSize($row['file_size']);
@@ -195,7 +195,7 @@ class PublicationFormatDAO extends RepresentationDAO {
 				$publicationFormat->getEntryKey(),
 				(int) $publicationFormat->getPhysicalFormat(),
 				(int) $publicationFormat->getMonographId(),
-				(int) $publicationFormat->getSeq(),
+				(int) $publicationFormat->getSequence(),
 				$publicationFormat->getFileSize(),
 				$publicationFormat->getFrontMatter(),
 				$publicationFormat->getBackMatter(),
@@ -261,7 +261,7 @@ class PublicationFormatDAO extends RepresentationDAO {
 				(int) $publicationFormat->getIsApproved(),
 				$publicationFormat->getEntryKey(),
 				(int) $publicationFormat->getPhysicalFormat(),
-				(int) $publicationFormat->getSeq(),
+				(int) $publicationFormat->getSequence(),
 				$publicationFormat->getFileSize(),
 				$publicationFormat->getFrontMatter(),
 				$publicationFormat->getBackMatter(),

--- a/plugins/importexport/csv/CSVImportExportPlugin.inc.php
+++ b/plugins/importexport/csv/CSVImportExportPlugin.inc.php
@@ -206,7 +206,7 @@ class CSVImportExportPlugin extends ImportExportPlugin {
 						$publicationFormat->setProductAvailabilityCode('20'); // ONIX code for Available.
 						$publicationFormat->setEntryKey('DA'); // ONIX code for Digital
 						$publicationFormat->setData('name', 'PDF', $submission->getLocale());
-						$publicationFormat->setSeq(REALLY_BIG_NUMBER);
+						$publicationFormat->setSequence(REALLY_BIG_NUMBER);
 						$publicationFormatId = $publicationFormatDao->insertObject($publicationFormat);
 
 						if ($doi) {


### PR DESCRIPTION
Update for compatibility with pkp/pkp-lib#1358, which addresses pkp/pkp-lib#1342 by normalizing usage throughout all `DataObject` subclasses.