### PR TITLE
adding conditional to chapter synopsis section

### DIFF
--- a/templates/frontend/objects/chapter.tpl
+++ b/templates/frontend/objects/chapter.tpl
@@ -77,14 +77,16 @@
 			{/if}
 
 			{* Abstract *}
-			<div class="item abstract">
-				<h2 class="label">
-					{translate key="submission.synopsis"}
-				</h2>
-				<div class="value">
-					{$chapter->getLocalizedData('abstract')|strip_unsafe_html}
+			{if $chapter->getLocalizedData('abstract')}
+				<div class="item abstract">
+					<h2 class="label">
+						{translate key="submission.synopsis"}
+					</h2>
+					<div class="value">
+						{$chapter->getLocalizedData('abstract')|strip_unsafe_html}
+					</div>
 				</div>
-			</div>
+			{/if}
 
 			{call_hook name="Templates::Catalog::Chapter::Main"}
 


### PR DESCRIPTION
We found that the synopsis header always appeared on chapter pages even in cases where we didn't include any synopsis data for the chapter. This is a quick fix to add a conditional to the template so the header only appears if there is data to show. 