### PR TITLE
Online-First publications Chapter extensions :  published date, pages

### DIFF
--- a/classes/monograph/Chapter.inc.php
+++ b/classes/monograph/Chapter.inc.php
@@ -191,6 +191,38 @@ class Chapter extends DataObject {
 		return $this->getLocalizedData('abstract');
 	}
 
+	/**
+	 * get date published
+	 * @return date
+	 */
+	function getDatePublished() {
+		return $this->getData('datePublished');
+	}
+
+	/**
+	 * set date published
+	 * @param $datePublished date
+	 */
+	function setDatePublished($datePublished) {
+		return $this->setData('datePublished', $datePublished);
+	}
+
+	/**
+	 * get pages
+	 * @return string
+	 */
+	function getPages() {
+		return $this->getData('pages');
+	}
+
+	/**
+	 * set pages
+	 * @param $pages string
+	 */
+	function setPages($pages) {
+		$this->setData('pages',$pages);
+	}
+
 }
 
 

--- a/classes/monograph/ChapterDAO.inc.php
+++ b/classes/monograph/ChapterDAO.inc.php
@@ -95,6 +95,9 @@ class ChapterDAO extends DAO implements PKPPubIdPluginDAO {
 		$additionalFields = parent::getAdditionalFieldNames();
 		// FIXME: Move this to a PID plug-in.
 		$additionalFields[] = 'pub-id::publisher-id';
+		$additionalFields[] = 'datePublished';
+		$additionalFields[] = 'pages';
+
 		return $additionalFields;
 	}
 

--- a/classes/monograph/Monograph.inc.php
+++ b/classes/monograph/Monograph.inc.php
@@ -236,20 +236,21 @@ class Monograph extends Submission {
 	}
 
 	/**
-	 * Return onlineFirst status
+	 * get enableChapterPublicationDates status
 	 * @return int
 	 */
