### PR TITLE
[Enhancement] Adds relation, default language to OAI

### DIFF
--- a/plugins/metadata/dc11/filter/Dc11SchemaPublicationFormatAdapter.inc.php
+++ b/plugins/metadata/dc11/filter/Dc11SchemaPublicationFormatAdapter.inc.php
@@ -78,7 +78,7 @@ class Dc11SchemaPublicationFormatAdapter extends MetadataDataObjectAdapter {
 
 		// Title
 		$titles = array();
-		foreach ($publication->getData('title') as $titleLocale => $title) {
+		foreach ($publication->$monograph->getTitle(null) as $titleLocale => $title) {
 			$titles[$titleLocale] = $monograph->getFullTitle($titleLocale);
 		}
 		$this->_addLocalizedElements($dc11Description, 'dc:title', $titles);

--- a/plugins/metadata/dc11/filter/Dc11SchemaPublicationFormatAdapter.inc.php
+++ b/plugins/metadata/dc11/filter/Dc11SchemaPublicationFormatAdapter.inc.php
@@ -78,7 +78,7 @@ class Dc11SchemaPublicationFormatAdapter extends MetadataDataObjectAdapter {
 
 		// Title
 		$titles = array();
-		foreach ($publication->$monograph->getTitle(null) as $titleLocale => $title) {
+		foreach ($monograph->getTitle(null) as $titleLocale => $title) {
 			$titles[$titleLocale] = $monograph->getFullTitle($titleLocale);
 		}
 		$this->_addLocalizedElements($dc11Description, 'dc:title', $titles);


### PR DESCRIPTION
@asmecher 

Hi Alec,

This PR  resloves the issue described in [forum](https://forum.pkp.sfu.ca/t/no-relation-url-when-running-oai-in-omp/56886) and in https://github.com/pkp/pkp-lib/issues/6361

#### OAI Metadata enhancements

* File download support for monograph files as dublincore relations.`<dc:relation>http://localhost/omp/index.php/pkp/catalog/view/2/5/10-1</dc:relation>`

* dc:language `<dc:language>eng</dc:language>`

I noticed also that dc:title is set to 0, and  users get only one language in a multilingual press.
`<dc:title xml:lang="0">The ABCs of Human Survival: A Paradigm for Global Citizenship</dc:title>`

Could fix it easily, but that would break the tests for OJS too. Therfore did not proceed without confirmation.
https://github.com/pkp/pkp-lib/blob/stable-3_2_1/cypress/tests/integration/oai/DC.spec.js#L33








