### PR TITLE
pkp/pkp-lib#9557 Section::getTitle() and PKPSection::getTitle() can return null

### DIFF
--- a/classes/section/Section.php
+++ b/classes/section/Section.php
@@ -47,7 +47,7 @@ class Section extends \PKP\section\PKPSection
     /**
      * Get title of series.
      */
-    public function getTitle(?string $locale, bool $includePrefix = true): string|array
+    public function getTitle(?string $locale, bool $includePrefix = true): string|array|null
     {
         $title = $this->getData('title', $locale);
         if ($includePrefix) {


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/9557