### PR TITLE
pkp/pkp-lib#2134 add book download hook in HtmlMonographFilePlugin

### DIFF
--- a/plugins/generic/htmlMonographFile/HtmlMonographFilePlugin.inc.php
+++ b/plugins/generic/htmlMonographFile/HtmlMonographFilePlugin.inc.php
@@ -103,10 +103,12 @@ class HtmlMonographFilePlugin extends GenericPlugin {
 		$request = Application::getRequest();
 
 		if ($submissionFile && $submissionFile->getFileType() == 'text/html') {
-			echo $this->_getHTMLContents($request, $publishedMonograph, $publicationFormat, $submissionFile);
-			$returner = true;
-			HookRegistry::call('HtmlMonographFilePlugin::monographDownloadFinished', array(&$returner));
-			return true;
+			if (!HookRegistry::call('HtmlMonographFilePlugin::monographDownload', array(&$this, &$publishedMonograph, &$publicationFormat, &$submissionFile, &$inline))) {
+				echo $this->_getHTMLContents($request, $publishedMonograph, $publicationFormat, $submissionFile);
+				$returner = true;
+				HookRegistry::call('HtmlMonographFilePlugin::monographDownloadFinished', array(&$returner));
+				return true;
+			}
 		}
 
 		return false;

--- a/plugins/generic/usageEvent/UsageEventPlugin.inc.php
+++ b/plugins/generic/usageEvent/UsageEventPlugin.inc.php
@@ -35,6 +35,7 @@ class UsageEventPlugin extends PKPUsageEventPlugin {
 		$ompHooks = array(
 			'CatalogBookHandler::view',
 			'CatalogBookHandler::download',
+			'HtmlMonographFilePlugin::monographDownload',
 			'HtmlMonographFilePlugin::monographDownloadFinished',
 		);
 
@@ -103,6 +104,7 @@ class UsageEventPlugin extends PKPUsageEventPlugin {
 					// Publication format file.
 				case 'CatalogBookHandler::view':
 				case 'CatalogBookHandler::download':
+				case 'HtmlMonographFilePlugin::monographDownload':
 					$pubObject = $hookArgs[3];
 					$assocType = ASSOC_TYPE_SUBMISSION_FILE;
 					$canonicalUrlOp = 'download';


### PR DESCRIPTION
HtmlMonographFilePlugin uses CatalogBookHandler::download hook and eventually blocks it for others, so it should create a new one, that can be then used by others, e.g. UsageEventPlugin.