### PR TITLE
Fix duplicate HTML content in HtmlMonographFilePlugin

### DIFF
--- a/plugins/generic/htmlMonographFile/HtmlMonographFilePlugin.php
+++ b/plugins/generic/htmlMonographFile/HtmlMonographFilePlugin.php
@@ -140,7 +140,8 @@ class HtmlMonographFilePlugin extends \PKP\plugins\GenericPlugin
                 Hook::call('HtmlMonographFilePlugin::monographDownloadFinished', [&$returner]);
 
                 $chapterDao = DAORegistry::getDAO('ChapterDAO'); /** @var ChapterDAO $chapterDao */
-                $chapter = $chapterDao->getChapter($submissionFile->getData('chapterId'));
+                $chapterId = $submissionFile->getData('chapterId');
+                $chapter = $chapterId ? $chapterDao->getChapter((int) $chapterId) : null;
                 event(new UsageEvent(Application::ASSOC_TYPE_SUBMISSION_FILE, $request->getContext(), $submission, $publicationFormat, $submissionFile, $chapter));
                 return true;
             }


### PR DESCRIPTION
## Summary

- Fix TypeError in `HtmlMonographFilePlugin::downloadCallback()` when viewing HTML publication format files not assigned to a chapter
- `$submissionFile->getData('chapterId')` returns `null` for non-chapter files, causing `ChapterDAO::getChapter(int)` to throw a TypeError in PHP 8
- `Hook::run()` silently catches the plugin exception and continues, so the hook returns `CONTINUE` instead of `ABORT` — `CatalogBookHandler::download()` then sends the file a second time via `app()->get('file')->download()`, resulting in **duplicate HTML content**

## Fix

Guard the `getChapter()` call with a null check (same pattern already used in `CatalogBookHandler::download()` at line 420):

```php
// Before
$chapter = $chapterDao->getChapter($submissionFile->getData('chapterId'));

// After
$chapterId = $submissionFile->getData('chapterId');
$chapter = $chapterId ? $chapterDao->getChapter((int) $chapterId) : null;
```

## Test plan

- [ ] Upload an HTML file as a publication format **without** assigning it to a chapter
- [ ] Publish the submission and view the HTML file via `/catalog/view/{id}/{formatId}/{fileId}`
- [ ] Verify the HTML content appears only once (not duplicated)
- [ ] Upload an HTML file **assigned to a chapter** and verify it still works correctly