### PR TITLE
pkp/pkp-lib#12555 fix max version for 3.5.0.x upgrade scripts

### DIFF
--- a/dbscripts/xml/upgrade.xml
+++ b/dbscripts/xml/upgrade.xml
@@ -168,16 +168,10 @@
 		<note file="docs/release-notes/README-3.5.0" />
 	</upgrade>
 
-	<upgrade minversion="3.5.0.0" maxversion="3.5.0.1">
+	<upgrade minversion="3.5.0.0" maxversion="3.5.0.9">
 		<migration class="PKP\migration\upgrade\v3_5_0\I11603_AddMissingUserRoleAssignmentInvitationEmail"/>
-	</upgrade>
-
-	<upgrade minversion="3.5.0.0" maxversion="3.5.0.2">
 		<migration class="PKP\migration\upgrade\v3_5_0\I11673_AddMissingApprovalToReviewerSuggestion"/>
-	</upgrade>
-
-	<upgrade minversion="3.5.0.0" maxversion="3.5.9.9">
-		<migration class="APP\migration\upgrade\v3_4_0\InstallEmailTemplates"/>
+		<migration class="PKP\migration\upgrade\v3_5_0\I11800_AddUserRoleMastheadUpdateEmail"/>
 	</upgrade>
 
 	<upgrade minversion="3.3.0.0" maxversion="3.5.9.9">


### PR DESCRIPTION
s. https://github.com/pkp/pkp-lib/issues/12555

`<migration class="APP\migration\upgrade\v3_4_0\InstallEmailTemplates"/>` that was wrongly added here https://github.com/pkp/omp/pull/2305 will be removed