### PR TITLE
bogus pagination on catalog-page if 1+ submission/form language

### DIFF
--- a/pages/catalog/CatalogHandler.inc.php
+++ b/pages/catalog/CatalogHandler.inc.php
@@ -100,7 +100,7 @@ class CatalogHandler extends Handler {
 			'returnObject' => SUBMISSION_RETURN_PUBLISHED,
 		);
 		$publishedMonographs = $submissionService->getSubmissions($context->getId(), $params);
-		$total = $submissionService->getSubmissionsMaxCount($context->getId(), $params);
+		$total = count($publishedMonographs);
 
 		$featureDao = DAORegistry::getDAO('FeatureDAO');
 		$featuredMonographIds = $featureDao->getSequencesByAssoc(ASSOC_TYPE_PRESS, $context->getId());
@@ -181,7 +181,7 @@ class CatalogHandler extends Handler {
 			'returnObject' => SUBMISSION_RETURN_PUBLISHED,
 		);
 		$publishedMonographs = $submissionService->getSubmissions($context->getId(), $params);
-		$total = $submissionService->getSubmissionsMaxCount($context->getId(), $params);
+		$total = count($publishedMonographs);
 
 		$featureDao = DAORegistry::getDAO('FeatureDAO');
 		$featuredMonographIds = $featureDao->getSequencesByAssoc(ASSOC_TYPE_CATEGORY, $category->getId());
@@ -258,7 +258,7 @@ class CatalogHandler extends Handler {
 			'returnObject' => SUBMISSION_RETURN_PUBLISHED,
 		);
 		$publishedMonographs = $submissionService->getSubmissions($context->getId(), $params);
-		$total = $submissionService->getSubmissionsMaxCount($context->getId(), $params);
+		$total = count($publishedMonographs);
 
 		$featureDao = DAORegistry::getDAO('FeatureDAO');
 		$featuredMonographIds = $featureDao->getSequencesByAssoc(ASSOC_TYPE_SERIES, $series->getId());
@@ -431,5 +431,3 @@ class CatalogHandler extends Handler {
 		));
 	}
 }
-
-


### PR DESCRIPTION
Look at PKPSubmissionService.inc.php, l. 7, function getSubmissionsMaxCount. Here a very complicated query is constructed to get the total numbers of items in catalog.
An item will be counted twice or even more often, if it has different titles in different languages.

But in CatalogHandler.inx.php, l. 102 (and 260) we find

$publishedMonographs = $submissionService->getSubmissions($context->getId(), $params);
$total = $submissionService->getSubmissionsMaxCount($context->getId(), $params);

In my case $total is 16 and count($publishedMonographs) is 10. So I have ten books but 6 of them have
different (or omitted) titles in different languages, the other 4 have the same title in English and German.

The result is a bogus pagination in catalog.tpl template. It says " 1-10 of 16 Next ". If I click on next,
I get a empty page naturally, since there are no further items.

It's event worse. If I enable spanish as a third language for submissions and forms,
open and store one catalog entry there is is third setting named "title" in the table "submission_settings" -
so the complicated counting query above counts one item more. Even if I disable spanish again! It was very hard to debug this,
because spanish was disabled, and it was not possible to change the spansih title anymore.

I a, not sure if the complicated counting function is used intentional and I if, what was the intention,
but if not it would easy to fix this, by changing line 103 to $total = count($publishedMonographs);