### PR TITLE
Submission and metadata languages separated from UI and form languages

### DIFF
--- a/api/v1/_submissions/BackendSubmissionsController.php
+++ b/api/v1/_submissions/BackendSubmissionsController.php
@@ -175,8 +175,7 @@ class BackendSubmissionsController extends \PKP\API\v1\_submissions\PKPBackendSu
             ], Response::HTTP_BAD_REQUEST);
         }
 
-        $primaryLocale = $this->getRequest()->getContext()->getPrimaryLocale();
-        $allowedLocales = $this->getRequest()->getContext()->getSupportedFormLocales();
+        $supportedMetadataLocales = $this->getRequest()->getContext()->getSupportedSubmissionMetadataLocales();
 
         $validPublications = [];
         foreach ($submissionIds as $submissionId) {
@@ -193,9 +192,8 @@ class BackendSubmissionsController extends \PKP\API\v1\_submissions\PKPBackendSu
             if ($publication->getData('status') === Submission::STATUS_PUBLISHED) {
                 continue;
             }
-
-            $errors = Repo::publication()->validatePublish($publication, $submission, $allowedLocales, $primaryLocale);
-
+            $allowedLocales = $submission->getPublicationLanguages($supportedMetadataLocales);
+            $errors = Repo::publication()->validatePublish($publication, $submission, $allowedLocales, $submission->getData('locale'));
             if (!empty($errors)) {
                 return response()->json($errors, Response::HTTP_BAD_REQUEST);
             }

--- a/classes/components/listPanels/CatalogListPanel.php
+++ b/classes/components/listPanels/CatalogListPanel.php
@@ -138,8 +138,10 @@ class CatalogListPanel extends \PKP\components\listPanels\ListPanel
             'submissions'
         );
 
-        $locales = $context->getSupportedFormLocaleNames();
-        $locales = array_map(fn (string $locale, string $name) => ['key' => $locale, 'label' => $name], array_keys($locales), $locales);
+        $locales = collect($context->getSupportedSubmissionMetadataLocaleNames())
+            ->map(fn (string $locale, string $name) => ['key' => $locale, 'label' => $name])
+            ->values()
+            ->toArray();
         $addEntryForm = new \APP\components\forms\catalog\AddEntryForm($addEntryApiUrl, $searchSubmissionsApiUrl, $locales);
         $config['addEntryForm'] = $addEntryForm->getConfig();
 
@@ -149,7 +151,6 @@ class CatalogListPanel extends \PKP\components\listPanels\ListPanel
             'ASSOC_TYPE_CATEGORY' => Application::ASSOC_TYPE_CATEGORY,
             'ASSOC_TYPE_SERIES' => Application::ASSOC_TYPE_SERIES,
         ]);
-
 
         return $config;
     }

--- a/classes/migration/install/OMPMigration.php
+++ b/classes/migration/install/OMPMigration.php
@@ -119,7 +119,7 @@ class OMPMigration extends \PKP\migration\Migration
             $table->foreign('publication_format_id', 'publication_format_settings_publication_format_id')->references('publication_format_id')->on('publication_formats')->onDelete('cascade');
             $table->index(['publication_format_id'], 'publication_format_id_key');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->text('setting_value')->nullable();
             $table->string('setting_type', 6)->comment('(bool|int|float|string|object)');
@@ -290,7 +290,7 @@ class OMPMigration extends \PKP\migration\Migration
             $table->foreign('series_id', 'series_settings_series_id')->references('series_id')->on('series')->onDelete('cascade');
             $table->index(['series_id'], 'series_settings_series_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->text('setting_value')->nullable();
 
@@ -333,7 +333,7 @@ class OMPMigration extends \PKP\migration\Migration
             $table->foreign('chapter_id')->references('chapter_id')->on('submission_chapters')->onDelete('cascade');
             $table->index(['chapter_id'], 'submission_chapter_settings_chapter_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->text('setting_value')->nullable();
             $table->string('setting_type', 6)->comment('(bool|int|float|string|object)');

--- a/classes/migration/install/PressMigration.php
+++ b/classes/migration/install/PressMigration.php
@@ -30,7 +30,7 @@ class PressMigration extends \PKP\migration\Migration
             $table->bigInteger('press_id')->autoIncrement();
             $table->string('path', 32);
             $table->float('seq', 8, 2)->default(0);
-            $table->string('primary_locale', 14);
+            $table->string('primary_locale', 28);
             $table->smallInteger('enabled')->default(1);
             $table->unique(['path'], 'press_path');
         });
@@ -44,7 +44,7 @@ class PressMigration extends \PKP\migration\Migration
             $table->foreign('press_id')->references('press_id')->on('presses')->onDelete('cascade');
             $table->index(['press_id'], 'press_settings_press_id');
 
-            $table->string('locale', 14)->default('');
+            $table->string('locale', 28)->default('');
             $table->string('setting_name', 255);
             $table->text('setting_value')->nullable();
 

