### PR TITLE
Fix tests in omp-stable-1_2_0

### DIFF
--- a/tests/data/60-content/AclarkSubmissionTest.php
+++ b/tests/data/60-content/AclarkSubmissionTest.php
@@ -26,7 +26,6 @@ class AclarkSubmissionTest extends ContentBaseTestCase {
 			'lastName' => 'Clark',
 			'affiliation' => 'University of Calgary',
 			'country' => 'Canada',
-			'roles' => array('Author'),
 		));
 
 		$title = 'The ABCs of Human Survival: A Paradigm for Global Citizenship';

--- a/tests/data/60-content/AfinkelSubmissionTest.php
+++ b/tests/data/60-content/AfinkelSubmissionTest.php
@@ -26,7 +26,6 @@ class AfinkelSubmissionTest extends ContentBaseTestCase {
 			'lastName' => 'Finkel',
 			'affiliation' => 'Athabasca University',
 			'country' => 'Canada',
-			'roles' => array('Volume editor'),
 		));
 
 		$title = 'The West and Beyond: New Perspectives on an Imagined Region';

--- a/tests/data/60-content/AlkarrasSubmissionTest.php
+++ b/tests/data/60-content/AlkarrasSubmissionTest.php
@@ -26,7 +26,6 @@ class AlkarrasSubmissionTest extends ContentBaseTestCase {
 			'lastName' => 'Karras',
 			'affiliation' => 'Saskatchewan',
 			'country' => 'Canada',
-			'roles' => array('Author'),
 		));
 
 		$title = 'Northern Rover: The Life Story of Olaf Hanson';

--- a/tests/data/60-content/BbarnetsonSubmissionTest.php
+++ b/tests/data/60-content/BbarnetsonSubmissionTest.php
@@ -26,7 +26,6 @@ class BbarnetsonSubmissionTest extends ContentBaseTestCase {
 			'lastName' => 'Barnetson',
 			'affiliation' => 'Athabasca University',
 			'country' => 'Canada',
-			'roles' => array('Author'),
 		));
 
 		$this->createSubmission(array(

--- a/tests/data/60-content/BbeatySubmissionTest.php
+++ b/tests/data/60-content/BbeatySubmissionTest.php
@@ -26,7 +26,6 @@ class BbeatySubmissionTest extends ContentBaseTestCase {
 			'lastName' => 'Beaty',
 			'affiliation' => 'University of British Columbia',
 			'country' => 'Canada',
-			'roles' => array('Volume editor'),
 		));
 
 		$title = 'How Canadians Communicate: Contexts of Canadian Popular Culture';

--- a/tests/data/60-content/CallanSubmissionTest.php
+++ b/tests/data/60-content/CallanSubmissionTest.php
@@ -26,7 +26,6 @@ class CallanSubmissionTest extends ContentBaseTestCase {
 			'lastName' => 'Allan',
 			'affiliation' => 'University of Southern California',
 			'country' => 'Canada',
-			'roles' => array('Author'),
 		));
 
 		$title = 'Bomb Canada and Other Unkind Remarks in the American Media';

--- a/tests/data/60-content/DbernnardSubmissionTest.php
+++ b/tests/data/60-content/DbernnardSubmissionTest.php
@@ -26,7 +26,6 @@ class DbernnardSubmissionTest extends ContentBaseTestCase {
 			'lastName' => 'Bernnard',
 			'affiliation' => 'SUNY',
 			'country' => 'United States',
-			'roles' => array('Volume editor'),
 		));
 
 		$title = 'The Information Literacy User’s Guide';

--- a/tests/data/60-content/DcoatesSubmissionTest.php
+++ b/tests/data/60-content/DcoatesSubmissionTest.php
@@ -26,7 +26,6 @@ class DcoatesSubmissionTest extends ContentBaseTestCase {
 			'lastName' => 'Coates',
 			'affiliation' => 'University of Calgary',
 			'country' => 'Canada',
-			'roles' => array('Volume editor'),
 		));
 
 		$title = 'Wild Words: Essays on Alberta Literature';

--- a/tests/data/60-content/DkennepohlSubmissionTest.php
+++ b/tests/data/60-content/DkennepohlSubmissionTest.php
@@ -26,7 +26,6 @@ class DkennepohlSubmissionTest extends ContentBaseTestCase {
 			'lastName' => 'Kennepohl',
 			'affiliation' => 'Athabasca University',
 			'country' => 'Canada',
-			'roles' => array('Volume editor'),
 		));
 
 		$title = 'Accessible Elements: Teaching Science Online and at a Distance';

--- a/tests/data/60-content/FperiniSubmissionTest.php
+++ b/tests/data/60-content/FperiniSubmissionTest.php
@@ -26,7 +26,6 @@ class FperiniSubmissionTest extends ContentBaseTestCase {
 			'lastName' => 'Perini',
 			'affiliation' => 'University of Sussex',
 			'country' => 'Canada',
-			'roles' => array('Volume editor'),
 		));
 
 		$title = 'Enabling Openness: The future of the information society in Latin America and the Caribbean';

