### PR TITLE
pkp/pkp-lib#2444: Refactor GridCellProvider::__construct()

### DIFF
--- a/controllers/grid/catalogEntry/IdentificationCodeGridCellProvider.inc.php
+++ b/controllers/grid/catalogEntry/IdentificationCodeGridCellProvider.inc.php
@@ -16,12 +16,6 @@
 import('lib.pkp.classes.controllers.grid.DataObjectGridCellProvider');
 
 class IdentificationCodeGridCellProvider extends DataObjectGridCellProvider {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
 
 	//
 	// Template methods from GridCellProvider

--- a/controllers/grid/catalogEntry/IdentificationCodeGridHandler.inc.php
+++ b/controllers/grid/catalogEntry/IdentificationCodeGridHandler.inc.php
@@ -154,7 +154,7 @@ class IdentificationCodeGridHandler extends GridHandler {
 		);
 
 		// Columns
-		$cellProvider = new IdentificationCodeGridCellProvider();
+		$cellProvider = new IdentificationCodeGridCellProvider($request);
 		$this->addColumn(
 			new GridColumn(
 				'value',

--- a/controllers/grid/catalogEntry/MarketsGridCellProvider.inc.php
+++ b/controllers/grid/catalogEntry/MarketsGridCellProvider.inc.php
@@ -16,12 +16,6 @@
 import('lib.pkp.classes.controllers.grid.DataObjectGridCellProvider');
 
 class MarketsGridCellProvider extends DataObjectGridCellProvider {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
 
 	//
 	// Template methods from GridCellProvider

--- a/controllers/grid/catalogEntry/MarketsGridHandler.inc.php
+++ b/controllers/grid/catalogEntry/MarketsGridHandler.inc.php
@@ -154,7 +154,7 @@ class MarketsGridHandler extends GridHandler {
 		);
 
 		// Columns
-		$cellProvider = new MarketsGridCellProvider();
+		$cellProvider = new MarketsGridCellProvider($request);
 		$this->addColumn(
 			new GridColumn(
 				'territory',

--- a/controllers/grid/catalogEntry/PublicationDateGridCellProvider.inc.php
+++ b/controllers/grid/catalogEntry/PublicationDateGridCellProvider.inc.php
@@ -16,12 +16,6 @@
 import('lib.pkp.classes.controllers.grid.DataObjectGridCellProvider');
 
 class PublicationDateGridCellProvider extends DataObjectGridCellProvider {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
 
 	//
 	// Template methods from GridCellProvider

--- a/controllers/grid/catalogEntry/PublicationDateGridHandler.inc.php
+++ b/controllers/grid/catalogEntry/PublicationDateGridHandler.inc.php
@@ -155,7 +155,7 @@ class PublicationDateGridHandler extends GridHandler {
 		);
 
 		// Columns
-		$cellProvider = new PublicationDateGridCellProvider();
+		$cellProvider = new PublicationDateGridCellProvider($request);
 		$this->addColumn(
 			new GridColumn(
 				'value',

--- a/controllers/grid/catalogEntry/PublicationFormatGridCellProvider.inc.php
+++ b/controllers/grid/catalogEntry/PublicationFormatGridCellProvider.inc.php
@@ -28,11 +28,12 @@ class PublicationFormatGridCellProvider extends DataObjectGridCellProvider {
 
 	/**
 	 * Constructor
+	 * @param $request PKPRequest
 	 * @param $submissionId int Submission ID
 	 * @param $canManage boolean
 	 */
-	function __construct($submissionId, $canManage) {
-		parent::__construct();
+	function __construct($request, $submissionId, $canManage) {
+		parent::__construct($request);
 		$this->_submissionId = $submissionId;
 		$this->_canManage = $canManage;
 	}
@@ -94,20 +95,20 @@ class PublicationFormatGridCellProvider extends DataObjectGridCellProvider {
 	/**
 	 * @see GridCellProvider::getCellActions()
 	 */
-	function getCellActions($request, $row, $column) {
+	function getCellActions($row, $column) {
 		$data = $row->getData();
-		$router = $request->getRouter();
+		$router = $this->_request->getRouter();
 		if (is_a($data, 'Representation')) {
 			switch ($column->getId()) {
 				case 'isAvailable':
 					return array(new LinkAction(
 						'availableRepresentation',
 						new RemoteActionConfirmationModal(
-							$request->getSession(),
+							$this->_request->getSession(),
 							__($data->getIsAvailable()?'grid.catalogEntry.availableRepresentation.removeMessage':'grid.catalogEntry.availableRepresentation.message'),
 							__('grid.catalogEntry.availableRepresentation.title'),
 							$router->url(
-								$request, null, null, 'setAvailable', null,
+								$this->_request, null, null, 'setAvailable', null,
 								array(
 									'representationId' => $data->getId(),
 									'newAvailableState' => $data->getIsAvailable()?0:1,
@@ -134,12 +135,12 @@ class PublicationFormatGridCellProvider extends DataObjectGridCellProvider {
 					AppLocale::requireComponents(LOCALE_COMPONENT_PKP_EDITOR);
 					return array(
 						new AddFileLinkAction(
-							$request, $data->getSubmissionId(), WORKFLOW_STAGE_ID_PRODUCTION,
+							$this->_request, $data->getSubmissionId(), WORKFLOW_STAGE_ID_PRODUCTION,
 							array(ROLE_ID_MANAGER, ROLE_ID_SUB_EDITOR, ROLE_ID_ASSISTANT), null, SUBMISSION_FILE_PROOF,
 							ASSOC_TYPE_REPRESENTATION, $data->getId()
 						),
 						new SelectFilesLinkAction(
-							$request,
+							$this->_request,
 							array(
 								'submissionId' => $data->getSubmissionId(),
 								'assocType' => ASSOC_TYPE_REPRESENTATION,
@@ -157,7 +158,7 @@ class PublicationFormatGridCellProvider extends DataObjectGridCellProvider {
 						'approveRepresentation',
 						new AjaxModal(
 							$router->url(
-								$request, null, null, 'setApproved', null,
+								$this->_request, null, null, 'setApproved', null,
 								array(
 									'representationId' => $data->getId(),
 									'newApprovedState' => $data->getIsApproved()?0:1,
@@ -189,7 +190,7 @@ class PublicationFormatGridCellProvider extends DataObjectGridCellProvider {
 					return array(new LinkAction(
 						'editApprovedProof',
 						new AjaxModal(
-							$router->url($request, null, null, 'editApprovedProof', null, array(
+							$router->url($this->_request, null, null, 'editApprovedProof', null, array(
 								'fileId' => $submissionFile->getFileId() . '-' . $submissionFile->getRevision(),
 								'submissionId' => $submissionFile->getSubmissionId(),
 								'representationId' => $submissionFile->getAssocId(),
@@ -203,7 +204,7 @@ class PublicationFormatGridCellProvider extends DataObjectGridCellProvider {
 				case 'name':
 					import('lib.pkp.controllers.grid.files.FileNameGridColumn');
 					$fileNameColumn = new FileNameGridColumn(true, WORKFLOW_STAGE_ID_PRODUCTION, true);
-					return $fileNameColumn->getCellActions($request, $row);
+					return $fileNameColumn->getCellActions($this->_request, $row);
 				case 'isComplete':
 					AppLocale::requireComponents(LOCALE_COMPONENT_PKP_EDITOR);
 					import('lib.pkp.classes.linkAction.request.AjaxModal');
@@ -212,7 +213,7 @@ class PublicationFormatGridCellProvider extends DataObjectGridCellProvider {
 						$submissionFile->getViewable()?'approved':'not_approved',
 						new AjaxModal(
 							$router->url(
-								$request, null, null, 'setProofFileCompletion',
+								$this->_request, null, null, 'setProofFileCompletion',
 								null,
 								array(
 									'submissionId' => $submissionFile->getSubmissionId(),
@@ -230,7 +231,7 @@ class PublicationFormatGridCellProvider extends DataObjectGridCellProvider {
 					));
 			}
 		}
-		return parent::getCellActions($request, $row, $column);
+		return parent::getCellActions($this->_request, $row, $column);
 	}
 }
 

--- a/controllers/grid/catalogEntry/PublicationFormatGridHandler.inc.php
+++ b/controllers/grid/catalogEntry/PublicationFormatGridHandler.inc.php
@@ -133,7 +133,7 @@ class PublicationFormatGridHandler extends CategoryGridHandler {
 		// Columns
 		$submission = $this->getSubmission();
 		import('controllers.grid.catalogEntry.PublicationFormatGridCellProvider');
-		$this->_cellProvider = new PublicationFormatGridCellProvider($submission->getId(), $this->_canManage);
+		$this->_cellProvider = new PublicationFormatGridCellProvider($request, $submission->getId(), $this->_canManage);
 		$this->addColumn(
 			new GridColumn(
 				'name',

--- a/controllers/grid/catalogEntry/RepresentativesGridCellProvider.inc.php
+++ b/controllers/grid/catalogEntry/RepresentativesGridCellProvider.inc.php
@@ -16,12 +16,6 @@
 import('lib.pkp.classes.controllers.grid.DataObjectGridCellProvider');
 
 class RepresentativesGridCellProvider extends DataObjectGridCellProvider {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
 
 	//
 	// Template methods from GridCellProvider

--- a/controllers/grid/catalogEntry/RepresentativesGridHandler.inc.php
+++ b/controllers/grid/catalogEntry/RepresentativesGridHandler.inc.php
@@ -125,7 +125,7 @@ class RepresentativesGridHandler extends CategoryGridHandler {
 		);
 
 		// Columns
-		$cellProvider = new RepresentativesGridCellProvider();
+		$cellProvider = new RepresentativesGridCellProvider($request);
 		$this->addColumn(
 			new GridColumn(
 				'name',

--- a/controllers/grid/catalogEntry/SalesRightsGridCellProvider.inc.php
+++ b/controllers/grid/catalogEntry/SalesRightsGridCellProvider.inc.php
@@ -16,12 +16,6 @@
 import('lib.pkp.classes.controllers.grid.DataObjectGridCellProvider');
 
 class SalesRightsGridCellProvider extends DataObjectGridCellProvider {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
 
 	//
 	// Template methods from GridCellProvider

--- a/controllers/grid/catalogEntry/SalesRightsGridHandler.inc.php
+++ b/controllers/grid/catalogEntry/SalesRightsGridHandler.inc.php
@@ -155,7 +155,7 @@ class SalesRightsGridHandler extends GridHandler {
 		);
 
 		// Columns
-		$cellProvider = new SalesRightsGridCellProvider();
+		$cellProvider = new SalesRightsGridCellProvider($request);
 		$this->addColumn(
 			new GridColumn(
 				'type',

--- a/controllers/grid/content/spotlights/ManageSpotlightsGridHandler.inc.php
+++ b/controllers/grid/content/spotlights/ManageSpotlightsGridHandler.inc.php
@@ -112,7 +112,7 @@ class ManageSpotlightsGridHandler extends GridHandler {
 
 		// Columns
 		import('controllers.grid.content.spotlights.SpotlightsGridCellProvider');
-		$spotlightsGridCellProvider = new SpotlightsGridCellProvider();
+		$spotlightsGridCellProvider = new SpotlightsGridCellProvider($request);
 		$this->addColumn(
 			new GridColumn('title',
 				'grid.content.spotlights.form.title',

--- a/controllers/grid/content/spotlights/SpotlightsGridCellProvider.inc.php
+++ b/controllers/grid/content/spotlights/SpotlightsGridCellProvider.inc.php
@@ -16,12 +16,6 @@
 import('lib.pkp.classes.controllers.grid.DataObjectGridCellProvider');
 
 class SpotlightsGridCellProvider extends DataObjectGridCellProvider {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
 
 	//
 	// Template methods from GridCellProvider

--- a/controllers/grid/manageCatalog/CatalogMonographsGridCellProvider.inc.php
+++ b/controllers/grid/manageCatalog/CatalogMonographsGridCellProvider.inc.php
@@ -30,12 +30,13 @@ class CatalogMonographsGridCellProvider extends GridCellProvider {
 
 	/**
 	 * Constructor.
+	 * @param $request PKPRequest
 	 * @param $assocType int
 	 * @param $assocId int
 	 * @param $requestArgs array Grid request arguments.
 	 */
-	function __construct($assocType, $assocId, $requestArgs) {
-		parent::__construct();
+	function __construct($request, $assocType, $assocId, $requestArgs) {
+		parent::__construct($request);
 		$this->_assocType = $assocType;
 		$this->_assocId = $assocId;
 		$this->_requestArgs = $requestArgs;
@@ -56,9 +57,9 @@ class CatalogMonographsGridCellProvider extends GridCellProvider {
 			case 'title':
 				// Delegate to the submission grid cell provider that holds the logic
 				// for the submission title plus author name.
-				$user = Application::getRequest()->getUser();
+				$user = $this->_request->getUser();
 				import('lib.pkp.controllers.grid.submissions.SubmissionsListGridCellProvider');
-				$submissionsListCellProvider = new SubmissionsListGridCellProvider($user);
+				$submissionsListCellProvider = new SubmissionsListGridCellProvider($this->_request, $user);
 				return $submissionsListCellProvider->getTemplateVarsFromRowColumn($row, $column);
 			case 'isFeatured':
 				$featureDao = DAORegistry::getDAO('FeatureDAO');
@@ -74,10 +75,10 @@ class CatalogMonographsGridCellProvider extends GridCellProvider {
 	/**
 	 * @see GridCellProvider::getCellActions()
 	 */
-	function getCellActions($request, $row, $column) {
+	function getCellActions($row, $column) {
 		import('lib.pkp.classes.linkAction.request.AjaxAction');
 		$monograph = $row->getData();
-		$router = $request->getRouter();
+		$router = $this->_request->getRouter();
 		$currentState = $toggleType = null;
 		switch ($column->getId()) {
 			case 'isFeatured':
@@ -97,7 +98,7 @@ class CatalogMonographsGridCellProvider extends GridCellProvider {
 				'toggleFeature',
 				new AjaxAction(
 					$router->url(
-						$request, null, null, 'toggle', null,
+						$this->_request, null, null, 'toggle', null,
 						array_merge(array(
 							'rowId' => $monograph->getId(),
 							'assocType' => $this->_assocType,
@@ -109,7 +110,7 @@ class CatalogMonographsGridCellProvider extends GridCellProvider {
 				)
 			));
 		} else {
-			return parent::getCellActions($request, $row, $column);
+			return parent::getCellActions($row, $column);
 		}
 	}
 }

--- a/controllers/grid/settings/category/CategoryCategoryGridHandler.inc.php
+++ b/controllers/grid/settings/category/CategoryCategoryGridHandler.inc.php
@@ -91,7 +91,7 @@ class CategoryCategoryGridHandler extends CategoryGridHandler {
 		);
 
 		// Add grid columns.
-		$cellProvider = new DataObjectGridCellProvider();
+		$cellProvider = new DataObjectGridCellProvider($request);
 		$cellProvider->setLocale(AppLocale::getLocale());
 
 		$this->addColumn(

--- a/controllers/grid/users/chapter/ChapterGridCategoryRowCellProvider.inc.php
+++ b/controllers/grid/users/chapter/ChapterGridCategoryRowCellProvider.inc.php
@@ -20,16 +20,9 @@ class ChapterGridCategoryRowCellProvider extends GridCellProvider {
 	var $_readOnly;
 
 	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
-
-	/**
 	 * @see GridCellProvider::getCellActions()
 	 */
-	function getCellActions($request, $row, $column) {
+	function getCellActions($row, $column) {
 		if ($column->getId() == 'name' && !$row->isReadOnly()) {
 			$chapter = $row->getData();
 			$monograph = $row->getMonograph();
@@ -43,7 +36,7 @@ class ChapterGridCategoryRowCellProvider extends GridCellProvider {
 			return array(new LinkAction(
 					'editChapter',
 					new AjaxModal(
-						$router->url($request, null, null, 'editChapter', null, $actionArgs),
+						$router->url($this->_request, null, null, 'editChapter', null, $actionArgs),
 						__('submission.chapter.editChapter'),
 						'modal_edit'
 					),

--- a/controllers/grid/users/chapter/ChapterGridHandler.inc.php
+++ b/controllers/grid/users/chapter/ChapterGridHandler.inc.php
@@ -120,7 +120,7 @@ class ChapterGridHandler extends CategoryGridHandler {
 
 		// Columns
 		// reuse the cell providers for the AuthorGrid
-		$cellProvider = new PKPAuthorGridCellProvider();
+		$cellProvider = new PKPAuthorGridCellProvider($request);
 		$this->addColumn(
 			new GridColumn(
 				'name',

--- a/controllers/listbuilder/categories/CategoryListbuilderGridCellProvider.inc.php
+++ b/controllers/listbuilder/categories/CategoryListbuilderGridCellProvider.inc.php
@@ -16,12 +16,6 @@
 import('lib.pkp.classes.controllers.grid.GridCellProvider');
 
 class CategoryListbuilderGridCellProvider extends GridCellProvider {
-	/**
-	 * Constructor
-	 */
-	function __construct() {
-		parent::__construct();
-	}
 
 	//
 	// Template methods from GridCellProvider

--- a/controllers/listbuilder/settings/CategoriesListbuilderHandler.inc.php
+++ b/controllers/listbuilder/settings/CategoriesListbuilderHandler.inc.php
@@ -131,7 +131,7 @@ class CategoriesListbuilderHandler extends SetupListbuilderHandler {
 		$nameColumn = new ListbuilderGridColumn($this, 'name', 'common.name');
 
 		import('controllers.listbuilder.categories.CategoryListbuilderGridCellProvider');
-		$nameColumn->setCellProvider(new CategoryListbuilderGridCellProvider());
+		$nameColumn->setCellProvider(new CategoryListbuilderGridCellProvider($request));
 		$this->addColumn($nameColumn);
 	}
 }

--- a/controllers/listbuilder/users/ChapterAuthorListbuilderHandler.inc.php
+++ b/controllers/listbuilder/users/ChapterAuthorListbuilderHandler.inc.php
@@ -107,7 +107,7 @@ class ChapterAuthorListbuilderHandler extends ListbuilderHandler {
 		$nameColumn = new ListbuilderGridColumn($this, 'name', 'common.name');
 		// We can reuse the User cell provider because getFullName
 		import('lib.pkp.controllers.listbuilder.users.UserListbuilderGridCellProvider');
-		$nameColumn->setCellProvider(new UserListbuilderGridCellProvider());
+		$nameColumn->setCellProvider(new UserListbuilderGridCellProvider($request));
 		$this->addColumn($nameColumn);
 	}
 

--- a/controllers/submission/CategoriesListbuilderHandler.inc.php
+++ b/controllers/submission/CategoriesListbuilderHandler.inc.php
@@ -174,7 +174,7 @@ class CategoriesListbuilderHandler extends ListbuilderHandler {
 		$nameColumn = new ListbuilderGridColumn($this, 'name', 'common.name');
 
 		import('controllers.listbuilder.categories.CategoryListbuilderGridCellProvider');
-		$nameColumn->setCellProvider(new CategoryListbuilderGridCellProvider());
+		$nameColumn->setCellProvider(new CategoryListbuilderGridCellProvider($request));
 		$this->addColumn($nameColumn);
 	}
 }


### PR DESCRIPTION
Store an initial PKPRequest object, then use this request object for other methods rather than passing it as a parameter.  ##ulsdevteam/refactor-gridcell-provider-constructor##