### PR TITLE
pkp/pkp-lib#10511 menu item of type series without content even when they exist in the OMP 3.4

### DIFF
--- a/controllers/grid/navigationMenus/form/NavigationMenuItemsForm.php
+++ b/controllers/grid/navigationMenus/form/NavigationMenuItemsForm.php
@@ -45,11 +45,9 @@ class NavigationMenuItemsForm extends PKPNavigationMenuItemsForm
             ->getCollector()
             ->filterByContextIds([$contextId])
             ->getMany();
-
-        $seriesTitles = [];
-        foreach ($series as $seriesObj) {
-            $seriesTitles[$seriesObj->getId()] = $seriesObj->getLocalizedTitle();
-        }
+        $seriesTitles = $series->mapWithKeys(fn (Section $seriesObj) => [
+            $seriesObj->getId() => $seriesObj->getLocalizedTitle()
+        ])->all();
 
         $categories = Repo::category()->getCollector()
             ->filterByParentIds([null])

--- a/controllers/grid/navigationMenus/form/NavigationMenuItemsForm.php
+++ b/controllers/grid/navigationMenus/form/NavigationMenuItemsForm.php
@@ -45,9 +45,11 @@ class NavigationMenuItemsForm extends PKPNavigationMenuItemsForm
             ->getCollector()
             ->filterByContextIds([$contextId])
             ->getMany();
-        $seriesTitles = $series->map(fn (Section $seriesObj) => [
-            $seriesObj->getId() => $seriesObj->getLocalizedTitle()
-        ]);
+
+        $seriesTitles = [];
+        foreach ($series as $seriesObj) {
+            $seriesTitles[$seriesObj->getId()] = $seriesObj->getLocalizedTitle();
+        }
 
         $categories = Repo::category()->getCollector()
             ->filterByParentIds([null])


### PR DESCRIPTION
This PR fixes a bug with the display of series without content when trying to add a series-type menu item in OMP 3.4.

Related issue: [pkp/pkp-lib#10511](https://github.com/pkp/pkp-lib/issues/10511)