### PR TITLE
pkp/pkp-lib#3739: PostgreSQL forbids table aliases within SET clauses

### DIFF
--- a/dbscripts/xml/upgrade/3.1.1_update.xml
+++ b/dbscripts/xml/upgrade/3.1.1_update.xml
@@ -44,12 +44,12 @@
 	</sql>
 	<!-- pkp/pkp-lib#2894 Set 0 review ratings to NULL -->
 	<sql>
-		<query>UPDATE review_assignments ra SET ra.quality = NULL WHERE ra.quality = 0</query>
+		<query>UPDATE review_assignments ra SET quality = NULL WHERE ra.quality = 0</query>
 	</sql>
 	<!-- pkp/pkp-lib#2894 Update old localised user gossip entries -->
 	<sql>
-		<query driver="mysql">UPDATE users u, (SELECT user_id, GROUP_CONCAT(DISTINCT setting_value SEPARATOR ' ') AS groupedGossips FROM user_settings WHERE setting_name = 'gossip' AND setting_value &lt;&gt; '' GROUP BY user_id) us SET u.gossip = us.groupedGossips WHERE us.user_id = u.user_id</query>
-		<query driver="mysqli">UPDATE users u, (SELECT user_id, GROUP_CONCAT(DISTINCT setting_value SEPARATOR ' ') AS groupedGossips FROM user_settings WHERE setting_name = 'gossip' AND setting_value &lt;&gt; '' GROUP BY user_id) us SET u.gossip = us.groupedGossips WHERE us.user_id = u.user_id</query>
+		<query driver="mysql">UPDATE users u, (SELECT user_id, GROUP_CONCAT(DISTINCT setting_value SEPARATOR ' ') AS groupedGossips FROM user_settings WHERE setting_name = 'gossip' AND setting_value &lt;&gt; '' GROUP BY user_id) us SET gossip = us.groupedGossips WHERE us.user_id = u.user_id</query>
+		<query driver="mysqli">UPDATE users u, (SELECT user_id, GROUP_CONCAT(DISTINCT setting_value SEPARATOR ' ') AS groupedGossips FROM user_settings WHERE setting_name = 'gossip' AND setting_value &lt;&gt; '' GROUP BY user_id) us SET gossip = us.groupedGossips WHERE us.user_id = u.user_id</query>
 		<query driver="postgres7">UPDATE users SET gossip = us.groupedGossips FROM (SELECT user_id, string_agg(DISTINCT setting_value, ' ') AS groupedGossips FROM user_settings WHERE setting_name = 'gossip' AND setting_value &lt;&gt; '' GROUP BY user_id) AS us WHERE us.user_id = users.user_id</query>
 		<query>DELETE FROM user_settings WHERE setting_name='gossip'</query>
 	</sql>


### PR DESCRIPTION
Fixes PostgreSQL incompatibilities per pkp/pkp-lib#3739.