### PR TITLE
pkp/pkp-lib#10515 Fix call to a member function on null error from getAvailableEditorialDecisions

### DIFF
--- a/classes/submission/maps/Schema.php
+++ b/classes/submission/maps/Schema.php
@@ -152,6 +152,7 @@ class Schema extends \PKP\submission\maps\Schema
 
         $reviewRoundDao = DAORegistry::getDAO('ReviewRoundDAO'); /** @var ReviewRoundDAO $reviewRoundDao */
         $reviewRound = $reviewRoundDao->getLastReviewRoundBySubmissionId($submission->getId(), $stageId);
+        $reviewRoundId = $reviewRound ? $reviewRound->getId() : null;
 
         $isOnlyRecommending = $permissions['isOnlyRecommending'];
 
@@ -180,7 +181,7 @@ class Schema extends \PKP\submission\maps\Schema
                     ];
                     $cancelInternalReviewRound = new CancelInternalReviewRound();
 
-                    if ($cancelInternalReviewRound->canRetract($submission, $reviewRound->getId())) {
+                    if ($cancelInternalReviewRound->canRetract($submission, $reviewRoundId)) {
                         $decisionTypes[] = $cancelInternalReviewRound;
                     }
 
@@ -197,7 +198,7 @@ class Schema extends \PKP\submission\maps\Schema
                     ];
 
                     $cancelReviewRound = new CancelReviewRound();