--- a/classes/migration/upgrade/v3_5_0/I9425_SeparateUIAndSubmissionLocales.php
+++ b/classes/migration/upgrade/v3_5_0/I9425_SeparateUIAndSubmissionLocales.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file classes/migration/upgrade/v3_5_0/I9425_SeparateUIAndSubmissionLocales.php
+ *
+ * Copyright (c) 2024 Simon Fraser University
+ * Copyright (c) 2024 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class I9425_SeparateUIAndSubmissionLocales
+ *
+ * @brief pkp/pkp-lib#9425 Make submission language selection and metadata forms independent from website language settings
+ */
+
+namespace APP\migration\upgrade\v3_5_0;
+
+class I9425_SeparateUIAndSubmissionLocales extends \PKP\migration\upgrade\v3_5_0\I9425_SeparateUIAndSubmissionLocales
+{
+    protected function getContextTable(): string
+    {
+        return 'presses';
+    }
+    protected function getContextSettingsTable(): string
+    {
+        return 'press_settings';
+    }
+    protected function getContextIdColumn(): string
+    {
+        return 'press_id';
+    }
+}

--- a/classes/publication/Repository.php
+++ b/classes/publication/Repository.php
@@ -77,7 +77,7 @@ class Repository extends \PKP\publication\Repository
                 $submissionContext = Services::get('context')->get($submission->getData('contextId'));
             }
 
-            $supportedLocales = $submissionContext->getSupportedSubmissionLocales();
+            $supportedLocales = $submission->getPublicationLanguages($submissionContext->getSupportedSubmissionMetadataLocales());
             foreach ($supportedLocales as $localeKey) {
                 if (!array_key_exists($localeKey, $publication->getData('coverImage'))) {
                     continue;
@@ -272,7 +272,7 @@ class Repository extends \PKP\publication\Repository
                         $publicFileManager->removeContextFile($submission->getData('contextId'), $this->getThumbnailFileName($oldCoverImage[$localeKey]['uploadName']));
                     }
 
-                    // Otherwise generate a new thumbnail if a cover image exists
+                // Otherwise generate a new thumbnail if a cover image exists
                 } elseif (!empty($newCoverImage) && array_key_exists('temporaryFileId', $newCoverImage)) {
                     $coverImageFilePath = $publicFileManager->getContextFilesPath($submission->getData('contextId')) . '/' . $coverImages[$localeKey]['uploadName'];
                     $this->makeThumbnail(

--- a/classes/publication/maps/Schema.php
+++ b/classes/publication/maps/Schema.php
@@ -96,7 +96,9 @@ class Schema extends \PKP\publication\maps\Schema
             );
         }
 
-        $output = $this->schemaService->addMissingMultilingualValues(PKPSchemaService::SCHEMA_PUBLICATION, $output, $this->context->getSupportedSubmissionLocales());
+        $locales = $this->submission->getPublicationLanguages($this->context->getSupportedSubmissionMetadataLocales());
+
+        $output = $this->schemaService->addMissingMultilingualValues(PKPSchemaService::SCHEMA_PUBLICATION, $output, $locales);
 
         ksort($output);
 

--- a/classes/submission/maps/Schema.php
+++ b/classes/submission/maps/Schema.php
@@ -59,7 +59,13 @@ class Schema extends \PKP\submission\maps\Schema
             $output['newRelease'] = $newReleaseDao->getNewReleaseAll($submission->getId());
         }
 
-        $output = $this->schemaService->addMissingMultilingualValues($this->schemaService::SCHEMA_SUBMISSION, $output, $this->context->getSupportedSubmissionLocales());
+        $locales = $this->context->getSupportedSubmissionMetaDataLocales();
+
+        if (!in_array($submissionLocale = $submission->getData('locale'), $locales)) {
+            $locales[] = $submissionLocale;
+        }
+
+        $output = $this->schemaService->addMissingMultilingualValues($this->schemaService::SCHEMA_SUBMISSION, $output, $locales);
 
         ksort($output);
 

