### PR TITLE
Add smtp_suppress_cert_check directive

### DIFF
--- a/config.TEMPLATE.inc.php
+++ b/config.TEMPLATE.inc.php
@@ -334,6 +334,10 @@ sendmail_path = "/usr/sbin/sendmail -bs"
 ; smtp_oauth_clientsecret =
 ; smtp_oauth_refreshtoken =
 
+; Enable suppressing verification of SMTP certificate in PHPMailer
+; Note: this is not recommended per PHPMailer documentation
+; smtp_suppress_cert_check = On
+
 ; Allow envelope sender to be specified
 ; (may not be possible with some server configurations)
 ; allow_envelope_sender = Off


### PR DESCRIPTION
Adding the smtp_suppress_cert_check directive. In OJS there is this directive and in OMP there is not.
I suggest adding this directive to the SMTP when needed configuration.