### PR TITLE
Add references at chapter level

### DIFF
--- a/classes/migration/install/OMPMigration.php
+++ b/classes/migration/install/OMPMigration.php
@@ -357,6 +357,40 @@ class OMPMigration extends \PKP\migration\Migration
             $table->unique(['author_id', 'chapter_id'], 'chapter_authors_pkey');
         });
 
+        Schema::create('chapter_citations', function (Blueprint $table) {
+            $table->comment('The citations associated with each submission chapter.');
+
+            $table->bigInteger('chapter_citation_id')->autoIncrement();
+            $table->bigInteger('chapter_id');
+            $table->text('raw_citation');
+            $table->bigInteger('seq')->default(0);
+
+            $table->foreign('chapter_id', 'citations_chapter')
+                ->references('chapter_id')
+                ->on('submission_chapters')
+                ->onDelete('cascade');
+            $table->index(['chapter_id'], 'citations_chapter');
+            $table->unique(['chapter_id', 'seq'], 'citations_chapter_seq');
+        });
+
+        Schema::create('chapter_citation_settings', function (Blueprint $table) {
+            $table->comment('Additional data about chapter citations, including localized content.');
+
+            $table->bigIncrements('chapter_citation_setting_id');
+            $table->bigInteger('chapter_citation_id');
+            $table->string('locale', 28)->default('');
+            $table->string('setting_name', 255);
+            $table->mediumText('setting_value')->nullable();
+            $table->string('setting_type', 6);
+
+            $table->foreign('chapter_citation_id', 'chapter_citation_settings_citation_id')
+                ->references('chapter_citation_id')
+                ->on('chapter_citations')
+                ->onDelete('cascade');
+            $table->index(['chapter_citation_id'], 'chapter_citation_settings_citation_id');
+            $table->unique(['chapter_citation_id', 'locale', 'setting_name'], 'chapter_citation_settings_unique');
+        });
+
         // Add doi_id to submission files
         Schema::table('submission_files', function (Blueprint $table) {
             $table->bigInteger('doi_id')->nullable();

--- a/classes/monograph/ChapterCitation.php
+++ b/classes/monograph/ChapterCitation.php
@@ -18,8 +18,6 @@
 
 namespace APP\monograph;
 
-use PKP\core\PKPString;
-
 class ChapterCitation extends \PKP\core\DataObject
 {
     /**
@@ -92,7 +90,7 @@ class ChapterCitation extends \PKP\core\DataObject
     private function cleanCitationString($citationString)
     {
         $citationString = trim(stripslashes($citationString));
-        $citationString = PKPString::regexp_replace('/[\s]+/', ' ', $citationString);
+        $citationString = preg_replace('/[\s]+/u', ' ', $citationString);
 
         return $citationString;
     }

--- a/classes/monograph/ChapterCitation.php
+++ b/classes/monograph/ChapterCitation.php
@@ -28,7 +28,10 @@ class ChapterCitation extends \PKP\core\DataObject
     public function __construct(?string $rawCitation = null)
     {
         parent::__construct();
-        $this->setRawCitation($rawCitation);
+
+        if ($rawCitation) {
+            $this->setRawCitation($rawCitation);
+        }
     }
 
     /**

--- a/classes/monograph/ChapterCitation.php
+++ b/classes/monograph/ChapterCitation.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * @file classes/monograph/ChapterCitation.php
+ *
+ * Copyright (c) 2014-2025 Simon Fraser University
+ * Copyright (c) 2000-2025 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class ChapterCitation
+ *
+ * @ingroup monograph
+ *
+ * @see ChapterCitationDAO
+ *
+ * @brief Describes a monograph chapter's citation
+ */
+
+namespace APP\monograph;
+
+use PKP\core\PKPString;
+
+class ChapterCitation extends \PKP\core\DataObject
+{
+    /**
+     * Constructor.
+     *
+     * @param string $rawCitation an unparsed citation string
+     */
+    public function __construct(?string $rawCitation = null)
+    {
+        parent::__construct();
+        $this->setRawCitation($rawCitation);
+    }
+
+    /**
+     * Replace URLs through HTML links, if the citation does not already contain HTML links
+     *
+     * @return string
+     */
+    public function getCitationWithLinks()
+    {
+        $citation = $this->getRawCitation();
+        if (stripos($citation, '<a href=') === false) {
+            $citation = preg_replace_callback(
+                '#(http|https|ftp)://[\d\w\.-]+\.[\w\.]{2,6}[^\s\]\[\<\>]*/?#',
+                function ($matches) {
+                    $trailingDot = in_array($char = substr($matches[0], -1), ['.', ',']);
+                    $url = rtrim($matches[0], '.,');
+                    return "<a href=\"{$url}\">{$url}</a>" . ($trailingDot ? $char : '');
+                },
+                $citation
+            );
+        }
+        return $citation;
+    }
+
+    public function getChapterId(): int
+    {
+        return $this->getData('chapterId');
+    }
+
+    public function setChapterId(int $chapterId)
+    {
+        $this->setData('chapterId', $chapterId);
+    }
+
+    public function getRawCitation(): string
+    {
+        return $this->getData('rawCitation');
+    }
+
+    public function setRawCitation(string $rawCitation)
+    {
+        $rawCitation = $this->cleanCitationString($rawCitation);
+        $this->setData('rawCitation', $rawCitation);
+    }
+
+    public function getSequence(): int
+    {
+        return $this->getData('seq');
+    }
+
+    public function setSequence(int $sequence)
+    {
+        $this->setData('seq', $sequence);
+    }
+
+    /**
+     * Take a citation string and clean/normalize it
+     */
+    private function cleanCitationString($citationString)
+    {
+        $citationString = trim(stripslashes($citationString));
+        $citationString = PKPString::regexp_replace('/[\s]+/', ' ', $citationString);
+
+        return $citationString;
+    }
+}

--- a/classes/monograph/ChapterCitationDAO.php
+++ b/classes/monograph/ChapterCitationDAO.php
@@ -68,9 +68,8 @@ class ChapterCitationDAO extends DAO
 
         foreach ($citationStrings as $seq => $citationString) {
             if (!empty(trim($citationString))) {
-                $chapterCitation = new ChapterCitation();
+                $chapterCitation = new ChapterCitation($citationString);
                 $chapterCitation->setChapterId($chapterId);
-                $chapterCitation->setRawCitation($citationString);
                 $chapterCitation->setSequence($seq + 1);
 
                 $this->insertObject($chapterCitation);

--- a/classes/monograph/ChapterCitationDAO.php
+++ b/classes/monograph/ChapterCitationDAO.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * @file classes/monograph/ChapterCitationDAO.php
+ *
+ * Copyright (c) 2014-2025 Simon Fraser University
+ * Copyright (c) 2000-2025 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * @class ChapterCitationDAO
+ *
+ * @ingroup monograph
+ *
+ * @see ChapterCitation
+ *
+ * @brief Operations for retrieving and modifying ChapterCitation objects
+ */
+
+namespace APP\monograph;
+
+use Illuminate\Support\Facades\DB;
+use PKP\citation\CitationListTokenizerFilter;
+use PKP\db\DAO;
+
+class ChapterCitationDAO extends DAO
+{
+    public $table = 'chapter_citations';
+
+    public function insertObject($chapterCitation)
+    {
+        $seq = $chapterCitation->getSequence();
+        if (!(is_numeric($seq) && $seq > 0)) {
+            $lastSeq = DB::table($this->table)
+                ->where('chapter_id', '=', $chapterCitation->getChapterId())
+                ->max('seq');
+            $chapterCitation->setSequence($lastSeq ? $lastSeq + 1 : 1);
+        }
+
+        DB::table($this->table)->insert([
+            'chapter_id' => $chapterCitation->getChapterId(),
+            'raw_citation' => $chapterCitation->getRawCitation(),
+            'seq' => $chapterCitation->getSequence()
+        ]);
+
+        return $this->getInsertId();
+    }
+
+    public function getByChapterId($chapterId)
+    {
+        $result = DB::table($this->table)
+            ->where('chapter_id', '=', $chapterId)
+            ->get();
+
+        $chapterCitations = [];
+        foreach ($result as $row) {
+            $chapterCitations[] = $this->fromRow(get_object_vars($row));
+        }
+
+        return $chapterCitations;
+    }
+
+    public function importChapterCitations($chapterId, $rawCitationList)
+    {
+        $this->deleteByChapterId($chapterId);
+
+        $citationTokenizer = new CitationListTokenizerFilter();
+        $citationStrings = $rawCitationList ? $citationTokenizer->execute($rawCitationList) : [];
+
+        foreach ($citationStrings as $seq => $citationString) {
+            if (!empty(trim($citationString))) {
+                $chapterCitation = new ChapterCitation();
+                $chapterCitation->setChapterId($chapterId);
+                $chapterCitation->setRawCitation($citationString);
+                $chapterCitation->setSequence($seq + 1);
+
+                $this->insertObject($chapterCitation);
+            }
+        }
+    }
+
+    public function deleteByChapterId($chapterId)
+    {
+        DB::table($this->table)
+            ->where('chapter_id', '=', $chapterId)
+            ->delete();
+    }
+
+    public function newDataObject()
+    {
+        return new ChapterCitation();
+    }
+
+    private function fromRow($row)
+    {
+        $chapterCitation = $this->newDataObject();
+        $chapterCitation->setId((int) $row['chapter_citation_id']);
+        $chapterCitation->setChapterId((int) $row['chapter_id']);
+        $chapterCitation->setRawCitation($row['raw_citation']);
+        $chapterCitation->setSequence((int) $row['seq']);
+
+        return $chapterCitation;
+    }
+}

--- a/classes/monograph/ChapterDAO.php
+++ b/classes/monograph/ChapterDAO.php
@@ -168,6 +168,7 @@ class ChapterDAO extends \PKP\db\DAO implements PKPPubIdPluginDAO
         $additionalFields[] = 'pub-id::publisher-id';
         $additionalFields[] = 'datePublished';
         $additionalFields[] = 'pages';
+        $additionalFields[] = 'chapterCitationsRaw';
         $additionalFields[] = 'isPageEnabled';
         $additionalFields[] = 'licenseUrl';
         return $additionalFields;

--- a/pages/catalog/CatalogBookHandler.php
+++ b/pages/catalog/CatalogBookHandler.php
@@ -22,6 +22,7 @@ use APP\core\Request;
 use APP\facades\Repo;
 use APP\handler\Handler;
 use APP\monograph\Chapter;
+use APP\monograph\ChapterCitationDAO;
 use APP\monograph\ChapterDAO;
 use APP\observers\events\UsageEvent;
 use APP\payment\omp\OMPCompletedPaymentDAO;
@@ -149,6 +150,11 @@ class CatalogBookHandler extends Handler
             $chapterAuthors = $this->chapter->getAuthors();
             $chapterAuthors = $chapterAuthors->toArray();
 
+            if ($this->chapter->getData('chapterCitationsRaw')) {
+                $chapterCitationDao = new ChapterCitationDAO();
+                $chapterCitations = $chapterCitationDao->getByChapterId($this->chapter->getId());
+            }
+
             $datePublished = $submission->getEnableChapterPublicationDates() && $this->chapter->getDatePublished()
                 ? $this->chapter->getDatePublished()
                 : $this->publication->getData('datePublished');
@@ -165,6 +171,7 @@ class CatalogBookHandler extends Handler
             $templateMgr->assign([
                 'chapter' => $this->chapter,
                 'chapterAuthors' => $chapterAuthors,
+                'chapterCitations' => $chapterCitations,
                 'sourceChapter' => $sourceChapter,
                 'firstDatePublished' => $firstDatePublished ?: $datePublished,
                 'datePublished' => $datePublished,

--- a/templates/controllers/grid/users/chapter/form/chapterForm.tpl
+++ b/templates/controllers/grid/users/chapter/form/chapterForm.tpl
@@ -42,6 +42,11 @@
 	    {fbvElement type="text" id="pages" value=$pages inline=true size=$fbvStyles.size.LARGE}
 	{/fbvFormSection}
 
+	{fbvFormSection title="submission.citations"}
+		<div class="pkpFormField__description">{translate key="submission.citations.description"}</div>
+		{fbvElement type="textarea" name="chapterCitationsRaw" id="chapterCitationsRaw"  value=$chapterCitationsRaw multilingual=false}
+	{/fbvFormSection}
+
 	{if $enableChapterPublicationDates}
 		{fbvFormSection title="publication.datePublished" for="customExtras"}
 		{fbvElement type="text" id="datePublished" value=$datePublished inline=true size=$fbvStyles.size.LARGE  class="datepicker"}

--- a/templates/frontend/objects/chapter.tpl
+++ b/templates/frontend/objects/chapter.tpl
@@ -126,6 +126,24 @@
 				</div>
 			{/if}
 
+			{* Chapter references *}
+			{if $chapterCitations || $chapter->getData('chapterCitationsRaw')}
+				<div class="item references">
+					<h2 class="label">
+						{translate key="submission.citations"}
+					</h2>
+					<div class="value">
+						{if $chapterCitations}
+							{foreach from=$chapterCitations item=$chapterCitation}
+								<p>{$chapterCitation->getCitationWithLinks()|strip_unsafe_html}</p>
+							{/foreach}
+						{else}
+							{$chapter->getData('chapterCitationsRaw')|escape|nl2br}
+						{/if}
+					</div>
+				</div>
+			{/if}
+
 		</div><!-- .main_entry -->
 
 		<div class="entry_details">


### PR DESCRIPTION
This pull request adds references at chapter level in OMP. It addresses a previous demand for OMP, which was discussed in [this topic of the forum](https://forum.pkp.sfu.ca/t/reference-list-at-chapter-level-in-omp-3-1-2-4/61570).

As we said in our [last comment](http://forum.pkp.sfu.ca/t/reference-list-at-chapter-level-in-omp-3-1-2-4/61570/11), we developed a plugin with this feature for 3.4.0, but we intended to make it a native feature in OMP.