### PR TITLE
pkp/pkp-lib#1873 comments_to_ed migration if no author is assigned

### DIFF
--- a/classes/install/Upgrade.inc.php
+++ b/classes/install/Upgrade.inc.php
@@ -434,21 +434,34 @@ class Upgrade extends Installer {
 	 */
 	function convertCommentsToEditor() {
 		$submissionDao = Application::getSubmissionDAO();
+		$stageAssignmetDao = DAORegistry::getDAO('StageAssignmentDAO');
 		$queryDao = DAORegistry::getDAO('QueryDAO');
 		$noteDao = DAORegistry::getDAO('NoteDAO');
+		$userGroupDao = DAORegistry::getDAO('UserGroupDAO');
+
+		import('lib.pkp.classes.security.Role'); // ROLE_ID_...
 
 		$commentsResult = $submissionDao->retrieve(
-			'SELECT s.submission_id, s.comments_to_ed, s.date_submitted, sa.user_id
+			'SELECT s.submission_id, s.context_id, s.comments_to_ed, s.date_submitted
 			FROM submissions_tmp s
-			LEFT JOIN stage_assignments sa ON sa.submission_id = s.submission_id
-			LEFT JOIN user_groups ug ON ug.user_group_id = sa.user_group_id
-			WHERE s.comments_to_ed IS NOT NULL AND s.comments_to_ed != \'\' AND ug.role_id = 65536
-			ORDER BY s.submission_id'
+			WHERE s.comments_to_ed IS NOT NULL AND s.comments_to_ed != \'\''
 		);
 		while (!$commentsResult->EOF) {
 			$row = $commentsResult->getRowAssoc(false);
 			$comments_to_ed = PKPString::stripUnsafeHtml($row['comments_to_ed']);
 			if ($comments_to_ed != ""){
+				$userId = null;
+				$authorAssignmentsResult = $stageAssignmetDao->getBySubmissionAndRoleId($row['submission_id'], ROLE_ID_AUTHOR);
+				if ($authorAssignmentsResult->getCount() != 0) {
+					// We assume the results are ordered by stage_assignment_id i.e. first author assignemnt is first
+					$userId = $authorAssignmentsResult->next()->getUserId();
+				} else {
+					$managerUserGroup = $userGroupDao->getDefaultByRoleId($row['context_id'], ROLE_ID_MANAGER);
+					$managerUsers = $userGroupDao->getUsersById($managerUserGroup->getId(), $row['context_id']);
+					$userId = $managerUsers->next()->getId();
+				}
+				assert($userId);
+
 				$query = $queryDao->newDataObject();
 				$query->setAssocType(ASSOC_TYPE_SUBMISSION);
 				$query->setAssocId($row['submission_id']);
@@ -457,12 +470,12 @@ class Upgrade extends Installer {
 
 				$queryDao->insertObject($query);
 				$queryDao->resequence(ASSOC_TYPE_SUBMISSION, $row['submission_id']);
-				$queryDao->insertParticipant($query->getId(), $row['user_id']);
+				$queryDao->insertParticipant($query->getId(), $userId);
 
 				$queryId = $query->getId();
 
 				$note = $noteDao->newDataObject();
-				$note->setUserId($row['user_id']);
+				$note->setUserId($userId);
 				$note->setAssocType(ASSOC_TYPE_QUERY);
 				$note->setTitle('Cover Note to Editor');
 				$note->setContents($comments_to_ed);

--- a/dbscripts/xml/upgrade/3.1.0_preupdate_commentsToEditor.xml
+++ b/dbscripts/xml/upgrade/3.1.0_preupdate_commentsToEditor.xml
@@ -15,7 +15,7 @@
 <data>
 	<sql>
 		<query>
-			CREATE TABLE submissions_tmp AS (SELECT submission_id, comments_to_ed, date_submitted FROM submissions)
+			CREATE TABLE submissions_tmp AS (SELECT submission_id, context_id, comments_to_ed, date_submitted FROM submissions)
 		</query>
 	</sql>
 </data>


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/1873
This PR considers the situation when no author is assigned to a submission with a comment for the editors. In that situation the first JM found will be used.