### PR TITLE
Update PressOAI.inc.php

### DIFF
--- a/classes/oai/omp/PressOAI.inc.php
+++ b/classes/oai/omp/PressOAI.inc.php
@@ -196,7 +196,7 @@ class PressOAI extends OAI
     public function records($metadataPrefix, $from, $until, $set, $offset, $limit, &$total)
     {
         $records = null;
-        if (!HookRegistry::call('PressOAI::records', [&$this, $from, $until, $set, $offset, $limit, $total, &$records])) {
+        if (!HookRegistry::call('PressOAI::records', [&$this, $from, $until, $set, $offset, $limit, &$total, &$records])) {
             $seriesId = null;
             if (isset($set)) {
                 [$pressId, $seriesId] = $this->setSpecToSeriesId($set);
@@ -214,7 +214,7 @@ class PressOAI extends OAI
     public function identifiers($metadataPrefix, $from, $until, $set, $offset, $limit, &$total)
     {
         $records = null;
-        if (!HookRegistry::call('PressOAI::identifiers', [&$this, $from, $until, $set, $offset, $limit, $total, &$records])) {
+        if (!HookRegistry::call('PressOAI::identifiers', [&$this, $from, $until, $set, $offset, $limit, &$total, &$records])) {
             $seriesId = null;
             if (isset($set)) {
                 [$pressId, $seriesId] = $this->setSpecToSeriesId($set);
@@ -232,7 +232,7 @@ class PressOAI extends OAI
     public function sets($offset, $limit, &$total)
     {
         $sets = null;
-        if (!HookRegistry::call('PressOAI::sets', [&$this, $offset, $limit, $total, &$sets])) {
+        if (!HookRegistry::call('PressOAI::sets', [&$this, $offset, $limit, &$total, &$sets])) {
             $sets = $this->dao->getSets($this->pressId, $offset, $limit, $total);
         }
         return $sets;


### PR DESCRIPTION
$total variable must be called by reference to get  resumption tokens, when using the hooks. It is already fixed in OJS.