### PR TITLE
Clean up unused entries of translations

### DIFF
--- a/locale/ca_ES/submission.po
+++ b/locale/ca_ES/submission.po
@@ -137,12 +137,6 @@ msgstr "Posició dins aquesta sèrie (p. ex. Llibre 2 o Volum 2)"
 msgid "submission.submit.form.localeRequired"
 msgstr "Seleccioneu la llengua per a la tramesa."
 
-msgid "submission.submit.submissionChecklist"
-msgstr "Llista de verificació de la tramesa"
-
-msgid "submission.submit.submissionChecklistDescription"
-msgstr "Completeu i marqueu els següents requisits per fer trameses a aquesta publicació per poder continuar (podeu afegir-hi comentaris a l'editor/a a sota)."
-
 msgid "submission.submit.privacyStatement"
 msgstr "Declaració de privacitat"
 

--- a/locale/da_DK/submission.po
+++ b/locale/da_DK/submission.po
@@ -41,12 +41,6 @@ msgstr "Redigeret værk: Forfattere er knyttet til deres eget kapitel."
 msgid "submission.workflowType.authoredWork"
 msgstr "Monografi: Forfattere er forbundet med bogen som helhed."
 
-msgid "submission.workflowType.editedVolume.selectEditors"
-msgstr "Vælg redaktører"
-
-msgid "submission.workflowType.editedVolume.selectEditors.description"
-msgstr "Vælg de forfattere, der skal identificeres som redaktører for hele værket."
-
 msgid "submission.editorName"
 msgstr "{$editorName} (ed)"
 
@@ -225,9 +219,6 @@ msgstr "Kapitler"
 
 msgid "grid.copyediting.deleteCopyeditorResponse"
 msgstr "Slet upload fra manuskriptredaktør"
-
-msgid "submission.catalogEntry"
-msgstr "Katalogindgang"
 
 msgid "submission.complete"
 msgstr "Godkendt"

--- a/locale/de_DE/submission.po
+++ b/locale/de_DE/submission.po
@@ -137,12 +137,6 @@ msgstr "Beispiel: Buch 2, Band 2"
 msgid "submission.submit.form.localeRequired"
 msgstr "Bitte wählen Sie die Sprache des Manuskripts aus."
 
-msgid "submission.submit.submissionChecklist"
-msgstr "Checkliste für den Einreichungsprozess"
-
-msgid "submission.submit.submissionChecklistDescription"
-msgstr "Die eingereichten Manuskripte müssen den folgenden Vorgaben entsprechen. Um fortfahren zu können, müssen Sie die Erfüllung der Vorgaben bestätigen (Kommentare an die Redaktion können unten hinzugefügt werden)."
-
 msgid "submission.submit.privacyStatement"
 msgstr "Datenschutzerklärung"
 

--- a/locale/es_ES/submission.po
+++ b/locale/es_ES/submission.po
@@ -134,12 +134,6 @@ msgstr "Lugar que ocupa dentro de esta serie, colección, ... (por ejemplo, Libr
 msgid "submission.submit.form.localeRequired"
 msgstr "Selecciona una lengua para la propuesta."
 
-msgid "submission.submit.submissionChecklist"
-msgstr "Lista de comprobación de la presentación"
-
-msgid "submission.submit.submissionChecklistDescription"
-msgstr "Tienen que completarse y marcarse las siguientes exigencias para la propuesta a esta editorial antes de continuar (se pueden añadir a continuación comentarios al editor) ."
-
 msgid "submission.submit.privacyStatement"
 msgstr "Declaración de privacidad"
 
@@ -298,9 +292,6 @@ msgstr "Guardar orden"
 
 msgid "submission.editorName"
 msgstr "{$editorName} (ed)"
-
-msgid "submission.editorSeparator"
-msgstr ","
 
 msgid "submission.authorListSeparator"
 msgstr "; "

