### PR TITLE
pkp/pkp-lib#10080 fix editorial masthead locale keys and submodule update

### DIFF
--- a/locale/en/manager.po
+++ b/locale/en/manager.po
@@ -524,9 +524,6 @@ msgstr "Items per page"
 msgid "manager.setup.itemsPerPage.description"
 msgstr "Limit the number of items (for example, submissions, users, or editing assignments) to show in a list before showing subsequent items in another page."
 
-msgid "manager.setup.editorialMasthead.description"
-msgstr "Please provide the editorial history of your press, including the full name, affiliation, and start and end dates of each editor."
-
 msgid "manager.setup.labelName"
 msgstr "Label Name"
 


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/10080