### PR TITLE
Add missing one-click login to OMP 3.4

### DIFF
--- a/pages/reviewer/ReviewerHandler.php
+++ b/pages/reviewer/ReviewerHandler.php
@@ -3,8 +3,8 @@
 /**
  * @file pages/reviewer/ReviewerHandler.php
  *
- * Copyright (c) 2014-2021 Simon Fraser University
- * Copyright (c) 2003-2021 John Willinsky
+ * Copyright (c) 2014-2026 Simon Fraser University
+ * Copyright (c) 2003-2026 John Willinsky
  * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
  *
  * @class ReviewerHandler
@@ -17,12 +17,30 @@
 namespace APP\pages\reviewer;
 
 use APP\core\Request;
+use APP\facades\Repo;
+use APP\submission\reviewer\form\ReviewerReviewStep3Form;
+use APP\submission\Submission;
+use PKP\core\PKPRequest;
+use PKP\db\DAORegistry;
 use PKP\pages\reviewer\PKPReviewerHandler;
+use PKP\security\AccessKeyManager;
 use PKP\security\authorization\SubmissionAccessPolicy;
 use PKP\security\Role;
+use PKP\security\Validation;
+use PKP\session\SessionManager;
+use PKP\submission\reviewAssignment\ReviewAssignment;
+use PKP\submission\reviewAssignment\ReviewAssignmentDAO;
+use PKP\user\User;
 
 class ReviewerHandler extends PKPReviewerHandler
 {
+
+    /** @var Submission */
+    public $submission;
+
+    /** @var User */
+    public $user;
+
     /**
      * Constructor
      */
@@ -39,20 +57,84 @@ class ReviewerHandler extends PKPReviewerHandler
     }
 
     /**
-     * @see PKPHandler::authorize()
-     *
-     * @param Request $request
-     * @param array $args
-     * @param array $roleAssignments
+     * @copydoc PKPHandler::authorize()
      */
     public function authorize($request, &$args, $roleAssignments)
     {
+        $context = $request->getContext();
+        if ($context->getData('reviewerAccessKeysEnabled')) {
+            $this->_validateAccessKey($request);
+        }
+
         $router = $request->getRouter();
         $this->addPolicy(new SubmissionAccessPolicy(
             $request,
             $args,
             $roleAssignments
         ));
+
         return parent::authorize($request, $args, $roleAssignments);
     }
+
+    /**
+     * Tests if the request contains a valid access token. If this is the case
+     * the regular login process will be skipped
+     *
+     * @param Request $request
+     */
+    protected function _validateAccessKey($request)
+    {
+        $accessKeyCode = $request->getUserVar('key');
+        $reviewId = $request->getUserVar('reviewId');
+        if (!($accessKeyCode && $reviewId)) {
+            return;
+        }
+
+        // Check if the user is already logged in
+        $sessionManager = SessionManager::getManager();
+        $session = $sessionManager->getUserSession();
+        if ($session->getUserId()) {
+            return;
+        }
+
+        $reviewAssignmentDao = DAORegistry::getDAO('ReviewAssignmentDAO'); /** @var ReviewAssignmentDAO $reviewAssignmentDao */
+        $reviewAssignment = $reviewAssignmentDao->getById($reviewId);
+        if (!$reviewAssignment) {
+            return;
+        } // e.g. deleted review assignment
+
+        $reviewSubmission = Repo::submission()->get($reviewAssignment->getSubmissionId());
+        $context = $request->getContext();
+
+        // Check if the submission exists and is from the current context
+        if (!$reviewSubmission || $reviewSubmission->getContextId() != $context->getId()) {
+            return;
+        }
+
+        // Validate the access key
+        $accessKeyManager = new AccessKeyManager();
+        $accessKeyHash = $accessKeyManager->generateKeyHash($accessKeyCode);
+        $accessKey = $accessKeyManager->validateKey(
+            $context->getId(),
+            $reviewAssignment->getReviewerId(),
+            $accessKeyHash
+        );
+        if (!$accessKey) {
+            return;
+        }
+
+        // Get the reviewer user object
+        $user = Repo::user()->get($accessKey->getUserId());
+        if (!$user) {
+            return;
+        }
+
+        // Register the user object in the session
+        $reason = null;
+        if (Validation::registerUserSession($user, $reason)) {
+            $this->submission = $reviewSubmission;
+            $this->user = $user;
+        }
+    }
+
 }


### PR DESCRIPTION
In OMP 3.4 the one click reviewer access seems to be broken. The email contains a link that looks ok, there is also corresponding line in access_keys. However, the link leads to the login page. In OJS 3.4 the one-click links works.

Seems that it is not handled at all in OMP 3.4
https://github.com/pkp/omp/blob/stable-3_4_0/pages/reviewer/ReviewerHandler.php

OJS 3.4 has the required handling
https://github.com/pkp/ojs/blob/stable-3_4_0/pages/reviewer/ReviewerHandler.php

This pr introduces the similar logic to OMP 3.4.