### PR TITLE
Cascade last_modified stamping to Submission on Chapter changes (extends pkp-lib#13074)

### DIFF
--- a/classes/monograph/ChapterDAO.php
+++ b/classes/monograph/ChapterDAO.php
@@ -24,6 +24,7 @@ use Illuminate\Support\Facades\DB;
 use PKP\db\DAOResultFactory;
 use PKP\plugins\Hook;
 use PKP\plugins\PKPPubIdPluginDAO;
+use PKP\observers\events\MetadataChanged;
 
 class ChapterDAO extends \PKP\db\DAO implements PKPPubIdPluginDAO
 {
@@ -260,6 +261,8 @@ class ChapterDAO extends \PKP\db\DAO implements PKPPubIdPluginDAO
             ]
         );
         $this->updateLocaleFields($chapter);
+
+        $this->dispatchMetadataChanged((int) $chapter->getData('publicationId')); // #13074
     }
 
     /**
@@ -275,11 +278,21 @@ class ChapterDAO extends \PKP\db\DAO implements PKPPubIdPluginDAO
      */
     public function deleteById(int $chapterId): int
     {
+        $publicationId = $this->getChapter($chapterId)?->getData('publicationId'); // #13074
+
         DB::table('submission_file_settings')
             ->where('setting_name', '=', 'chapterId')
             ->where('setting_value', '=', $chapterId)
             ->delete();
-        return DB::table('submission_chapters')->where('chapter_id', '=', $chapterId)->delete();
+
+        // #13074
+        $result = DB::table('submission_chapters')->where('chapter_id', '=', $chapterId)->delete();
+
+        if ($publicationId !== null) {
+            $this->dispatchMetadataChanged((int) $publicationId);
+        }
+
+        return $result;
     }
 
     /**
@@ -307,6 +320,11 @@ class ChapterDAO extends \PKP\db\DAO implements PKPPubIdPluginDAO
                 'UPDATE submission_chapters SET seq = ? WHERE chapter_id = ?',
                 [++$i, $row->chapter_id]
             );
+        }
+
+        // #13074 (once for the whole batch)
+        if ($publicationId !== null) {
+            $this->dispatchMetadataChanged((int) $publicationId);
         }
     }
 
@@ -359,6 +377,25 @@ class ChapterDAO extends \PKP\db\DAO implements PKPPubIdPluginDAO
             $affectedRows += $this->deletePubId($chapter->getId(), $pubIdType);
         }
         return $affectedRows;
+    }
+
+    /**
+     * Dispatch MetadataChanged for the submission owning the given publication.
+     * Silently no-ops if the publication or submission can't be resolved.
+     *
+     * @see https://github.com/pkp/pkp-lib/issues/13074
+     */
+    private function dispatchMetadataChanged(int $publicationId): void
+    {
+        $publication = Repo::publication()->get($publicationId);
+        if (!$publication) {
+            return;
+        }
+        $submission = Repo::submission()->get($publication->getData('submissionId'));
+        if (!$submission) {
+            return;
+        }
+        event(new MetadataChanged($submission));
     }
 }
 


### PR DESCRIPTION
**Draft PR — companion to pkp/pkp-lib#13074 (see https://github.com/pkp/pkp-lib/pull/13104)**

Extends the same `last_modified` cascade fix to Chapters (OMP-specific), confirmed in
scope by @asmecher.

Draft PR — work in progress, opened for early feedback as requested by @asmecher

## Summary

Editing, adding, deleting, or resequencing a Chapter did not update `submissions.last_modified`
on the parent Submission, the same gap addressed for Author/Citation in pkp-lib#13074.

This PR adds the corresponding dispatch in `ChapterDAO.php`, reusing the same
`StampSubmissionModified` listener introduced in pkp-lib#13074.

## Testing done so far

- Manual testing on OMP: add/edit/delete/resequence a Chapter on a published Submission,
  confirmed `last_modified` on the parent Submission updates in all cases. 
- Run existing pkp-lib/omp automated test suite before and after the fix with same results

## Still to do before this leaves draft status

- [ ] Write unit/functional test for the new dispatch point

## Dependency

This PR assumes `StampSubmissionModified` (from pkp-lib#13074) is merged or at least
stable on the target branch; it does not duplicate that listener.

## AI-assisted development disclosure

Portions of this PR's code analysis and drafting were assisted by an AI tool (Claude).
All technical claims and code have been independently reviewed and verified by the author
prior to submission, per PKP's AI contribution policy.