### PR TITLE
Added sl_SI locale

### DIFF
--- a/registry/locales.xml
+++ b/registry/locales.xml
@@ -21,5 +21,6 @@
 	<locale key="en_US" complete="true"  name="English" iso639-2b="eng" iso639-3="eng" />
 	<locale key="es_ES" complete="true" name="Español (España)" iso639-2b="spa" iso639-3="spa" />
 	<locale key="fr_CA" complete="false" name="Français (Canada)" iso639-2b="fre" iso639-3="fra" />
+	<locale key="sl_SI" complete="false" name="Slovenščina" iso639-2b="slv" iso639-3="slv" />
 	<locale key="pt_BR" complete="true" name="Português (Brasil)" iso639-2b="por" iso639-3="por" />
 </locales>


### PR DESCRIPTION
In April this year I've submitted the Slovenian translation for OMP. I was upgrading our OMP today and noticed, that locale files are present, but sl_SI locale is still missing from this list. So I've added the proper entry for sl_SI.