### PR TITLE
pkp/pkp-lib#2169 Submodule update ##touhidurabir/i2169_fix_stable_3_3_0 #

### DIFF
--- a/cypress/tests/data/20-CreateContext.spec.js
+++ b/cypress/tests/data/20-CreateContext.spec.js
@@ -94,7 +94,6 @@ describe('Data suite tests', function() {
 		cy.get('div[id=contact').find('button').contains('Save').click();
 		cy.get('div[id="contact-contactName-error"]').contains('This field is required.');
 		cy.get('div[id="contact-contactEmail-error"]').contains('This field is required.');
-		cy.get('div[id="contact-mailingAddress-error"]').contains('This field is required.');
 		cy.get('div[id="contact-supportName-error"]').contains('This field is required.');
 		cy.get('div[id="contact-supportEmail-error"]').contains('This field is required.');
 


### PR DESCRIPTION
fix to issue https://github.com/pkp/pkp-lib/issues/2169 which make the `Mailing address` as a non required field in the `Settings => Contact` section . A corresponding pull request to `pkp/pkp-lib` repo for this has made at https://github.com/pkp/pkp-lib/pull/7852 . Also tests are updated according to this change .