### PR TITLE
pkp/pkp-lib#4901 Missing translation key

### DIFF
--- a/templates/frontend/pages/catalogCategory.tpl
+++ b/templates/frontend/pages/catalogCategory.tpl
@@ -69,7 +69,7 @@
 		<h2>
 			{translate key="catalog.category.heading"}
 		</h2>
-		<p>{translate key="catalog.noTitlesSection"}</p>
+		<p>{translate key="catalog.category.noItems"}</p>
 
 	{else}
 

--- a/templates/frontend/pages/catalogSeries.tpl
+++ b/templates/frontend/pages/catalogSeries.tpl
@@ -58,7 +58,7 @@
 		<h2>
 			{translate key="catalog.category.heading"}
 		</h2>
-		<p>{translate key="catalog.noTitlesSection"}</p>
+		<p>{translate key="catalog.category.noItems"}</p>
 
 	{else}
 


### PR DESCRIPTION
Key was renamed in #4446.