### PR TITLE
pkp/pkp-lib#4235 Don't output invalid chars in OAI setSpec

### DIFF
--- a/classes/oai/omp/PressOAI.inc.php
+++ b/classes/oai/omp/PressOAI.inc.php
@@ -110,12 +110,9 @@ class PressOAI extends OAI
         $tmpArray = preg_split('/:/', $setSpec);
         if (count($tmpArray) == 1) {
             [$pressSpec] = $tmpArray;
-            $pressSpec = urldecode($pressSpec);
             $seriesSpec = null;
         } elseif (count($tmpArray) == 2) {
             [$pressSpec, $seriesSpec] = $tmpArray;
-            $pressSpec = urldecode($pressSpec);
-            $seriesSpec = urldecode($seriesSpec);
         } else {
             return [0, 0];
         }

--- a/classes/publicationFormat/PublicationFormatTombstoneManager.inc.php
+++ b/classes/publicationFormat/PublicationFormatTombstoneManager.inc.php
@@ -14,6 +14,7 @@
  */
 
 use APP\facades\Repo;
+use APP\oai\omp\OAIDAO;
 use APP\submission\Submission;
 use PKP\submission\PKPSubmission;
 
@@ -45,10 +46,10 @@ class PublicationFormatTombstoneManager
         $dataObjectTombstoneDao->deleteByDataObjectId($publicationFormat->getId());
         // insert publication format tombstone
         if (is_a($series, 'Series')) {
-            $setSpec = urlencode($press->getPath()) . ':' . urlencode($series->getPath());
+            $setSpec = OAIDAO::setSpec($press, $series);
             $setName = $series->getLocalizedTitle();
         } else {
-            $setSpec = urlencode($press->getPath());
+            $setSpec = OAIDAO::setSpec($press);
             $setName = $press->getLocalizedName();
         }
         $oaiIdentifier = 'oai:' . Config::getVar('oai', 'repository_id') . ':' . 'publicationFormat/' . $publicationFormat->getId();


### PR DESCRIPTION
Issue: pkp/pkp-lib#4235
Since press and series paths are used to construct the setSpec string we can do a simpler fix than for OJS (pkp/ojs/pull/3194). Just remove the unnecessary `urlencode` and `urldecode`.