### PR TITLE
DOIPubIdPlugin: add CitationStyleLanguagePlugin support

### DIFF
--- a/templates/frontend/objects/chapter.tpl
+++ b/templates/frontend/objects/chapter.tpl
@@ -243,6 +243,11 @@
 				</div>
 			{/if}
 
+			{* How to cite *}
+			{if $citation}
+				{include file="../plugins/generic/citationStyleLanguage/templates/citationblock.tpl"}
+			{/if}
+
 			{* Series *}
 			{if $series}
 				<div class="item series">

--- a/templates/frontend/objects/monograph_full.tpl
+++ b/templates/frontend/objects/monograph_full.tpl
@@ -333,6 +333,11 @@
 				</div>
 			{/if}
 
+			{* How to cite *}
+			{if $citation}
+				{include file="../plugins/generic/citationStyleLanguage/templates/citationblock.tpl"}
+			{/if}
+
 			{* Series *}
 			{if $series}
 				<div class="item series">


### PR DESCRIPTION
Hi,
I add support for CitationStyleLanguagePlagin to DOIPubIdPlugin, that the DOI can be shown in the citation of books and chapters. I also changed the `PubIdPlugin` class to use the new `source_chapter_id` and not the `chapter_id`. 
Thirdly I found a different result by creating an DOI for a publicaion between OMP 3.3 and OMP 3.4:
In OMP 3.3 (on our systems) the press initials in the DOIs are always lower case, but in OMP 3.4 the press initials are lower case for chapters but not for books. I didn't found the code, that changed this, but a way to fix it (DOIPubIDPlugin.inc.php line 380) . 