### PR TITLE
Update Dc11SchemaPublicationFormatAdapter.inc.php

### DIFF
--- a/plugins/metadata/dc11/filter/Dc11SchemaPublicationFormatAdapter.inc.php
+++ b/plugins/metadata/dc11/filter/Dc11SchemaPublicationFormatAdapter.inc.php
@@ -78,11 +78,7 @@ class Dc11SchemaPublicationFormatAdapter extends MetadataDataObjectAdapter
         $dc11Description = $this->instantiateMetadataDescription();
 
         // Title
-        $titles = [];
-        foreach ($monograph->getTitle(null) as $titleLocale => $title) {
-            $titles[$titleLocale] = $monograph->getFullTitle($titleLocale);
-        }
-        $this->_addLocalizedElements($dc11Description, 'dc:title', $titles);
+        $this->_addLocalizedElements($dc11Description, 'dc:title', $monograph->getFullTitle(null));
 
         // Creator
         $authors = $monograph->getAuthors();

--- a/plugins/metadata/dc11/filter/Dc11SchemaPublicationFormatAdapter.inc.php
+++ b/plugins/metadata/dc11/filter/Dc11SchemaPublicationFormatAdapter.inc.php
@@ -78,8 +78,9 @@ class Dc11SchemaPublicationFormatAdapter extends MetadataDataObjectAdapter
         $dc11Description = $this->instantiateMetadataDescription();
 
         // Title
-        $this->_addLocalizedElements($dc11Description, 'dc:title', $monograph->getFullTitle(null));
-
+        $publication = $monograph->getCurrentPublication();
+        $this->_addLocalizedElements($dc11Description, 'dc:title', $publication->getFullTitles());
+         
         // Creator
         $authors = $monograph->getAuthors();
         foreach ($authors as $author) {


### PR DESCRIPTION
Hi,
when I enable two languages (german and english) in OMP 3.3.0.7 I get something like 

```
<dc:title xml:lang="0">german title</dc:title>
<dc:title xml:lang="0">english title</dc:title>
<dc:title xml:lang="1">english title</dc:title>
```
in dc_oai. I looked into the OMP demo, there is also an error: 

`<dc:title xml:lang="0">The Class Imperative</dc:title>`

This fix works at least in my installation.


