### PR TITLE
[OMP] Hide inactive series in browse block plugin

### DIFF
--- a/plugins/blocks/browse/templates/block.tpl
+++ b/plugins/blocks/browse/templates/block.tpl
@@ -50,11 +50,13 @@
 					{translate key="plugins.block.browse.series"}
 					<ul>
 						{foreach from=$browseSeries item=browseSeriesItem}
-							<li class="series_{$browseSeriesItem->getId()}{if $browseBlockSelectedSeries == $browseSeriesItem->getPath() && $browseBlockSelectedSeries != ''} current{/if}">
-								<a href="{url router=PKPApplication::ROUTE_PAGE page="catalog" op="series" path=$browseSeriesItem->getPath()|escape}">
-									{$browseSeriesItem->getLocalizedTitle()|escape}
-								</a>
-							</li>
+							{if !$browseSeriesItem->getIsInactive()}
+								<li class="series_{$browseSeriesItem->getId()}{if $browseBlockSelectedSeries == $browseSeriesItem->getPath() && $browseBlockSelectedSeries != ''} current{/if}">
+									<a href="{url router=PKPApplication::ROUTE_PAGE page="catalog" op="series" path=$browseSeriesItem->getPath()|escape}">
+										{$browseSeriesItem->getLocalizedTitle()|escape}
+									</a>
+								</li>
+							{/if}
 						{/foreach}
 					</ul>
 				</li>


### PR DESCRIPTION
When an inactive series is set from backend, you shouldn't view in 'browse' public frontend.