--- a/tests/data/60-content/JbrowerSubmissionTest.php
+++ b/tests/data/60-content/JbrowerSubmissionTest.php
@@ -26,7 +26,6 @@ class JbrowerSubmissionTest extends ContentBaseTestCase {
 			'lastName' => 'Brower',
 			'affiliation' => 'Buffalo National Park Foundation',
 			'country' => 'Canada',
-			'roles' => array('Author'),
 		));
 
 		$this->createSubmission(array(

--- a/tests/data/60-content/JlockehartSubmissionTest.php
+++ b/tests/data/60-content/JlockehartSubmissionTest.php
@@ -26,7 +26,6 @@ class JlockehartSubmissionTest extends ContentBaseTestCase {
 			'lastName' => 'Locke Hart',
 			'affiliation' => 'University of Alberta',
 			'country' => 'Canada',
-			'roles' => array('Author'),
 		));
 
 		$title = 'Dreamwork';

--- a/tests/data/60-content/LelderSubmissionTest.php
+++ b/tests/data/60-content/LelderSubmissionTest.php
@@ -26,7 +26,6 @@ class LelderSubmissionTest extends ContentBaseTestCase {
 			'lastName' => 'Elder',
 			'affiliation' => 'International Development Research Centre',
 			'country' => 'Canada',
-			'roles' => array('Volume editor'),
 		));
 
 		$title = 'Connecting ICTs to Development';

--- a/tests/data/60-content/MallySubmissionTest.php
+++ b/tests/data/60-content/MallySubmissionTest.php
@@ -26,7 +26,6 @@ class MallySubmissionTest extends ContentBaseTestCase {
 			'lastName' => 'Ally',
 			'affiliation' => 'Athabasca University',
 			'country' => 'Canada',
-			'roles' => array('Volume editor'),
 		));
 
 		$title = 'Mobile Learning: Transforming the Delivery of Education and Training';

--- a/tests/data/60-content/MdawsonSubmissionTest.php
+++ b/tests/data/60-content/MdawsonSubmissionTest.php
@@ -26,7 +26,6 @@ class MdawsonSubmissionTest extends ContentBaseTestCase {
 			'lastName' => 'Dawson',
 			'affiliation' => 'University of Alberta',
 			'country' => 'Canada',
-			'roles' => array('Volume editor'),
 		));
 
 		$title = 'From Bricks to Brains: The Embodied Cognitive Science of LEGO Robots';

--- a/tests/data/60-content/MforanSubmissionTest.php
+++ b/tests/data/60-content/MforanSubmissionTest.php
@@ -26,7 +26,6 @@ class MforanSubmissionTest extends ContentBaseTestCase {
 			'lastName' => 'Foran',
 			'affiliation' => 'University of Calgary',
 			'country' => 'Canada',
-			'roles' => array('Author'),
 		));
 
 		$title = 'Expansive Discourses: Urban Sprawl in Calgary, 1945-1978';

--- a/tests/data/60-content/MpowerSubmissionTest.php
+++ b/tests/data/60-content/MpowerSubmissionTest.php
@@ -26,7 +26,6 @@ class MpowerSubmissionTest extends ContentBaseTestCase {
 			'lastName' => 'Power',
 			'affiliation' => 'London School of Economics',
 			'country' => 'Canada',
-			'roles' => array('Author'),
 		));
 
 		$title = 'A Designer\'s Log: Case Studies in Instructional Design';

--- a/tests/data/60-content/MsmithSubmissionTest.php
+++ b/tests/data/60-content/MsmithSubmissionTest.php
@@ -26,7 +26,6 @@ class MsmithSubmissionTest extends ContentBaseTestCase {
 			'lastName' => 'Smith',
 			'affiliation' => 'International Development Research Centre',
 			'country' => 'Canada',
-			'roles' => array('Volume editor'),
 		));
 
 		$title = 'Open Development: Networked Innovations in International Development';

--- a/tests/data/60-content/WhildebrandtSubmissionTest.php
+++ b/tests/data/60-content/WhildebrandtSubmissionTest.php
@@ -26,7 +26,6 @@ class WhildebrandtSubmissionTest extends ContentBaseTestCase {
 			'lastName' => 'Hildebrandt',
 			'affiliation' => 'Canada',
 			'country' => 'Canada',
-			'roles' => array('Author'),
 		));
 
 		$title = 'Views From Fort Battleford: Constructed Visions of an Anglo-Canadian West';


### PR DESCRIPTION
This should fix the registration tests for the `omp-stable-1_2_0` branch. It cherry-picks a test update related to problems introduced when backporting changes in #336.