### PR TITLE
pkp/pkp-lib#1931 signoffs migration fix

### DIFF
--- a/dbscripts/xml/upgrade.xml
+++ b/dbscripts/xml/upgrade.xml
@@ -76,6 +76,10 @@
 		<note file="docs/release-notes/README-BEACON" />
 	</upgrade>
 
+	<upgrade minversion="1.2.0.0" maxversion="1.2.0.9">
+		<code function="fixQueriesAssocTypes" />
+	</upgrade>
+
 	<!-- Update plugin configuration - should be done as the final upgrade task -->
 	<code function="addPluginVersions" />
 </install>


### PR DESCRIPTION
S. https://github.com/pkp/pkp-lib/issues/1931
This PR does not repairs the wrong assoc_types in the DB table submission_files for those installations that already upgraded from 1.1 to 1.2, s. https://github.com/pkp/pkp-lib/issues/1931#issuecomment-257385293