### PR TITLE
pkp/pkp-lib#10768 [main] Fix type mismatch for parameter $selectedRoleIds on getDashboardViews()

### DIFF
--- a/classes/submission/Repository.php
+++ b/classes/submission/Repository.php
@@ -139,7 +139,7 @@ class Repository extends \PKP\submission\Repository
         return $doiCreationFailures;
     }
 
-    protected function mapDashboardViews(Collection $types, Context $context, User $user, bool $canAccessUnassignedSubmission, $selectedRoleIds): Collection
+    protected function mapDashboardViews(Collection $types, Context $context, User $user, bool $canAccessUnassignedSubmission, array $selectedRoleIds = []): Collection
     {
         $views = parent::mapDashboardViews($types, $context, $user, $canAccessUnassignedSubmission, $selectedRoleIds);
 


### PR DESCRIPTION
Based on recent change on pkp-lib for the parameter type of `$selectedRoleIds` on `getDashboardViews()`, we need to do the same for the Repository file on OMP to fix the type mismatch and resolve cypress issue for OMP main.
https://github.com/pkp/pkp-lib/pull/11059/files#diff-34fdc7c8e89313372f2d37b070cfd901eb72617c1d247a29bef206f4f1f2c852R859