### PR TITLE
German locale fix

### DIFF
--- a/locale/de/submission.po
+++ b/locale/de/submission.po
@@ -483,7 +483,7 @@ msgid "publication.chapter.landingPage"
 msgstr "Kapitelseite"
 
 msgid "publication.chapter.landingPage.doi.description"
-msgstr "(Dieses Kapitel wird immer auf einer eigenen Seite angezeigt, da es ein DOI hat)."
+msgstr "(Dieses Kapitel wird immer auf einer eigenen Seite angezeigt, da es eine DOI hat)."
 
 msgid "publication.chapter.hasLandingPage"
 msgstr ""

--- a/locale/de/submission.po
+++ b/locale/de/submission.po
@@ -482,6 +482,9 @@ msgstr "Diskussion zur Herstellung"
 msgid "publication.chapter.landingPage"
 msgstr "Kapitelseite"
 
+msgid "publication.chapter.landingPage.doi.description"
+msgstr "(Dieses Kapitel wird immer auf einer eigenen Seite angezeigt, da es ein DOI hat)."
+
 msgid "publication.chapter.hasLandingPage"
 msgstr ""
 "Dieses Kapitel auf einer eigenen Seite anzeigen, auf die vom "


### PR DESCRIPTION
"publication.chapter.landingPage.doi.description" was missing in German submission.po. Added the German translation.