### PR TITLE
pkp/pkp-lib#7864 DC.Title.Alternative fix: use getFullTitle instead o…

### DIFF
--- a/plugins/generic/dublinCoreMeta/DublinCoreMetaPlugin.inc.php
+++ b/plugins/generic/dublinCoreMeta/DublinCoreMetaPlugin.inc.php
@@ -218,7 +218,7 @@ class DublinCoreMetaPlugin extends GenericPlugin {
 		} else {
 			$templateMgr->addHeader('dublinCoreTitle', '<meta name="DC.Title" content="' . htmlspecialchars($monograph->getFullTitle($monograph->getLocale())) . '"/>');
 			$i=0;
-			foreach ($monograph->getFullTitles() as $locale => $title) {
+			foreach ($monograph->getFullTitle(null) as $locale => $title) {
 				if ($locale == $monograph->getLocale()) continue;
 				$templateMgr->addHeader('dublinCoreAltTitle' . $i++, '<meta name="DC.Title.Alternative" xml:lang="' . htmlspecialchars(substr($locale, 0, 2)) . '" content="' . htmlspecialchars($title) . '"/>');
 			}


### PR DESCRIPTION
…f getFullTitles

s. https://github.com/pkp/pkp-lib/issues/7864#issuecomment-1155051764

This fixes the error due to the wrong function call.