### PR TITLE
[OMP] #7173 Fix for covers and thumbnails not being migrated.

### DIFF
--- a/classes/install/Upgrade.inc.php
+++ b/classes/install/Upgrade.inc.php
@@ -809,9 +809,9 @@ class Upgrade extends Installer
 
             // Get existing image paths
             $basePath = Services::get('submissionFile')->getSubmissionDir($row->context_id, $row->submission_id);
-            $coverPath = $basePath . '/simple/' . $coverImage['name'];
+            $coverPath = Config::getVar('files', 'files_dir') . '/' . $basePath . '/simple/' . $coverImage['name'];
             $coverPathInfo = pathinfo($coverPath);
-            $thumbPath = $basePath . '/simple/' . $coverImage['thumbnailName'];
+            $thumbPath = Config::getVar('files', 'files_dir') . '/' . $basePath . '/simple/' . $coverImage['thumbnailName'];
             $thumbPathInfo = pathinfo($thumbPath);
 
             // Copy the files to the public directory


### PR DESCRIPTION
The cover and thumb paths declared in migrateSubmissionCoverImages() were missing the system file path set in the config file.