### PR TITLE
i5180 Changed alt text for OMP logo at footer

### DIFF
--- a/locale/en_US/locale.po
+++ b/locale/en_US/locale.po
@@ -1038,7 +1038,7 @@ msgid "about.pressSponsorship"
 msgstr "Press Sponsorship"
 
 msgid "about.aboutThisPublishingSystem"
-msgstr "About this Publishing System"
+msgstr "More information about the publishing system, Platform and Workflow by OMP/PKP."
 
 msgid "about.aboutThisPublishingSystem.altText"
 msgstr "OMP Editorial and Publishing Process"


### PR DESCRIPTION
From this issue "Address alt text / link location confusion in the OJS/OMP branding image on themes" (just the alt text for now): https://github.com/pkp/pkp-lib/issues/5180