--- a/controllers/grid/catalogEntry/form/PublicationFormatForm.php
+++ b/controllers/grid/catalogEntry/form/PublicationFormatForm.php
@@ -48,7 +48,8 @@ class PublicationFormatForm extends Form
      */
     public function __construct($monograph, $publicationFormat, $publication)
     {
-        parent::__construct('controllers/grid/catalogEntry/form/formatForm.tpl');
+        $localeNames = Application::get()->getRequest()->getContext()->getSupportedSubmissionMetadataLocaleNames() + $monograph->getPublicationLanguageNames();
+        parent::__construct('controllers/grid/catalogEntry/form/formatForm.tpl', true, $monograph->getData('locale'), $localeNames);
         $this->setMonograph($monograph);
         $this->setPublicationFormat($publicationFormat);
         $this->setPublication($publication);

--- a/cypress/tests/data/10-ApplicationSetup/20-CreateContext.cy.js
+++ b/cypress/tests/data/10-ApplicationSetup/20-CreateContext.cy.js
@@ -70,8 +70,13 @@ describe('Data suite tests', function() {
 		cy.get('#appearance [role="status"]').contains('Saved');
 
 		cy.get('button[id="languages-button"]').click();
-		cy.get('input[id^=select-cell-fr_CA-submissionLocale]').click();
-		cy.contains('Locale settings saved.');
+		cy.get('input[id^="select-cell-fr_CA-formLocale"]').click();
+		cy.get('a[id^=component-grid-settings-languages-submissionlanguagegrid-addLanguageModal-button]').click();
+		cy.get('#locale-fr_CA').should('exist').click();
+		cy.get('#addLanguageForm button[name="submitFormButton"]').click();
+		cy.contains('Submission locales updated.').should('exist');
+		cy.get('input[id^="select-cell-fr_CA-submissionLocale"]').click();
+		cy.get('input[id^="select-cell-fr_CA-submissionMetadataLocale"]').should('be.checked');
 
 		cy.get('button[id="indexing-button"]').click();
 		cy.get('input[name="searchDescription-en"]').type(Cypress.env('contextDescriptions')['en']);

--- a/cypress/tests/data/60-content/AfinkelSubmission.cy.js
+++ b/cypress/tests/data/60-content/AfinkelSubmission.cy.js
@@ -311,7 +311,7 @@ describe('Data suite tests', function() {
 			.find('h4').contains('Keywords').siblings('.submissionWizard__reviewPanel__item__value').contains('None provided')
 			.parents('.submissionWizard__reviewPanel')
 			.find('h4').contains('Abstract').siblings('.submissionWizard__reviewPanel__item__value').contains(submission.abstract);
-		cy.get('h3').contains('Details (French)')
+		cy.get('h3').contains('Details (French (Canada))')
 			.parents('.submissionWizard__reviewPanel')
 			.find('h4').contains('Title').siblings('.submissionWizard__reviewPanel__item__value').contains('None provided')
 			.parents('.submissionWizard__reviewPanel')
@@ -319,7 +319,7 @@ describe('Data suite tests', function() {
 			.parents('.submissionWizard__reviewPanel')
 			.find('h4').contains('Abstract').siblings('.submissionWizard__reviewPanel__item__value').contains('None provided');
 		cy.get('h3').contains('For the Editors (English)');
-		cy.get('h3').contains('For the Editors (French)');
+		cy.get('h3').contains('For the Editors (French (Canada))');
 
 		// Submit
 		cy.contains('Make a Submission: Review');

--- a/dbscripts/xml/upgrade.xml
+++ b/dbscripts/xml/upgrade.xml
@@ -109,6 +109,7 @@
 		<migration class="APP\migration\upgrade\v3_5_0\I9262_Highlights"/>
 		<migration class="PKP\migration\upgrade\v3_5_0\I9462_UserUserGroups"/>
 		<migration class="PKP\migration\upgrade\v3_5_0\I9552_UserGroupsMasthead"/>
+		<migration class="APP\migration\upgrade\v3_5_0\I9425_SeparateUIAndSubmissionLocales"/>
 	</upgrade>
 
 	<!-- Update plugin configuration - should be done as the final upgrade task -->

--- a/pages/submission/SubmissionHandler.php
+++ b/pages/submission/SubmissionHandler.php
@@ -102,7 +102,7 @@ class SubmissionHandler extends PKPSubmissionHandler
                     ? 'submission.wizard.submitting.monographInLanguage'
                     : 'submission.wizard.submitting.editedVolumeInLanguage'
                 ),
-                ['language' => Locale::getMetadata($submission->getData('locale'))->getDisplayName()]
+                ['language' => Locale::getSubmissionLocaleDisplayNames([$submission->getData('locale')])[$submission->getData('locale')]]
             );
         }
 
@@ -130,7 +130,7 @@ class SubmissionHandler extends PKPSubmissionHandler
 
         Hook::add('Template::SubmissionWizard::Section', function (string $hookName, array $params) {
             $templateMgr = $params[1]; /** @var TemplateManager $templateMgr */
-            $output = & $params[2]; /** @var string $step */
+            $output = &$params[2]; /** @var string $step */
 
             $output .= sprintf(
                 '<template v-else-if="section.id === \'' . self::CHAPTERS_SECTION_ID . '\'">%s</template>',
@@ -143,7 +143,7 @@ class SubmissionHandler extends PKPSubmissionHandler
         Hook::add('Template::SubmissionWizard::Section::Review', function (string $hookName, array $params) {
             $step = $params[0]['step']; /** @var string $step */
             $templateMgr = $params[1]; /** @var TemplateManager $templateMgr */
-            $output = & $params[2]; /** @var string $output */
+            $output = &$params[2]; /** @var string $output */
 
             if ($step === 'details') {
                 $output .= $templateMgr->fetch('submission/review-chapters.tpl');


### PR DESCRIPTION
- In Website Settings > Setup > Languages and in Administration > Hosted Journals > Settings Wizard > Journal Settings > Languages, separate Website Languages and Submission Languages settings. In the website languages are UI and Forms, and in the submission languages are submission and metadata.

- Submission metadata can be edited even if metadata isn't checked in that language in the settings.