### PR TITLE
pkp/pkp-lib#6477 Check if series ID is greater than zero

### DIFF
--- a/classes/services/PublicationService.inc.php
+++ b/classes/services/PublicationService.inc.php
@@ -14,10 +14,10 @@
  */
 namespace APP\Services;
 
-use \Application;
-use \Services;
-use \PKP\Services\PKPPublicationService;
+use Application;
 use DAORegistry;
+use PKP\Services\PKPPublicationService;
+use Services;
 
 class PublicationService extends PKPPublicationService {
 
@@ -120,7 +120,7 @@ class PublicationService extends PKPPublicationService {
 		$props = $args[2];
 
 		// Ensure that the specified series exists
-		if (isset($props['seriesId'])) {
+		if (isset($props['seriesId']) && ($props['seriesId']) > 0) {
 			$series = Application::get()->getSectionDAO()->getById($props['seriesId']);
 			if (!$series) {
 				$errors['seriesId'] = [__('publication.invalidSeries')];


### PR DESCRIPTION
Hi @NateWr ,

This PR checks whether a series ID is greater than zero for the publications service.

This was causing errors in  a submission (workflow -> publication - > catalog entry) as described in the 

Issue : https://github.com/pkp/pkp-lib/issues/6477