-                    if ($cancelReviewRound->canRetract($submission, $reviewRound->getId())) {
+                    if ($cancelReviewRound->canRetract($submission, $reviewRoundId)) {
                         $decisionTypes[] = $cancelReviewRound;
                     }
                     if ($submission->getData('status') === Submission::STATUS_DECLINED) {


### PR DESCRIPTION
Error stack trace:
```
[Wed Nov 13 15:47:06 2024] 127.0.0.1:44570 [500]: GET /index.php/publicknowledge/api/v1/_submissions?status=1&offset=0&count=30&page=1&perPage=30
[Wed Nov 13 15:47:06 2024] 127.0.0.1:44570 Closing
[Wed Nov 13 15:47:06 2024] 127.0.0.1:44578 Accepted
[Wed Nov 13 15:47:07 2024] Error: Call to a member function getId() on null in /home/runner/omp/classes/submission/maps/Schema.php:183
Stack trace:
#0 /home/runner/omp/lib/pkp/classes/submission/maps/Schema.php(654): APP\submission\maps\Schema->getAvailableEditorialDecisions()
#1 /home/runner/omp/lib/pkp/classes/submission/maps/Schema.php(393): PKP\submission\maps\Schema->getPropertyStages()
#2 /home/runner/omp/classes/submission/maps/Schema.php(65): PKP\submission\maps\Schema->mapByProperties()
#3 /home/runner/omp/lib/pkp/classes/submission/maps/Schema.php(250): APP\submission\maps\Schema->mapByProperties()
#4 /home/runner/omp/lib/pkp/classes/submission/maps/Schema.php(285): PKP\submission\maps\Schema->mapToSubmissionsList()
#5 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Collections/LazyCollection.php(779): PKP\submission\maps\Schema->PKP\submission\maps\{closure}()
#6 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Collections/LazyCollection.php(1707): Illuminate\Support\LazyCollection->Illuminate\Support\{closure}()
#7 [internal function]: Illuminate\Support\LazyCollection->Illuminate\Support\{closure}()
#8 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Collections/LazyCollection.php(106): iterator_to_array()
#9 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Collections/Traits/EnumeratesValues.php(964): Illuminate\Support\LazyCollection->all()
#10 [internal function]: Illuminate\Support\LazyCollection->jsonSerialize()
#11 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Http/JsonResponse.php(86): json_encode()
#12 /home/runner/omp/lib/pkp/lib/vendor/symfony/http-foundation/JsonResponse.php(49): Illuminate\Http\JsonResponse->setData()
#13 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Http/JsonResponse.php(32): Symfony\Component\HttpFoundation\JsonResponse->__construct()
#14 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Routing/ResponseFactory.php(102): Illuminate\Http\JsonResponse->__construct()
#15 /home/runner/omp/lib/pkp/api/v1/_submissions/PKPBackendSubmissionsController.php(229): Illuminate\Routing\ResponseFactory->json()
#16 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Routing/CallableDispatcher.php(40): PKP\API\v1\_submissions\PKPBackendSubmissionsController->getMany()
#17 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Routing/Route.php(238): Illuminate\Routing\CallableDispatcher->dispatch()
#18 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Routing/Route.php(209): Illuminate\Routing\Route->runCallable()
#19 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Routing/Router.php(808): Illuminate\Routing\Route->run()
#20 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(144): Illuminate\Routing\Router->Illuminate\Routing\{closure}()
#21 /home/runner/omp/lib/pkp/classes/middleware/HasRoles.php(75): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#22 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): PKP\middleware\HasRoles->handle()
#23 /home/runner/omp/lib/pkp/classes/middleware/HasContext.php(35): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#24 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): PKP\middleware\HasContext->handle()
#25 /home/runner/omp/lib/pkp/classes/middleware/HasUser.php(35): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#26 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): PKP\middleware\HasUser->handle()
#27 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(119): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#28 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Routing/Router.php(807): Illuminate\Pipeline\Pipeline->then()
#29 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Routing/Router.php(786): Illuminate\Routing\Router->runRouteWithinStack()
#30 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Routing/Router.php(750): Illuminate\Routing\Router->runRoute()
#31 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Routing/Router.php(739): Illuminate\Routing\Router->dispatchToRoute()
#32 /home/runner/omp/lib/pkp/classes/handler/APIHandler.php(103): Illuminate\Routing\Router->dispatch()
#33 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(144): PKP\handler\APIHandler->PKP\handler\{closure}()
#34 /home/runner/omp/lib/pkp/classes/middleware/PolicyAuthorizer.php(71): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#35 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): PKP\middleware\PolicyAuthorizer->handle()
#36 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php(21): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#37 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/ConvertEmptyStringsToNull.php(31): Illuminate\Foundation\Http\Middleware\TransformsRequest->handle()
#38 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull->handle()
#39 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php(21): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#40 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php(51): Illuminate\Foundation\Http\Middleware\TransformsRequest->handle()
#41 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): Illuminate\Foundation\Http\Middleware\TrimStrings->handle()
#42 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Http/Middleware/ValidatePostSize.php(27): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#43 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): Illuminate\Http\Middleware\ValidatePostSize->handle()
#44 /home/runner/omp/lib/pkp/classes/middleware/ValidateCsrfToken.php(55): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#45 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): PKP\middleware\ValidateCsrfToken->handle()
#46 /home/runner/omp/lib/pkp/classes/middleware/DecodeApiTokenWithValidation.php(76): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#47 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): PKP\middleware\DecodeApiTokenWithValidation->handle()
#48 /home/runner/omp/lib/pkp/classes/middleware/SetupContextBasedOnRequestUrl.php(63): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#49 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): PKP\middleware\SetupContextBasedOnRequestUrl->handle()
#50 /home/runner/omp/lib/pkp/classes/middleware/AllowCrossOrigin.php(34): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#51 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(183): PKP\middleware\AllowCrossOrigin->handle()
#52 /home/runner/omp/lib/pkp/lib/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(119): Illuminate\Pipeline\Pipeline->Illuminate\Pipeline\{closure}()
#53 /home/runner/omp/lib/pkp/classes/handler/APIHandler.php(102): Illuminate\Pipeline\Pipeline->then()
#54 /home/runner/omp/lib/pkp/classes/core/APIRouter.php(116): PKP\handler\APIHandler->runRoutes()
#55 /home/runner/omp/lib/pkp/classes/core/Dispatcher.php(158): PKP\core\APIRouter->route()
#56 /home/runner/omp/lib/pkp/classes/core/PKPApplication.php(388): PKP\core\Dispatcher->dispatch()
#57 /home/runner/omp/index.php(30): PKP\core\PKPApplication->execute()
#58 {main}
[Wed Nov 13 15:47:07 2024] 127.0.0.1:44578 [500]: GET /index.php/publicknowledge/api/v1/_submissions?status=1&offset=0&count=30&page=1&perPage=30

```

Some previous runs also failed due to this error:
https://github.com/pkp/omp/actions/runs/11796120294
https://github.com/pkp/omp/actions/runs/11819249724
https://github.com/pkp/omp/actions/runs/11823396074
https://github.com/pkp/omp/actions/runs/11836511345