--- a/locale/fi_FI/submission.po
+++ b/locale/fi_FI/submission.po
@@ -38,12 +38,6 @@ msgstr "Toimitettu teos: Jokaisella luvulla on eri kirjoittaja."
 msgid "submission.workflowType.authoredWork"
 msgstr "Erillisteos: Yhden tai useamman kirjoittajan kokonaan kirjoittama teos."
 
-msgid "submission.workflowType.editedVolume.selectEditors"
-msgstr "Valitse niteen toimittajat"
-
-msgid "submission.workflowType.editedVolume.selectEditors.description"
-msgstr "Valitse kirjoittajat, jotka ovat toimittaneet koko niteen."
-
 msgid "submission.editorName"
 msgstr "{$editorName} (toim.)"
 
@@ -226,9 +220,6 @@ msgstr "Luvut"
 
 msgid "grid.copyediting.deleteCopyeditorResponse"
 msgstr "Poista teknisen toimittajan lataus"
-
-msgid "submission.catalogEntry"
-msgstr "Luettelomerkintä"
 
 msgid "submission.complete"
 msgstr "Hyväksytty"

--- a/locale/fr_CA/submission.po
+++ b/locale/fr_CA/submission.po
@@ -131,12 +131,6 @@ msgstr "Position dans cette série (ex: livre 2 ou Volume 2)"
 msgid "submission.submit.form.localeRequired"
 msgstr "Veuillez choisir une langue pour la soumission."
 
-msgid "submission.submit.submissionChecklist"
-msgstr "Liste de vérification pour la soumission"
-
-msgid "submission.submit.submissionChecklistDescription"
-msgstr "Les exigences suivantes en ce qui concerne les soumissions à cette presse doivent être cochées avant de poursuivre la procédure (les commentaires à l'intention du rédacteur en chef seront ajoutés ci-dessous)."
-
 msgid "submission.submit.privacyStatement"
 msgstr "Énoncé de confidentialité"
 

--- a/locale/it_IT/submission.po
+++ b/locale/it_IT/submission.po
@@ -148,12 +148,6 @@ msgstr "Posizione occupata nella collana (cio?, Libro 2, o Volume 2)"
 msgid "submission.submit.form.localeRequired"
 msgstr "Per favore, scegli la lingua del caricamento."
 
-msgid "submission.submit.submissionChecklist"
-msgstr "Checklist per il caricamento"
-
-msgid "submission.submit.submissionChecklistDescription"
-msgstr "Prima di procedere, occorre completare e verificare i seguenti requisiti per l'immissione (i commenti all'editor possono essere aggiunti subito dopo)."
-
 msgid "submission.submit.privacyStatement"
 msgstr "Informativa sulla privacy"
 
@@ -234,9 +228,6 @@ msgstr "Capitoli"
 
 msgid "grid.copyediting.deleteCopyeditorResponse"
 msgstr "Cancella il caricamento del Copyeditor"
-
-msgid "submission.catalogEntry"
-msgstr "Catalogo"
 
 msgid "submission.editCatalogEntry"
 msgstr "Accesso"

--- a/locale/pt_BR/submission.po
+++ b/locale/pt_BR/submission.po
@@ -143,12 +143,6 @@ msgstr "Livros em séries são normalmente mantidos na ordem inversa em que são
 msgid "submission.submit.form.localeRequired"
 msgstr "Escolha o idioma da submissão."
 
-msgid "submission.submit.submissionChecklist"
-msgstr "Itens de verificação para submissão"
-
-msgid "submission.submit.submissionChecklistDescription"
-msgstr "É necessário concluir os seguintes requisitos para submissão a esta editora, assim como marcá-los antes de prosseguir (comentários ao editor podem ser inluídos a seguir)."
-
 msgid "submission.submit.privacyStatement"
 msgstr "Declaração de Privacidade"
 


### PR DESCRIPTION
I found some of these entries aren't used anywhere in the templates. While another entries are redundant, since they are already stated within the _pkp-lib_