### PR TITLE
pkp/pkp-lib#3585 Submodule Update ##touhidurabir/i3585_main##

### DIFF
--- a/classes/decision/Decision.inc.php
+++ b/classes/decision/Decision.inc.php
@@ -56,6 +56,8 @@ class Decision extends BaseDecision
     public const RECOMMEND_DECLINE_INTERNAL = 31;
     public const REVERT_INTERNAL_DECLINE = 32;
     public const NEW_INTERNAL_ROUND = 33;
+    public const DELETE_EMPTY_EXTERNAL_REVIEW_ROUND = 34;
+    public const DELETE_EMPTY_INTERNAL_REVIEW_ROUND = 35;
 }
 
 if (!PKP_STRICT_MODE) {

--- a/classes/decision/Repository.inc.php
+++ b/classes/decision/Repository.inc.php
@@ -45,6 +45,8 @@ use PKP\decision\types\RevertDecline;
 use PKP\decision\types\RevertInitialDecline;
 use PKP\decision\types\SendToProduction;
 use PKP\decision\types\SkipExternalReview;
+use PKP\decision\types\RemoveEmptyExternalReviewRound;
+use PKP\decision\types\RemoveEmptyInternalReviewRound;
 use PKP\plugins\HookRegistry;
 
 class Repository extends \PKP\decision\Repository
@@ -86,6 +88,8 @@ class Repository extends \PKP\decision\Repository
                 new SendToProduction(),
                 new SkipInternalReview(),
                 new SkipExternalReview(),
+                new RemoveEmptyExternalReviewRound(),
+                new RemoveEmptyInternalReviewRound(),
             ]);
             HookRegistry::call('Decision::types', [$decisionTypes]);
             $this->decisionTypes = $decisionTypes;


### PR DESCRIPTION
This PR aims to provide a way to handle pkp/pkp-lib#3585 by allowing the editor to delete/remove an empty review round when created accidentally . 