### PR TITLE
pkp/pkp-lib#9971 Add old AuthorForm class

### DIFF
--- a/classes/controllers/grid/users/author/form/AuthorForm.php
+++ b/classes/controllers/grid/users/author/form/AuthorForm.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @file controllers/grid/users/author/form/AuthorForm.php
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2003-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class AuthorForm
+ *
+ * @ingroup controllers_grid_users_author_form
+ *
+ * @deprecated 3.4
+ *
+ * @brief Form for adding/editing a author
+ */
+
+namespace APP\controllers\grid\users\author\form;
+
+use PKP\controllers\grid\users\author\form\PKPAuthorForm;
+
+class AuthorForm extends PKPAuthorForm
+{
+}


### PR DESCRIPTION
Add old AuthorForm class for QuickSubmit plugin.

Related issue: pkp/pkp-lib#9971