### PR TITLE
pkp/pkp-lib#9664 deprecate CompileUsageStatsFromTemporaryRecords job

### DIFF
--- a/jobs/statistics/CompileUsageStatsFromTemporaryRecords.php
+++ b/jobs/statistics/CompileUsageStatsFromTemporaryRecords.php
@@ -13,6 +13,8 @@
  * @ingroup jobs
  *
  * @brief Class to handle the usage metrics data loading as a Job
+ *
+ * @deprecated 3.4.0.5
  */
 
 namespace APP\jobs\statistics;


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/9664

forgot to deprecate the job