-	function getOnlineFirst() {
-		return $this->getData('onlineFirst');
+	function getEnableChapterPublicationDates() {
+		return $this->getData('enableChapterPublicationDates');
 	}
 
 	/**
-	 * Set  onlineFirst status
-	 * @param $onlineFirst int
+	 * get  enableChapterPublicationDates status
+	 * @param $enableChapterPublicationDates int
 	 */
-	function setOnlineFirst($onlineFirst) {
-		$this->setData('onlineFirst', $onlineFirst);
+	function setEnableChapterPublicationDates($enableChapterPublicationDates) {
+		$this->setData('enableChapterPublicationDates', $enableChapterPublicationDates);
 	}
+
 
 }
 

--- a/classes/monograph/Monograph.inc.php
+++ b/classes/monograph/Monograph.inc.php
@@ -234,6 +234,23 @@ class Monograph extends Submission {
 	function setCoverImageAltText($coverImageAltText) {
 		$this->setData('coverImageAltText', $coverImageAltText);
 	}
+
+	/**
+	 * Return onlineFirst status
+	 * @return int
+	 */
+	function getOnlineFirst() {
+		return $this->getData('onlineFirst');
+	}
+
+	/**
+	 * Set  onlineFirst status
+	 * @param $onlineFirst int
+	 */
+	function setOnlineFirst($onlineFirst) {
+		$this->setData('onlineFirst', $onlineFirst);
+	}
+
 }
 
 

--- a/classes/monograph/Monograph.inc.php
+++ b/classes/monograph/Monograph.inc.php
@@ -244,7 +244,7 @@ class Monograph extends Submission {
 	}
 
 	/**
-	 * get  enableChapterPublicationDates status
+	 * set  enableChapterPublicationDates status
 	 * @param $enableChapterPublicationDates int
 	 */
 	function setEnableChapterPublicationDates($enableChapterPublicationDates) {

--- a/classes/monograph/MonographDAO.inc.php
+++ b/classes/monograph/MonographDAO.inc.php
@@ -54,6 +54,7 @@ class MonographDAO extends SubmissionDAO {
 		$monograph->setSeriesPosition($row['series_position']);
 		$monograph->setSeriesTitle($row['series_title']);
 		$monograph->setWorkType($row['edited_volume']);
+		$monograph->setOnlineFirst($row['online_first']);
 
 		HookRegistry::call('MonographDAO::_fromRow', array(&$monograph, &$row));
 
@@ -77,9 +78,9 @@ class MonographDAO extends SubmissionDAO {
 		$monograph->stampModified();
 		$this->update(
 			sprintf('INSERT INTO submissions
-				(locale, context_id, series_id, series_position, language, date_submitted, date_status_modified, last_modified, status, submission_progress, stage_id, pages, hide_author, edited_volume, citations)
+				(locale, context_id, series_id, series_position, language, date_submitted, date_status_modified, last_modified, status, submission_progress, stage_id, pages, hide_author, edited_volume, citations, online_first)
 				VALUES
-				(?, ?, ?, ?, ?, %s, %s, %s, ?, ?, ?, ?, ?, ?, ?)',
+				(?, ?, ?, ?, ?, %s, %s, %s, ?, ?, ?, ?, ?, ?, ?, ?)',
 				$this->datetimeToDB($monograph->getDateSubmitted()), $this->datetimeToDB($monograph->getDateStatusModified()), $this->datetimeToDB($monograph->getLastModified())),
 			array(
 				$monograph->getLocale(),
@@ -94,6 +95,7 @@ class MonographDAO extends SubmissionDAO {
 				(int) $monograph->getHideAuthor(),
 				(int) $monograph->getWorkType(),
 				$monograph->getCitations(),
+				$monograph->getOnlineFirst() === null ? 0 : 1,
 			)
 		);
 
@@ -124,7 +126,8 @@ class MonographDAO extends SubmissionDAO {
 					stage_id = ?,
 					edited_volume = ?,
 					hide_author = ?,
-					citations = ?
+					citations = ?,
+					online_first = ?
 				WHERE	submission_id = ?',
 				$this->datetimeToDB($monograph->getDateSubmitted()), $this->datetimeToDB($monograph->getDateStatusModified()), $this->datetimeToDB($monograph->getLastModified())),
 			array(
@@ -139,6 +142,7 @@ class MonographDAO extends SubmissionDAO {
 				(int) $monograph->getWorkType(),
 				(int) $monograph->getHideAuthor(),
 				$monograph->getCitations(),
+				$monograph->getOnlineFirst() === null ? 0 : 1,
 				(int) $monograph->getId(),
 			)
 		);

--- a/classes/monograph/MonographDAO.inc.php
+++ b/classes/monograph/MonographDAO.inc.php
@@ -38,7 +38,7 @@ class MonographDAO extends SubmissionDAO {
 	function getAdditionalFieldNames() {
 		return array_merge(
 			parent::getAdditionalFieldNames(), array(
-				'coverImage', 'coverImageAltText',
+				'coverImage', 'coverImageAltText', 'enableChapterPublicationDates',
 		));
 	}
 
@@ -54,7 +54,6 @@ class MonographDAO extends SubmissionDAO {
 		$monograph->setSeriesPosition($row['series_position']);
 		$monograph->setSeriesTitle($row['series_title']);
 		$monograph->setWorkType($row['edited_volume']);
-		$monograph->setOnlineFirst($row['online_first']);
 
 		HookRegistry::call('MonographDAO::_fromRow', array(&$monograph, &$row));
 
@@ -78,9 +77,9 @@ class MonographDAO extends SubmissionDAO {
 		$monograph->stampModified();
 		$this->update(
 			sprintf('INSERT INTO submissions
-				(locale, context_id, series_id, series_position, language, date_submitted, date_status_modified, last_modified, status, submission_progress, stage_id, pages, hide_author, edited_volume, citations, online_first)
+				(locale, context_id, series_id, series_position, language, date_submitted, date_status_modified, last_modified, status, submission_progress, stage_id, pages, hide_author, edited_volume, citations)
 				VALUES
-				(?, ?, ?, ?, ?, %s, %s, %s, ?, ?, ?, ?, ?, ?, ?, ?)',
+				(?, ?, ?, ?, ?, %s, %s, %s, ?, ?, ?, ?, ?, ?, ?)',
 				$this->datetimeToDB($monograph->getDateSubmitted()), $this->datetimeToDB($monograph->getDateStatusModified()), $this->datetimeToDB($monograph->getLastModified())),
 			array(
 				$monograph->getLocale(),
@@ -95,7 +94,6 @@ class MonographDAO extends SubmissionDAO {
 				(int) $monograph->getHideAuthor(),
 				(int) $monograph->getWorkType(),
 				$monograph->getCitations(),
-				$monograph->getOnlineFirst() === null ? 0 : 1,
 			)
 		);
 
@@ -126,8 +124,7 @@ class MonographDAO extends SubmissionDAO {
 					stage_id = ?,
 					edited_volume = ?,
 					hide_author = ?,
-					citations = ?,
-					online_first = ?
+					citations = ?
 				WHERE	submission_id = ?',
 				$this->datetimeToDB($monograph->getDateSubmitted()), $this->datetimeToDB($monograph->getDateStatusModified()), $this->datetimeToDB($monograph->getLastModified())),
 			array(
@@ -142,7 +139,6 @@ class MonographDAO extends SubmissionDAO {
 				(int) $monograph->getWorkType(),
 				(int) $monograph->getHideAuthor(),
 				$monograph->getCitations(),
-				$monograph->getOnlineFirst() === null ? 0 : 1,
 				(int) $monograph->getId(),
 			)
 		);

--- a/controllers/grid/users/chapter/form/ChapterForm.inc.php
+++ b/controllers/grid/users/chapter/form/ChapterForm.inc.php
@@ -90,8 +90,8 @@ class ChapterForm extends Form {
 
 		$monograph = $this->getMonograph();
 		$this->setData('submissionId', $monograph->getId());
-		$isOnlineFirstSubmission = (int)$this->getMonograph()->getOnlineFirst() === 1;
-		$this->setData('IsOnlineFirstSubmission', $isOnlineFirstSubmission);
+		$chapterPublicationDatesEnabledSubmission = (int)$this->getMonograph()->getEnableChapterPublicationDates() === 1;
+		$this->setData('chapterPublicationDatesEnabledSubmission', $chapterPublicationDatesEnabledSubmission);
 
 		$chapter = $this->getChapter();
 		if ($chapter) {

--- a/controllers/grid/users/chapter/form/ChapterForm.inc.php
+++ b/controllers/grid/users/chapter/form/ChapterForm.inc.php
@@ -90,6 +90,8 @@ class ChapterForm extends Form {
 
 		$monograph = $this->getMonograph();
 		$this->setData('submissionId', $monograph->getId());
+		$isOnlineFirstSubmission = (int)$this->getMonograph()->getOnlineFirst() === 1;
+		$this->setData('IsOnlineFirstSubmission', $isOnlineFirstSubmission);
 
 		$chapter = $this->getChapter();
 		if ($chapter) {
@@ -97,10 +99,14 @@ class ChapterForm extends Form {
 			$this->setData('title', $chapter->getTitle());
 			$this->setData('subtitle', $chapter->getSubtitle());
 			$this->setData('abstract', $chapter->getAbstract());
+			$this->setData('datePublished', $chapter->getDatePublished());
+			$this->setData('pages', $chapter->getPages());
 		} else {
 			$this->setData('title', null);
 			$this->setData('subtitle', null);
 			$this->setData('abstract', null);
+			$this->setData('datePublished', null);
+			$this->setData('pages', null);
 		}
 	}
 
@@ -109,7 +115,7 @@ class ChapterForm extends Form {
 	 * @see Form::readInputData()
 	 */
 	function readInputData() {
-		$this->readUserVars(array('title', 'subtitle', 'authors', 'files','abstract'));
+		$this->readUserVars(array('title', 'subtitle', 'authors', 'files','abstract','datePublished','pages'));
 	}
 
 	/**
@@ -125,6 +131,8 @@ class ChapterForm extends Form {
 			$chapter->setTitle($this->getData('title'), null); //Localized
 			$chapter->setSubtitle($this->getData('subtitle'), null); //Localized
 			$chapter->setAbstract($this->getData('abstract'), null); //Localized
+			$chapter->setDatePublished($this->getData('datePublished'));
+			$chapter->setPages($this->getData('pages'));
 			$chapterDao->updateObject($chapter);
 		} else {
 			$monograph = $this->getMonograph();
@@ -134,6 +142,8 @@ class ChapterForm extends Form {
 			$chapter->setTitle($this->getData('title'), null); //Localized
 			$chapter->setSubtitle($this->getData('subtitle'), null); //Localized
 			$chapter->setAbstract($this->getData('abstract'), null); //Localized
+			$chapter->setDatePublished($this->getData('datePublished'));
+			$chapter->setPages($this->getData('pages'));
 			$chapter->setSequence(REALLY_BIG_NUMBER);
 			$chapterDao->insertChapter($chapter);
 			$chapterDao->resequenceChapters($monograph->getId());

--- a/controllers/grid/users/chapter/form/ChapterForm.inc.php
+++ b/controllers/grid/users/chapter/form/ChapterForm.inc.php
@@ -90,7 +90,7 @@ class ChapterForm extends Form {
 
 		$monograph = $this->getMonograph();
 		$this->setData('submissionId', $monograph->getId());
-		$chapterPublicationDatesEnabledSubmission = (int)$this->getMonograph()->getEnableChapterPublicationDates() === 1;
+		$chapterPublicationDatesEnabledSubmission = (int)$this->getMonograph()->getOnlineFirst() === 1;
 		$this->setData('chapterPublicationDatesEnabledSubmission', $chapterPublicationDatesEnabledSubmission);
 
 		$chapter = $this->getChapter();

--- a/controllers/grid/users/chapter/form/ChapterForm.inc.php
+++ b/controllers/grid/users/chapter/form/ChapterForm.inc.php
@@ -90,8 +90,8 @@ class ChapterForm extends Form {
 
 		$monograph = $this->getMonograph();
 		$this->setData('submissionId', $monograph->getId());
-		$chapterPublicationDatesEnabledSubmission = (int)$monograph->getEnableChapterPublicationDates() === 1;
-		$this->setData('chapterPublicationDatesEnabledSubmission', $chapterPublicationDatesEnabledSubmission);
+		$enableChapterPublicationDates = (int)$monograph->getEnableChapterPublicationDates() === 1;
+		$this->setData('enableChapterPublicationDates', $enableChapterPublicationDates);
 
 		$chapter = $this->getChapter();
 		if ($chapter) {

--- a/controllers/grid/users/chapter/form/ChapterForm.inc.php
+++ b/controllers/grid/users/chapter/form/ChapterForm.inc.php
@@ -90,7 +90,7 @@ class ChapterForm extends Form {
 
 		$monograph = $this->getMonograph();
 		$this->setData('submissionId', $monograph->getId());
-		$chapterPublicationDatesEnabledSubmission = (int)$this->getMonograph()->getOnlineFirst() === 1;
+		$chapterPublicationDatesEnabledSubmission = (int)$monograph->getEnableChapterPublicationDates() === 1;
 		$this->setData('chapterPublicationDatesEnabledSubmission', $chapterPublicationDatesEnabledSubmission);
 
 		$chapter = $this->getChapter();

--- a/controllers/tab/catalogEntry/form/CatalogEntryCatalogMetadataForm.inc.php
+++ b/controllers/tab/catalogEntry/form/CatalogEntryCatalogMetadataForm.inc.php
@@ -67,10 +67,12 @@ class CatalogEntryCatalogMetadataForm extends Form {
 	 */
 	function fetch($request, $template = null, $display = false) {
 		$templateMgr = TemplateManager::getManager($request);
+		$isOnlineFirst = (int) $this->getMonograph()->getOnlineFirst() == 1;
 		$templateMgr->assign('submissionId', $this->getMonograph()->getId());
 		$templateMgr->assign('stageId', $this->getStageId());
 		$templateMgr->assign('formParams', $this->getFormParams());
 		$templateMgr->assign('datePublished', $this->getMonograph()->getDatePublished());
+		$templateMgr->assign('onlineFirst',$isOnlineFirst) ;
 
 		$onixCodelistItemDao = DAORegistry::getDAO('ONIXCodelistItemDAO');
 
@@ -206,7 +208,7 @@ class CatalogEntryCatalogMetadataForm extends Form {
 			'audience', 'audienceRangeQualifier', 'audienceRangeFrom', 'audienceRangeTo', 'audienceRangeExact',
 			'copyrightYear', 'copyrightHolder', 'licenseURL', 'attachPermissions',
 			'temporaryFileId', // Cover image
-			'confirm', 'datePublished',
+			'confirm', 'datePublished','onlineFirst',
 			'workType', 'volumeEditors',
 		);
 
@@ -253,6 +255,7 @@ class CatalogEntryCatalogMetadataForm extends Form {
 			$publishedMonograph->setId($monograph->getId());
 		}
 		$monograph->setDatePublished($this->getData('datePublished'));
+		$monograph->setOnlineFirst($this->getData('onlineFirst'));
 
 		if ($this->getData('workType') == WORK_TYPE_EDITED_VOLUME) {
 			$volumeEditors = $this->getData('volumeEditors') ? $this->getData('volumeEditors') : [];

--- a/controllers/tab/catalogEntry/form/CatalogEntryCatalogMetadataForm.inc.php
+++ b/controllers/tab/catalogEntry/form/CatalogEntryCatalogMetadataForm.inc.php
@@ -67,12 +67,14 @@ class CatalogEntryCatalogMetadataForm extends Form {
 	 */
 	function fetch($request, $template = null, $display = false) {
 		$templateMgr = TemplateManager::getManager($request);
-		$isOnlineFirst = (int) $this->getMonograph()->getOnlineFirst() == 1;
-		$templateMgr->assign('submissionId', $this->getMonograph()->getId());
+		$monograph = $this->getMonograph();
+		$templateMgr->assign('submissionId', $monograph->getId());
 		$templateMgr->assign('stageId', $this->getStageId());
 		$templateMgr->assign('formParams', $this->getFormParams());
-		$templateMgr->assign('datePublished', $this->getMonograph()->getDatePublished());
-		$templateMgr->assign('onlineFirst',$isOnlineFirst) ;
+		$templateMgr->assign('datePublished', $monograph->getDatePublished());
+		$chapterPublicationDatesEnabled = (int)$monograph->getEnableChapterPublicationDates() == 1;
+		$templateMgr->assign('enableChapterPublicationDates', $chapterPublicationDatesEnabled);
+
 
 		$onixCodelistItemDao = DAORegistry::getDAO('ONIXCodelistItemDAO');
 
@@ -92,12 +94,12 @@ class CatalogEntryCatalogMetadataForm extends Form {
 				WORK_TYPE_EDITED_VOLUME => __('submission.workflowType.editedVolume'),
 				WORK_TYPE_AUTHORED_WORK => __('submission.workflowType.authoredWork'),
 			),
-			'workType' => $this->getMonograph()->getWorkType(),
+			'workType' => $monograph->getWorkType(),
 		));
 
 		// SelectListPanel for volume editors
 		$authorDao = DAORegistry::getDAO('AuthorDAO');
-		$authors = $authorDao->getBySubmissionId($this->getMonograph()->getId(), true);
+		$authors = $authorDao->getBySubmissionId($monograph->getId(), true);
 		$volumeEditorsListItems = array();
 		foreach ($authors as $author) {
 			$volumeEditorsListItems[] = array(
@@ -208,7 +210,7 @@ class CatalogEntryCatalogMetadataForm extends Form {
 			'audience', 'audienceRangeQualifier', 'audienceRangeFrom', 'audienceRangeTo', 'audienceRangeExact',
 			'copyrightYear', 'copyrightHolder', 'licenseURL', 'attachPermissions',
 			'temporaryFileId', // Cover image
-			'confirm', 'datePublished','onlineFirst',
+			'confirm', 'datePublished', 'enableChapterPublicationDates',
 			'workType', 'volumeEditors',
 		);
 
@@ -255,7 +257,8 @@ class CatalogEntryCatalogMetadataForm extends Form {
 			$publishedMonograph->setId($monograph->getId());
 		}
 		$monograph->setDatePublished($this->getData('datePublished'));
-		$monograph->setOnlineFirst($this->getData('onlineFirst'));
+		$enableChapterPublicationDates = $this->getData('enableChapterPublicationDates') ? 1 : 0;
+		$monograph->setEnableChapterPublicationDates($enableChapterPublicationDates);
 
 		if ($this->getData('workType') == WORK_TYPE_EDITED_VOLUME) {
 			$volumeEditors = $this->getData('volumeEditors') ? $this->getData('volumeEditors') : [];

--- a/dbscripts/xml/install.xml
+++ b/dbscripts/xml/install.xml
@@ -10,7 +10,7 @@
   * Installation descriptor file.
   -->
 
-<install version="3.1.2.0">
+<install version="3.1.2.1">
 	<code function="checkPhpVersion" />
 
 	<code function="createDirectories" />

--- a/dbscripts/xml/omp_schema.xml
+++ b/dbscripts/xml/omp_schema.xml
@@ -137,7 +137,7 @@
 			<col>publication_format_id</col>
 		</index>
 	</table>
-	
+
 	<!--
 	  *
 	  * TABLE representatives
@@ -399,6 +399,10 @@
 			<NOTNULL/>
 			<DEFAULT VALUE="1"/>
 		</field>
+		<field name="online_first" type="I1">
+			<NOTNULL/>
+			<DEFAULT VALUE="0"/>
+		</field>
 		<descr>Submissions</descr>
 		<index name="submissions_context_id">
 			<col>context_id</col>
@@ -406,6 +410,7 @@
 		<index name="submissions_series_id">
 			<col>series_id</col>
 		</index>
+
 	</table>
 
 	<!--
@@ -856,7 +861,7 @@
 			<col>assoc_id</col>
 		</index>
 	</table>
-	
+
 	<!--
 	  *
 	  * TABLE spotlight_settings

--- a/dbscripts/xml/omp_schema.xml
+++ b/dbscripts/xml/omp_schema.xml
@@ -137,7 +137,7 @@
 			<col>publication_format_id</col>
 		</index>
 	</table>
-
+	
 	<!--
 	  *
 	  * TABLE representatives
@@ -399,10 +399,6 @@
 			<NOTNULL/>
 			<DEFAULT VALUE="1"/>
 		</field>
-		<field name="online_first" type="I1">
-			<NOTNULL/>
-			<DEFAULT VALUE="0"/>
-		</field>
 		<descr>Submissions</descr>
 		<index name="submissions_context_id">
 			<col>context_id</col>
@@ -410,7 +406,6 @@
 		<index name="submissions_series_id">
 			<col>series_id</col>
 		</index>
-
 	</table>
 
 	<!--
@@ -861,7 +856,7 @@
 			<col>assoc_id</col>
 		</index>
 	</table>
-
+	
 	<!--
 	  *
 	  * TABLE spotlight_settings

--- a/dbscripts/xml/upgrade.xml
+++ b/dbscripts/xml/upgrade.xml
@@ -10,7 +10,7 @@
   * Upgrade descriptor file.
   -->
 
-<install version="3.1.2.0">
+<install version="3.1.2.1">
 	<code function="checkPhpVersion" />
 
 	<!-- there are some column and table name changes that need to occur first. -->

--- a/dbscripts/xml/version.xml
+++ b/dbscripts/xml/version.xml
@@ -13,9 +13,9 @@
 <version>
 	<application>omp</application>
 	<type>core</type>
-	<release>3.1.2.0</release>
-	<tag>3_1_2-0</tag>
-	<date>2019-02-28</date>
+	<release>3.1.2.1</release>
+	<tag>3_1_2-1</tag>
+	<date>2019-05-30</date>
 	<info>http://pkp.sfu.ca/omp/</info>
-	<package>http://pkp.sfu.ca/omp/download/omp-3.1.2.tar.gz</package>
+	<package>http://pkp.sfu.ca/omp/download/omp-3.1.2-1.tar.gz</package>
 </version>

--- a/docs/README
+++ b/docs/README
@@ -1,9 +1,9 @@
 	===================================
 	=== Open Monograph Press
 	=== The Public Knowledge Project
-	=== Version: 3.1.2
-	=== GIT tag: omp-3_1_2-0
-	=== Release date: February 28, 2019
+	=== Version: 3.1.2-1
+	=== GIT tag: omp-3_1_2-1
+	=== Release date: May 30, 2019
 	===================================
 
 About

--- a/docs/RELEASE
+++ b/docs/RELEASE
@@ -1,6 +1,6 @@
 OMP 3.1.2 Release Notes
-CVS tag: 3_1_2-0
-Release date: February 28, 2019
+Git tag: 3_1_2-1
+Release date: May 30, 2019
 ===============================
 
 New Features

--- a/docs/release-notes/README-3.1.2
+++ b/docs/release-notes/README-3.1.2
@@ -1,6 +1,6 @@
 OMP 3.1.2 Release Notes
-CVS tag: 3_1_2-0
-Release date: February 28, 2019
+Git tag: 3_1_2-1
+Release date: May 30, 2019
 ===============================
 
 New Features

--- a/locale/de_DE/submission.xml
+++ b/locale/de_DE/submission.xml
@@ -22,8 +22,6 @@
 	<message key="submission.workflowType.description">Eine Monografie ist ein Werk, das von einer Autorin/einem Autor oder mehreren Autor/innen gemeinsam verfasst worden ist. Ein Sammelband besteht aus mehreren Kapiteln jeweils unterschiedlicher Autor/innen (detaillierte Kapitelangaben sind erst zu einem späteren Zeitpunkt im Veröffentlichungsprozess zu machen).</message>
 	<message key="submission.workflowType.editedVolume">Sammelband</message>
 	<message key="submission.workflowType.authoredWork">Monografie</message>
-	<message key="submission.workflowType.editedVolume.selectEditors">Select Volume Editors</message>
-	<message key="submission.workflowType.editedVolume.selectEditors.description">Select the authors who should be identified as editors for the entire volume.</message>
 	<message key="submission.published">Druckreif</message>
 	<message key="submission.fairCopy">Reinschrift</message>
 	<message key="submission.artwork.permissions">Rechte</message>
@@ -100,10 +98,6 @@
 	<message key="submission.catalogEntry.confirm">Erstelle anhand der angegebenen Metadaten einen neuen Katalogeintrag.</message>
 	<message key="submission.catalogEntry.confirm.required">Bitte bestätigen Sie, dass der Publikationsprozess abgeschlossen ist und das Buch in den Katalog aufgenommen werden soll.</message>
 	<message key="submission.catalogEntry.isAvailable">Diese Monografie ist fertig und soll in den öffentlichen Katalog aufgenommen werden.</message>
-	<message key="submission.catalogEntry.viewSubmission">View Submission</message>
-	<message key="submission.catalogEntry.chapterPublicationDates">Publication Dates</message>
-	<message key="submission.catalogEntry.disableChapterPublicationDates">All chapters will use the publication date of the monograph.</message>
-	<message key="submission.catalogEntry.enableChapterPublicationDates">Each chapter may have its own publication date.</message>
 
 	<!-- Catalog Entry Tabs -->
 	<message key="submission.catalogEntry.monographMetadata">Monografie</message>

--- a/locale/de_DE/submission.xml
+++ b/locale/de_DE/submission.xml
@@ -96,8 +96,6 @@
 	<message key="submission.complete">Freigegeben</message>
 	<message key="submission.incomplete">Warte auf Freigabe</message>
 	<message key="submission.editCatalogEntry">Eintrag</message>
-	<message key="submission.onlineFirst">Online-First</message>
-	<message key="submission.onlineFirstDescription">Dieses Buch erscheint als Online-First-Publikation</message>
 	<message key="submission.catalogEntry.new">Neuer Katalogeintrag</message>
 	<message key="submission.catalogEntry.confirm">Erstelle anhand der angegebenen Metadaten einen neuen Katalogeintrag.</message>
 	<message key="submission.catalogEntry.confirm.required">Bitte bestätigen Sie, dass der Publikationsprozess abgeschlossen ist und das Buch in den Katalog aufgenommen werden soll.</message>

--- a/locale/de_DE/submission.xml
+++ b/locale/de_DE/submission.xml
@@ -22,6 +22,8 @@
 	<message key="submission.workflowType.description">Eine Monografie ist ein Werk, das von einer Autorin/einem Autor oder mehreren Autor/innen gemeinsam verfasst worden ist. Ein Sammelband besteht aus mehreren Kapiteln jeweils unterschiedlicher Autor/innen (detaillierte Kapitelangaben sind erst zu einem späteren Zeitpunkt im Veröffentlichungsprozess zu machen).</message>
 	<message key="submission.workflowType.editedVolume">Sammelband</message>
 	<message key="submission.workflowType.authoredWork">Monografie</message>
+	<message key="submission.workflowType.editedVolume.selectEditors">Select Volume Editors</message>
+	<message key="submission.workflowType.editedVolume.selectEditors.description">Select the authors who should be identified as editors for the entire volume.</message>
 	<message key="submission.published">Druckreif</message>
 	<message key="submission.fairCopy">Reinschrift</message>
 	<message key="submission.artwork.permissions">Rechte</message>
@@ -30,6 +32,9 @@
 	<message key="submission.chaptersDescription">Hier können Sie die Kapitel auflisten und ihnen Personen zuordnen, die in der oben stehenden Liste der Beiträger/innen (z.B. Kapitelautor/innen, Übersetzer/innen) verzeichnet sind. Beiträger/innen, die Sie an dieser Stelle dem Kapitel zuordnen, werden während des Veröffentlichungsprozesses Zugang zu dem Kapitel haben.</message>
 	<message key="submission.chapter.addChapter">Kapitel hinzufügen</message>
 	<message key="submission.chapter.editChapter">Kapitel bearbeiten</message>
+	<message key="submission.chapter.abstract">Abstrakt</message>
+	<message key="submission.chapter.pages">Seiten</message>
+	<message key="submission.chapter.datePublished">Veröffentlicht</message>
 	<message key="submission.copyedit">Lektorat</message>
 	<message key="submission.publicationFormats">Formate</message>
 	<message key="submission.proofs">Proofs</message>
@@ -97,6 +102,10 @@
 	<message key="submission.catalogEntry.confirm">Erstelle anhand der angegebenen Metadaten einen neuen Katalogeintrag.</message>
 	<message key="submission.catalogEntry.confirm.required">Bitte bestätigen Sie, dass der Publikationsprozess abgeschlossen ist und das Buch in den Katalog aufgenommen werden soll.</message>
 	<message key="submission.catalogEntry.isAvailable">Diese Monografie ist fertig und soll in den öffentlichen Katalog aufgenommen werden.</message>
+	<message key="submission.catalogEntry.viewSubmission">View Submission</message>
+	<message key="submission.catalogEntry.chapterPublicationDates">Publication Dates</message>
+	<message key="submission.catalogEntry.disableChapterPublicationDates">All chapters will use the publication date of the monograph.</message>
+	<message key="submission.catalogEntry.enableChapterPublicationDates">Each chapter may have its own publication date.</message>
 
 	<!-- Catalog Entry Tabs -->
 	<message key="submission.catalogEntry.monographMetadata">Monografie</message>

--- a/locale/de_DE/submission.xml
+++ b/locale/de_DE/submission.xml
@@ -91,6 +91,8 @@
 	<message key="submission.complete">Freigegeben</message>
 	<message key="submission.incomplete">Warte auf Freigabe</message>
 	<message key="submission.editCatalogEntry">Eintrag</message>
+	<message key="submission.onlineFirst">Online-First</message>
+	<message key="submission.onlineFirstDescription">Dieses Buch erscheint als Online-First-Publikation</message>
 	<message key="submission.catalogEntry.new">Neuer Katalogeintrag</message>
 	<message key="submission.catalogEntry.confirm">Erstelle anhand der angegebenen Metadaten einen neuen Katalogeintrag.</message>
 	<message key="submission.catalogEntry.confirm.required">Bitte bestätigen Sie, dass der Publikationsprozess abgeschlossen ist und das Buch in den Katalog aufgenommen werden soll.</message>

--- a/locale/en_US/submission.xml
+++ b/locale/en_US/submission.xml
@@ -94,6 +94,8 @@
 	<message key="submission.complete">Approved</message>
 	<message key="submission.incomplete">Awaiting Approval</message>
 	<message key="submission.editCatalogEntry">Entry</message>
+	<message key="submission.onlineFirst">Online First</message>
+	<message key="submission.onlineFirstDescription">This book is an Online First publication</message>
 	<message key="submission.catalogEntry.new">Add Entry</message>
 	<message key="submission.catalogEntry.add">Add Selected to Catalog</message>
 	<message key="submission.catalogEntry.select">Select monographs to add to the catalog</message>

--- a/locale/en_US/submission.xml
+++ b/locale/en_US/submission.xml
@@ -34,6 +34,9 @@
 	<message key="submission.chaptersDescription">You may list the chapters here, and assign contributors from the list of contributors, above. These contributors will be able to access the chapter during various stages of the publication process.</message>
 	<message key="submission.chapter.addChapter">Add Chapter</message>
 	<message key="submission.chapter.editChapter">Edit Chapter</message>
+	<message key="submission.chapter.abstract">Abstract</message>
+	<message key="submission.chapter.pages">Pages</message>
+	<message key="submission.chapter.datePublished">Published</message>
 	<message key="submission.copyedit">Copyedit</message>
 	<message key="submission.publicationFormats">Publication Formats</message>
 	<message key="submission.proofs">Proofs</message>
@@ -94,8 +97,6 @@
 	<message key="submission.complete">Approved</message>
 	<message key="submission.incomplete">Awaiting Approval</message>
 	<message key="submission.editCatalogEntry">Entry</message>
-	<message key="submission.onlineFirst">Online First</message>
-	<message key="submission.onlineFirstDescription">This book is an Online First publication</message>
 	<message key="submission.catalogEntry.new">Add Entry</message>
 	<message key="submission.catalogEntry.add">Add Selected to Catalog</message>
 	<message key="submission.catalogEntry.select">Select monographs to add to the catalog</message>
@@ -104,6 +105,10 @@
 	<message key="submission.catalogEntry.confirm.required">Please confirm that the submission is ready to be placed in the catalog.</message>
 	<message key="submission.catalogEntry.isAvailable">This monograph is ready to be included in the public catalog.</message>
 	<message key="submission.catalogEntry.viewSubmission">View Submission</message>
+	<message key="submission.catalogEntry.chapterPublicationDates">Publication Dates</message>
+	<message key="submission.catalogEntry.disableChapterPublicationDates">All chapters will use the publication date of the monograph.</message>
+	<message key="submission.catalogEntry.enableChapterPublicationDates">Each chapter may have its own publication date.</message>
+
 
 	<!-- Catalog Entry Tabs -->
 	<message key="submission.catalogEntry.monographMetadata">Monograph</message>

--- a/plugins/blocks/languageToggle/templates/block.tpl
+++ b/plugins/blocks/languageToggle/templates/block.tpl
@@ -20,7 +20,7 @@
 	<div class="content">
 		<ul>
 			{foreach from=$languageToggleLocales item=localeName key=localeKey}
-				<li class="locale_{$localeKey|escape}{if $localeKey == $currentLocale} current{/if}">
+				<li class="locale_{$localeKey|escape}{if $localeKey == $currentLocale} current{/if}" lang="{$localeKey|escape}">
 					<a href="{url router=$smarty.const.ROUTE_PAGE page="user" op="setLocale" path=$localeKey source=$smarty.server.REQUEST_URI}">
 						{$localeName}
 					</a>

--- a/plugins/paymethod/manual/templates/paymentForm.tpl
+++ b/plugins/paymethod/manual/templates/paymentForm.tpl
@@ -29,7 +29,7 @@
 	</table>
 
 	<p>
-		<a href="{url page="payment" op="plugin" path="ManualPayment"|to_array:"notify":$queuedPaymentId|escape}" class="action">{translate key="plugins.paymethod.manual.sendNotificationOfPayment"}</a>
+		<a href="{url page="payment" op="plugin" path="ManualPayment"|to_array:"notify":$queuedPaymentId}" class="action">{translate key="plugins.paymethod.manual.sendNotificationOfPayment"}</a>
 	</p>
 
 </div><!-- .page -->

--- a/templates/controllers/grid/users/chapter/form/chapterForm.tpl
+++ b/templates/controllers/grid/users/chapter/form/chapterForm.tpl
@@ -37,6 +37,16 @@
 	{fbvElement type="textarea" name="abstract" id="abstract" value=$abstract  rich="extended" multilingual=true}
 	{/fbvFormSection}
 
+	{fbvFormSection title="metadata.property.displayName.pages" for="customExtras"}
+	{fbvElement type="text" id="pages" value=$pages inline=true size=$fbvStyles.size.LARGE}
+	{/fbvFormSection}
+
+	{if $IsOnlineFirstSubmission}
+		{fbvFormSection title="metadata.property.displayName.datePublished" for="customExtras"}
+		{fbvElement type="text" id="datePublished" value=$datePublished inline=true size=$fbvStyles.size.LARGE  class="datepicker"}
+		{/fbvFormSection}
+	{/if}
+
 	{fbvFormSection}
 		<!--  Chapter Contributors -->
 		{capture assign=chapterAuthorUrl}{url router=$smarty.const.ROUTE_COMPONENT component="listbuilder.users.ChapterAuthorListbuilderHandler" op="fetch" submissionId=$submissionId chapterId=$chapterId escape=false}{/capture}

--- a/templates/controllers/grid/users/chapter/form/chapterForm.tpl
+++ b/templates/controllers/grid/users/chapter/form/chapterForm.tpl
@@ -33,16 +33,16 @@
 		{fbvElement type="text" name="subtitle" id="subtitle" value=$subtitle maxlength="255" multilingual=true}
 	{/fbvFormSection}
 
-	{fbvFormSection title="metadata.property.displayName.abstract" for="abstract"}
-	{fbvElement type="textarea" name="abstract" id="abstract" value=$abstract  rich="extended" multilingual=true}
+	{fbvFormSection title="submission.chapter.abstract" for="abstract"}
+		{fbvElement type="textarea" name="abstract" id="abstract" value=$abstract  rich="extended" multilingual=true}
 	{/fbvFormSection}
 
-	{fbvFormSection title="metadata.property.displayName.pages" for="customExtras"}
-	{fbvElement type="text" id="pages" value=$pages inline=true size=$fbvStyles.size.LARGE}
+	{fbvFormSection title="submission.chapter.pages" for="customExtras"}
+		{fbvElement type="text" id="pages" value=$pages inline=true size=$fbvStyles.size.LARGE}
 	{/fbvFormSection}
 
-	{if $IsOnlineFirstSubmission}
-		{fbvFormSection title="metadata.property.displayName.datePublished" for="customExtras"}
+	{if $chapterPublicationDatesEnabledSubmission}
+		{fbvFormSection title="submission.chapter.datePublished" for="customExtras"}
 		{fbvElement type="text" id="datePublished" value=$datePublished inline=true size=$fbvStyles.size.LARGE  class="datepicker"}
 		{/fbvFormSection}
 	{/if}

--- a/templates/controllers/grid/users/chapter/form/chapterForm.tpl
+++ b/templates/controllers/grid/users/chapter/form/chapterForm.tpl
@@ -41,7 +41,7 @@
 		{fbvElement type="text" id="pages" value=$pages inline=true size=$fbvStyles.size.LARGE}
 	{/fbvFormSection}
 
-	{if $chapterPublicationDatesEnabledSubmission}
+	{if $enableChapterPublicationDates}
 		{fbvFormSection title="submission.chapter.datePublished" for="customExtras"}
 		{fbvElement type="text" id="datePublished" value=$datePublished inline=true size=$fbvStyles.size.LARGE  class="datepicker"}
 		{/fbvFormSection}

--- a/templates/controllers/tab/catalogEntry/form/catalogMetadataFormFields.tpl
+++ b/templates/controllers/tab/catalogEntry/form/catalogMetadataFormFields.tpl
@@ -53,6 +53,10 @@
 		{fbvElement type="text" id="datePublished" value=$datePublished|date_format:$dateFormatShort class="datepicker"}
 	{/fbvFormSection}
 
+	{fbvFormSection title="submission.onlineFirst" list="true"}
+		{fbvElement type="checkbox" id="onlineFirst" checked=$onlineFirst label="submission.onlineFirstDescription" value=""}
+	{/fbvFormSection}
+
 	{fbvFormSection label="submission.workflowType"}
 		{fbvElement type="select" id="workType" from=$workTypeOptions selected=$workType translate=false disabled=$formParams.readOnly size=$fbvStyles.size.SMALL}
 	{/fbvFormSection}

--- a/templates/controllers/tab/catalogEntry/form/catalogMetadataFormFields.tpl
+++ b/templates/controllers/tab/catalogEntry/form/catalogMetadataFormFields.tpl
@@ -53,9 +53,12 @@
 		{fbvElement type="text" id="datePublished" value=$datePublished|date_format:$dateFormatShort class="datepicker"}
 	{/fbvFormSection}
 
-	{fbvFormSection title="submission.onlineFirst" list="true"}
-		{fbvElement type="checkbox" id="onlineFirst" checked=$onlineFirst label="submission.onlineFirstDescription" value=""}
-	{/fbvFormSection}
+	{fbvFormArea id="chapterPublicationDates" class="border" title="submission.catalogEntry.chapterPublicationDates"}
+		{fbvFormSection list=true}
+			{fbvElement type="radio" id="enableChapterPublicationDates-0" name="enableChapterPublicationDates" value="0" checked=!$enableChapterPublicationDates label="submission.catalogEntry.disableChapterPublicationDates"}
+			{fbvElement type="radio" id="enableChapterPublicationDates-1" name="enableChapterPublicationDates" value="1" checked=$enableChapterPublicationDates label="submission.catalogEntry.enableChapterPublicationDates"}
+		{/fbvFormSection}
+	{/fbvFormArea}
 
 	{fbvFormSection label="submission.workflowType"}
 		{fbvElement type="select" id="workType" from=$workTypeOptions selected=$workType translate=false disabled=$formParams.readOnly size=$fbvStyles.size.SMALL}


### PR DESCRIPTION
Hi @asmecher 

I have filed a PR for  the extensions in Stable 3.1.2  which  I proposed for the chapters.

-  Adds a page range as  in OJS3
- Chapter modal allows  setting  a published date, if the submission is an online-first  publication.

There is one thing, which I  was not sure:
- If the user deselects the  online-first status, after adding  dates to chapters, it does not delete  the chapter publishing date.

The name online-first was used, cause it seems  to be  more generic also for the journals. [Online reference](https://journals.sagepub.com/page/help/online-first)   Please let me know, if anything has to be changed to be more expressive.

![omp_chapter_pages_date](https://user-images.githubusercontent.com/1921992/60109117-11a71180-976a-11e9-9985-de619feb9291.gif)

  
FYI @NateWr  Please let me know, if anything has to be  changed to UI

