### PR TITLE
pkp/pkp-lib#8481 Consider not migrated assoc and metric types when copying orphaned metrics into the temporary table

### DIFF
--- a/classes/migration/upgrade/v3_4_0/I6782_OrphanedMetrics.php
+++ b/classes/migration/upgrade/v3_4_0/I6782_OrphanedMetrics.php
@@ -8,7 +8,9 @@
  * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
  *
  * @class I6782_OrphanedMetrics
- * @brief Migrate usage stats settings, and data from the old DB table metrics into the new DB tables.
+ * @brief Migrate metrics data from objects that do not exist any more and from assoc types that are not considered in the upgrade into the temporary table.
+ * These entries will be copied back and stay in the table metrics_old, s. I6782_CleanOldMetrics.
+ * Consider only metric_type ojs::counter here, because these entries will be removed during the upgrade.
  */
 
 namespace APP\migration\upgrade\v3_4_0;
@@ -20,6 +22,12 @@ class I6782_OrphanedMetrics extends \PKP\migration\upgrade\v3_4_0\I6782_Orphaned
 {
     private const ASSOC_TYPE_CONTEXT = 0x0000200;
     private const ASSOC_TYPE_SERIES = 0x0000212;
+
+
+    protected function getMetricType(): string
+    {
+        return 'omp::counter';
+    }
 
     protected function getContextAssocType(): int
     {
@@ -46,6 +54,17 @@ class I6782_OrphanedMetrics extends \PKP\migration\upgrade\v3_4_0\I6782_Orphaned
         return 'publication_format_id';
     }
 
+    protected function getAssocTypesToMigrate(): array
+    {
+        return array_merge(
+            [
+                self::ASSOC_TYPE_CONTEXT,
+                self::ASSOC_TYPE_SERIES,
+            ],
+            parent::getAssocTypesToMigrate()
+        );
+    }
+
     /**
      * Run the migration.
      */
@@ -58,7 +77,7 @@ class I6782_OrphanedMetrics extends \PKP\migration\upgrade\v3_4_0\I6782_Orphaned
         // Clean orphaned series IDs
         // as assoc_id
         $orphanedIds = DB::table('metrics AS m')->leftJoin('series AS s', 'm.assoc_id', '=', 's.series_id')->where('m.assoc_type', '=', self::ASSOC_TYPE_SERIES)->whereNull('s.series_id')->distinct()->pluck('m.assoc_id');
-        $orphandedSeries = DB::table('metrics')->select($metricsColumns)->where('assoc_type', '=', self::ASSOC_TYPE_SERIES)->whereIn('assoc_id', $orphanedIds);
+        $orphandedSeries = DB::table('metrics')->select($metricsColumns)->where('assoc_type', '=', self::ASSOC_TYPE_SERIES)->whereIn('assoc_id', $orphanedIds)->where('metric_type', '=', $this->getMetricType());
         DB::table('metrics_tmp')->insertUsing($metricsColumns, $orphandedSeries);
         DB::table('metrics')->where('assoc_type', '=', self::ASSOC_TYPE_SERIES)->whereIn('assoc_id', $orphanedIds)->delete();
     }


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/8481