### PR TITLE
fixes #2759

### DIFF
--- a/pages/catalog/CatalogBookHandler.inc.php
+++ b/pages/catalog/CatalogBookHandler.inc.php
@@ -91,6 +91,7 @@ class CatalogBookHandler extends Handler {
 		$press = $request->getPress();
 		$paymentManager = Application::getPaymentManager($press);
 		$submissionFileDao = DAORegistry::getDAO('SubmissionFileDAO');
+
 		if ($paymentManager->isConfigured()) {
 			$availableFiles = array_filter(
 				$submissionFileDao->getLatestRevisions($publishedMonograph->getId()),
@@ -110,6 +111,9 @@ class CatalogBookHandler extends Handler {
 
 			// Expose variables to template
 			$templateMgr->assign('availableFiles', $filteredAvailableFiles);
+		} else {
+			error_log("payment manager not configured");
+			$templateMgr->assign('availableFiles', array());
 		}
 
 		// Provide the currency to the template, if configured.

--- a/plugins/paymethod/manual/ManualPaymentPlugin.inc.php
+++ b/plugins/paymethod/manual/ManualPaymentPlugin.inc.php
@@ -62,7 +62,7 @@ class ManualPaymentPlugin extends PaymethodPlugin {
 	 */
 	function isConfigured($context) {
 		if (!$context) return false;
-		if ($this->getSetting($context->getId(), 'manualInstructions') == '') return false;
+		//if ($this->getSetting($context->getId(), 'manualInstructions') == '') return false;
 		return true;
 	}
 


### PR DESCRIPTION
- in  pages/catalog/CatalogBookHandler.inc.php -> does not set smarty var to undefined now if payment manager is unconfigured

-  plugins/paymethod/manual/ManualPaymentPlugin.inc.php - > does not need a manualInstructions-Text now. It was very confusing for the user, when a fresh install of OMP can't display any Galleys because this text is missing. OMP even tries to use the ManualPaymentPlugin if no plugin is selected at all.